### PR TITLE
Harden #repo= deep link: repoHashKey never throws on a malformed hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.45.1] — 2026-07-02
+
+### 🛡️ Deep-link hardening — a mangled `#repo=` link can no longer throw
+- **`repoHashKey()` stops trusting the hash to be valid percent-encoding.** A shared/pasted URL whose `#repo=` fragment carries a malformed `%` sequence (`#repo=%`, `#repo=%zz`, a truncated multi-byte `#repo=%E0%A4%A`) made `decodeURIComponent` throw `URIError`. The **boot** open was wrapped in try/catch, but the live `hashchange` handler and the `closeCard → clearRepoHash` path were **not** — so pasting a mangled link (or closing a card while one was in the address bar) threw an uncaught exception and could wedge the modal state. `repoHashKey()` now catches the decode and falls back to the **raw** captured key, which `repoByKey` then resolves normally or safely rejects as `null`. Valid links are byte-for-byte unchanged.
+- **Regression guard.** `scripts/smoke.mjs` now runs the **real** shipped `repoHashKey` (extracted from `index.html`) against malformed hashes and asserts it returns the raw key instead of throwing, plus a static check that the decode is guarded — alongside the existing round-trip cases. Smoke **59** (+3).
+- **Verified.** Live in Chrome (desktop + 390px mobile): a genuine `hashchange` to `#repo=%zz` / `#repo=%` no longer throws (`window.onerror` stays empty), closing a card on a malformed hash clears it cleanly, a fresh boot on a malformed deep link opens no wrong card and shows no overflow, and valid `#repo=` links still open/switch to the exact card — **0 console errors**. Smoke 59 + council 130 + live 56 green; `scholars.js` / `grounded.js` syntax-clean.
+
 ## [1.45.0] — 2026-07-02
 
 ### 🧭 Navigation / identity reliability — a shown repo can never open a different one

--- a/index.html
+++ b/index.html
@@ -4358,7 +4358,8 @@ function repoByKey(key){
    closeCard clears it, and back/forward + hashchange stay in sync. Other
    query params (?user=/?rt=/?dbg) are preserved. */
 let _repoHashGuard=false;
-function repoHashKey(){ const m=String(location.hash||'').match(/^#repo=(.+)$/); return m?decodeURIComponent(m[1]):null; }
+function repoHashKey(){ const m=String(location.hash||'').match(/^#repo=(.+)$/); if(!m) return null;
+  try{ return decodeURIComponent(m[1]); }catch(_){ return m[1]; } }   // malformed %-encoding (mangled shared link) → raw fallback, never throw
 function setRepoHash(repo){ if(_repoHashGuard||!repo||!repo.repo) return; _repoHashGuard=true;
   try{ const h='#repo='+encodeURIComponent(repo.repo); if(location.hash!==h) history.replaceState(null,'',location.pathname+location.search+h); }catch(e){}
   _repoHashGuard=false; }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -134,10 +134,11 @@ if (genSrc && tokSrc && matchSrc) {
 group('repoByKey canonical identity resolve (navigation reliability)');
 ok(/function repoByKey\(key\)\{/.test(HTML), 'repoByKey canonical resolver exists');
 ok(/function openRepoFromHash\(\)\{/.test(HTML) && /#repo=/.test(HTML), 'repo deep link (#repo=) wiring exists');
+ok(/function repoHashKey\(\)\{[\s\S]*?try\{[\s\S]*?\}catch/.test(HTML), 'repoHashKey guards decodeURIComponent (a mangled shared link cannot throw)');
 ok(/modal\._repoKey=repo\.repo/.test(HTML), 'openCard records the card repo key for hash sync');
 const normSrc = (HTML.match(/const _repoNorm=[^;]+;/) || [])[0];
 const rbkSrc  = (HTML.match(/function repoByKey\(key\)\{[\s\S]*?return null; \}/) || [])[0];
-const rhkSrc  = (HTML.match(/function repoHashKey\(\)\{[\s\S]*?\}/) || [])[0];
+const rhkSrc  = (HTML.match(/function repoHashKey\(\)\{[\s\S]*?catch\(_\)\{ return m\[1\]; \} \}/) || [])[0];
 ok(!!(normSrc && rbkSrc && rhkSrc), 'repoByKey + _repoNorm + repoHashKey extractable from index.html');
 if (normSrc && rbkSrc) {
   let repos = [];
@@ -165,6 +166,9 @@ if (rhkSrc) {
   ok(mk('#repo=' + encodeURIComponent('youtube-dl-nas')) === 'youtube-dl-nas', 'deep-link hash round-trips the canonical key');
   ok(mk('#repo=' + encodeURIComponent('owner/repo name')) === 'owner/repo name', 'deep-link hash decodes special chars');
   ok(mk('') === null && mk('#other') === null, 'non-repo hash yields null');
+  const noThrow = h => { try { return mk(h); } catch (e) { return '__THREW__:' + e.name; } };
+  ok(noThrow('#repo=%') === '%', 'malformed %-encoding hash falls back to raw (never throws URIError)');
+  ok(noThrow('#repo=%zz') === '%zz', 'invalid %-sequence hash falls back to raw (never throws URIError)');
 }
 
 console.log('\n──────────────────────────────');


### PR DESCRIPTION
## 요약
`#repo=` 딥링크에서 **% 인코딩이 깨진 공유/붙여넣기 링크가 `URIError`를 던지던 잠재 버그**를 고칩니다. (1.45.0가 도입한 딥링크 기능의 무방비 경로)

## 문제
`repoHashKey()`가 `decodeURIComponent(m[1])`를 무방비로 호출합니다. `#repo=%`, `#repo=%zz`, 잘린 멀티바이트 `#repo=%E0%A4%A` 같은 해시에서 `decodeURIComponent`가 `URIError`를 던집니다.

- **부팅** 경로(`openRepoFromHash`)는 `try/catch`로 감싸져 있었지만,
- 실시간 **`hashchange` 핸들러**와 **`closeCard → clearRepoHash`** 경로는 무방비였습니다.

→ 망가진 링크를 주소창에 붙여넣거나, 그 상태에서 카드를 닫으면 **처리되지 않은 예외**가 발생하고 모달 상태가 꼬일 수 있었습니다.

## 해결
- **`index.html`** — `repoHashKey()`가 디코드를 `try/catch`로 감싸고, 실패 시 **원본 캡처 키로 폴백**합니다. `repoByKey`가 이를 정상 해석하거나 안전하게 `null`로 거부합니다. **정상 링크 동작은 완전히 동일**합니다.
- **`scripts/smoke.mjs`** — 실제 shipped `repoHashKey`를 깨진 해시(`#repo=%`, `#repo=%zz`)에 돌려 **throw 없이 원본 폴백**을 반환하는지 검증 + 디코드가 가드되었는지 정적 체크. 기존 라운드트립 케이스는 유지. Smoke **56 → 59** (+3).
- **`CHANGELOG.md`** — 1.45.1 항목.

## 검증
- `node scripts/smoke.mjs` → **59** green
- `node council/test.mjs` → **130** green
- `node council/test-live.mjs` → **56** green
- `node --check scholars.js` / `cloudflare-taxi/src/grounded.js` → OK
- **브라우저(Chrome, 데스크톱 + 390×844 모바일):**
  - 정상 딥링크 `#repo=youtube-dl-nas` → 정확한 카드 오픈 (displayed == target == key)
  - `hashchange`로 `#repo=%zz` / `#repo=%` → **`window.onerror` 비어있음**, 카드 유지
  - 정상 딥링크 전환 `#repo=Repolis` → 카드 정확히 전환
  - 망가진 해시에서 카드 닫기 → 해시 정리 + 모달 닫힘, 예외 없음
  - 망가진 딥링크로 **새 부팅**(모바일) → 잘못된 카드 안 열림, 가로 오버플로 없음
  - **콘솔 에러 0**

## 영향 범위
`index.html` 1줄 → 2줄(순수 로직), smoke 가드, CHANGELOG. 새 의존성·빌드 스텝 없음, 시크릿 없음, public-safe.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>