### PR TITLE
Fix: resident speech bubbles no longer cut off mid-sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.50.3] — 2026-07-04
+
+### 💬 Fix — resident speech bubbles were getting cut off mid-sentence
+- **Why it cut off.** The resident ambient bubble (`makeResBubble`) rendered at most **3 lines** on a small canvas and hard-truncated the 3rd line with a mid-word `…` — but the worker was told the AI could write up to **180 characters**, and ambient AI is live in production (`NPC_FLAGS` KV `liveToggle`), so real NPC lines ran far longer than 3 lines could hold and got chopped in the middle of a word (e.g. `…화분 덕에 더…`).
+- **The fix is on both ends.** Client: the bubble is enlarged (`448×252`, up to **5 lines**, 24px) so a full short line fits, and ambient text now runs through a new **`_capBub`** clean cap (≤80 chars) that trims only at a sentence/clause/word boundary — never inside a word — appending `…` solely when it actually trims. Worker: the shared persona guard drops from **“180 characters” → “90 characters”**, the ambient prompt asks for **~60 characters**, and the server response is capped role-aware (`ambient 90 / player 180`) so ambient lines come back bubble-sized natively. Player-chat in the DOM panel keeps the fuller 180-char cap.
+- **Preserved.** All prior NPC guards: hidden-tab freeze, visitor-chat freeze, pair cooldown, budget/env gating, 10-turn hard ceiling, `motionEnabled` locomotion, and the lifelike LOW_END walking pace from 1.50.2.
+- **Guards.** `scripts/smoke.mjs` (**→ 176**) adds checks that ambient text uses `_capBub` (word-boundary trim, no mid-word cut), the bubble renders up to 5 lines, and player chat keeps its 180-char cap.
+
+### Verified
+- Hermetic block green: **smoke 176 · council 130 · live 56/0**, `scholars.js` + `grounded.js` syntax-clean, inline module syntax-checked. Chrome mobile **390×844** (LOW_END forced) + desktop **1440×900**: a 79-char line renders as **4 full lines with no ellipsis** ending cleanly (`…바라보네요.`); a 108-char AI line is trimmed to a clean 77-char clause (`…퍼지고,`) then wraps to 4 lines — no mid-word cuts, **0 console errors**. Deployed worker (`repolis-taxi`) now returns short complete ambient lines (~27–28 chars, e.g. `카이, 오늘은 웹 골목 화단이 유난히 싱그럽더라 🌿`).
+
 ## [1.50.2] — 2026-07-04
 
 ### 🚶 Tuning — LOW_END residents now walk at a lifelike pace (not a crawl)

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -690,16 +690,16 @@ const NPC_PERSONAS = {
 function _npcName(id, lang) { const p = NPC_PERSONAS[id]; if (!p) return id; return (lang === "en" ? p.en : p.ko); }
 function _npcGuard(lang) {
   return lang === "en"
-    ? "You are an ordinary townsperson in a cozy 3D city of code repositories. Speak ONLY as this resident about their district's everyday life, streets, gardens, builds, docs or mood. Never say you are an AI, never mention models, providers, prompts, tokens, budgets, or any private/internal detail, and don't impersonate the plaza scholars or the taxi. One short natural line, at most 180 characters, no emoji spam."
-    : "당신은 코드 저장소들로 이루어진 아늑한 3D 도시의 평범한 주민입니다. 오직 이 주민으로서 자기 구역의 일상·거리·정원·빌드·문서·분위기에 대해서만 말하세요. 자신이 AI라고 말하거나 모델·제공자·프롬프트·토큰·예산·내부/비공개 정보를 언급하지 말고, 광장의 현자나 택시를 흉내 내지 마세요. 짧고 자연스러운 한 줄, 최대 180자.";
+    ? "You are an ordinary townsperson in a cozy 3D city of code repositories. Speak ONLY as this resident about their district's everyday life, streets, gardens, builds, docs or mood. Never say you are an AI, never mention models, providers, prompts, tokens, budgets, or any private/internal detail, and don't impersonate the plaza scholars or the taxi. One short natural line, at most 90 characters, no emoji spam."
+    : "당신은 코드 저장소들로 이루어진 아늑한 3D 도시의 평범한 주민입니다. 오직 이 주민으로서 자기 구역의 일상·거리·정원·빌드·문서·분위기에 대해서만 말하세요. 자신이 AI라고 말하거나 모델·제공자·프롬프트·토큰·예산·내부/비공개 정보를 언급하지 말고, 광장의 현자나 택시를 흉내 내지 마세요. 짧고 자연스러운 한 줄, 최대 90자.";
 }
 function npcAmbientPrompt(speakerId, listenerId, topic, lang) {
   const s = _npcName(speakerId, lang), l = _npcName(listenerId, lang), P = NPC_PERSONAS[speakerId] || {};
   const zn = (P.zone && (lang === "en" ? P.zone.en : P.zone.ko)) || "";
   const vb = (P.vibe && (lang === "en" ? P.vibe.en : P.vibe.ko)) || "";
   return lang === "en"
-    ? `${_npcGuard(lang)} Your name is ${s.name}, the ${s.role} of ${zn} — ${vb}. You are chatting with your neighbour ${l.name}. Continue the small talk with ONE friendly line about town life.`
-    : `${_npcGuard(lang)} 당신의 이름은 ${s.name}, ${zn}의 ${s.role}이고 성격은 ${vb} 편이에요. 이웃 ${l.name}와 담소 중이에요. 마을살이에 대한 친근한 한 줄로 대화를 이어가세요.`;
+    ? `${_npcGuard(lang)} Your name is ${s.name}, the ${s.role} of ${zn} — ${vb}. You are chatting with your neighbour ${l.name}. Continue the small talk with ONE friendly line about town life, kept short (about 60 characters).`
+    : `${_npcGuard(lang)} 당신의 이름은 ${s.name}, ${zn}의 ${s.role}이고 성격은 ${vb} 편이에요. 이웃 ${l.name}와 담소 중이에요. 마을살이에 대한 친근한 한 줄로, 짧게(60자 안팎) 대화를 이어가세요.`;
 }
 function npcPlayerPrompt(speakerId, lang) {
   const s = _npcName(speakerId, lang), P = NPC_PERSONAS[speakerId] || {};
@@ -713,7 +713,7 @@ function npcAmbientUser(body, lang) {
   if (!last.length) return lang === "en" ? "(open the conversation)" : "(대화를 시작하세요)";
   return last.map((t) => `${_npcName(t.who, lang).name}: ${String(t.text || "").slice(0, 180)}`).join("\n");
 }
-function capLine(s) { return String(s || "").replace(/\s+/g, " ").trim().slice(0, 180); }
+function capLine(s, max = 180) { return String(s || "").replace(/\s+/g, " ").trim().slice(0, max); }
 
 // --- NPC budget: UTC-day module-scope ledger (best-effort; deferred: D1/DO for durable multi-isolate enforcement) ---
 let _npcLedger = { day: "", spentUsd: 0, turns: 0 };
@@ -845,7 +845,7 @@ async function npcHandler(body, request, env) {
     npcChargeTurn(env, cost);
     const budget2 = npcBudgetState(env);
     npcMetric(env, role === "ambient" ? "npc_ambient_turn" : "npc_player_chat", { where: role, ai: true, line: out.text, spent: cost });
-    return json({ ok: true, line: capLine(out.text), budget: budget2 }, 200, env);
+    return json({ ok: true, line: capLine(out.text, role === "ambient" ? 90 : 180), budget: budget2 }, 200, env);
   }
   return json({ error: "unknown npc_action" }, 400, env);
 }

--- a/index.html
+++ b/index.html
@@ -4388,21 +4388,22 @@ function residentTag(res){ const W=256,H=100,c=document.createElement('canvas');
   x.fillStyle=hex; x.font='600 19px system-ui,Arial'; x.fillText('\u00b7 '+L.role+' \u00b7', W/2, 74);
   const tx=new THREE.CanvasTexture(c); tx.anisotropy=4;
   const s=new THREE.Sprite(new THREE.SpriteMaterial({map:tx,transparent:true,depthWrite:false,fog:false})); s.scale.set(2.9,1.13,1); s.position.y=3.06; s.renderOrder=6; s._res=res; return s; }
-function makeResBubble(){ const W=384,H=176, cv=document.createElement('canvas'); cv.width=W; cv.height=H; const c=cv.getContext('2d');
-  const tex=new THREE.CanvasTexture(cv); const sp=new THREE.Sprite(new THREE.SpriteMaterial({map:tex,transparent:true,opacity:0,depthWrite:false})); sp.scale.set(6.4,2.93,1); sp.renderOrder=19; let life=0;
+function makeResBubble(){ const W=448,H=252, cv=document.createElement('canvas'); cv.width=W; cv.height=H; const c=cv.getContext('2d');
+  const tex=new THREE.CanvasTexture(cv); const sp=new THREE.Sprite(new THREE.SpriteMaterial({map:tex,transparent:true,opacity:0,depthWrite:false})); sp.scale.set(7.47,4.2,1); sp.renderOrder=19; let life=0;
+  const ML=5, FS=24, LH=30;                                                    // up to 5 lines so a full conversational line shows instead of being cut off after 3
   function wrap(text,maxw){ const words=String(text).split(/\s+/); const lines=[]; let cur='';
-    for(const w of words){ const tryl=cur?cur+' '+w:w; if(c.measureText(tryl).width>maxw && cur){ lines.push(cur); cur=w; if(lines.length>=3) break; } else cur=tryl; }
-    if(cur&&lines.length<3) lines.push(cur);
-    if(lines.length>=3){ let last=lines[2]; while(c.measureText(last+'\u2026').width>maxw && last.length>1) last=last.slice(0,-1); lines[2]=last+'\u2026'; }
+    for(const w of words){ const tryl=cur?cur+' '+w:w; if(c.measureText(tryl).width>maxw && cur){ lines.push(cur); cur=w; if(lines.length>=ML) break; } else cur=tryl; }
+    if(cur&&lines.length<ML) lines.push(cur);
+    if(lines.length>=ML){ let last=lines[ML-1]; while(c.measureText(last+'\u2026').width>maxw && last.length>1) last=last.slice(0,-1); lines[ML-1]=last+'\u2026'; }
     return lines; }
-  function draw(text,hex){ c.clearRect(0,0,W,H); c.font='600 25px system-ui,sans-serif'; const lines=wrap(text,W-56);
-    const bh=28*lines.length+30, top=(H-26)-bh, r=24;
+  function draw(text,hex){ c.clearRect(0,0,W,H); c.font='600 '+FS+'px system-ui,sans-serif'; const lines=wrap(text,W-56);
+    const bh=LH*lines.length+30, top=(H-26)-bh, r=24;
     c.beginPath(); c.moveTo(12+r,top); c.arcTo(W-12,top,W-12,top+bh,r); c.arcTo(W-12,top+bh,12,top+bh,r); c.arcTo(12,top+bh,12,top,r); c.arcTo(12,top,W-12,top,r); c.closePath();
     c.fillStyle='rgba(255,251,242,0.97)'; c.fill(); c.lineWidth=4; c.strokeStyle=hex||'#caa'; c.stroke();
     c.beginPath(); c.moveTo(W/2-14,top+bh-2); c.lineTo(W/2+14,top+bh-2); c.lineTo(W/2-10,top+bh+20); c.closePath(); c.fillStyle='rgba(255,251,242,0.97)'; c.fill();
-    c.fillStyle='#33271a'; c.textAlign='center'; c.textBaseline='middle'; lines.forEach((ln,i)=>{ c.fillText(ln, W/2, top+22+i*28); }); tex.needsUpdate=true; }
-  return { sprite:sp, say(text,hex){ draw(text,hex); life=Math.min(9, 3.4 + String(text).length*0.03); }, clear(){ life=0; },
-    update(dt){ life=Math.max(0,life-dt); const want=life>0?1:0; sp.material.opacity+=(want-sp.material.opacity)*0.14; sp.position.y=3.9+Math.sin(clock.elapsedTime*1.5)*0.05; } }; }
+    c.fillStyle='#33271a'; c.textAlign='center'; c.textBaseline='middle'; lines.forEach((ln,i)=>{ c.fillText(ln, W/2, top+24+i*LH); }); tex.needsUpdate=true; }
+  return { sprite:sp, say(text,hex){ draw(text,hex); life=Math.min(11, 4.0 + String(text).length*0.035); }, clear(){ life=0; },
+    update(dt){ life=Math.max(0,life-dt); const want=life>0?1:0; sp.material.opacity+=(want-sp.material.opacity)*0.14; sp.position.y=4.55+Math.sin(clock.elapsedTime*1.5)*0.05; } }; }
 
 const RES_REACH=3.4; const RESIDENTS_LIVE=[]; let nearResident=null;
 // ---- wander + rendezvous tuning: townsfolk stroll around home and walk toward one another to actually meet before talking ----
@@ -4421,7 +4422,7 @@ function _residentSpot(res){
   return {x:hub.x+7, z:hub.z}; }
 function placeResident(res){ const g=buildResident(res), sp=_residentSpot(res);
   g.position.set(sp.x,0,sp.z); g.rotation.y=Math.atan2(-sp.x,-sp.z);
-  const tag=residentTag(res); g.add(tag); const bub=makeResBubble(); bub.sprite.position.set(0,3.9,0); g.add(bub.sprite); scene.add(g);
+  const tag=residentTag(res); g.add(tag); const bub=makeResBubble(); bub.sprite.position.set(0,4.55,0); g.add(bub.sprite); scene.add(g);
   const live={ res, group:g, tag, bub, _baseRot:g.rotation.y, _ph:Math.random()*6.28, _gt:0, lastLine:-1,
     home:{x:sp.x,z:sp.z}, _rt:null, _rp:Math.random()*4, _wk:Math.random()*6.28, _wspd:RES_MOVE.wanderSpd*(0.85+Math.random()*0.3) };
   live._npc={ resident:true, id:res.id, kind:'resident', res, pos:g.position, reach:RES_REACH }; res._live=live;
@@ -4443,6 +4444,12 @@ let _ambConv=null, _ambNextAt=9, _guestCdUntil=0; const _pairCd=new Map(); const
 function _resChatActive(){ try{ return !!(activeNpc&&activeNpc.resident&&chatEl&&!chatEl.classList.contains('hidden')); }catch(e){ return false; } }
 function _pairKey(a,b){ return [a.res.id,b.res.id].sort().join('|'); }
 function _cap180(s){ return String(s||'').replace(/\s+/g,' ').trim().slice(0,180); }
+function _capBub(s){ s=String(s||'').replace(/\s+/g,' ').trim(); const MAX=80;   // bubble holds ~5 lines; trim at a sentence/clause/word boundary so a line never gets cut mid-word
+  if(s.length<=MAX) return s; const cut=s.slice(0,MAX);
+  const p=Math.max(cut.lastIndexOf('. '),cut.lastIndexOf('! '),cut.lastIndexOf('? '),cut.lastIndexOf('\u3002'),cut.lastIndexOf('\uff01'),cut.lastIndexOf('\uff1f'),cut.lastIndexOf('\u2026 '),cut.lastIndexOf(', '),cut.lastIndexOf('~ '));
+  if(p>=40) return cut.slice(0,p+1).trim();
+  const sp=cut.lastIndexOf(' '); if(sp>=40) return cut.slice(0,sp).trim()+'\u2026';
+  return cut.trim()+'\u2026'; }
 function _pushTranscript(t){ _npcTranscript.push(t); if(_npcTranscript.length>60) _npcTranscript.shift(); }
 function _scriptLine(L){ const bank=(L.res.amb&&(L.res.amb[LANG]||L.res.amb.ko))||['\u2026']; let i=(Math.random()*bank.length)|0; if(bank.length>1 && i===L.lastLine) i=(i+1)%bank.length; L.lastLine=i; return bank[i]; }
 function _ambientAllowed(){ return NPC_CFG.modeEnabled && !document.hidden && !_resChatActive() && RESIDENTS_LIVE.length>=NPC_CFG.activeMin && (NPC_CFG.scriptedAmbient || (NPC_CFG.aiEnabled&&NPC_CFG.ambientAiEnabled)); }
@@ -4458,7 +4465,7 @@ function _startAmb(a,b){ const now=clock.elapsedTime;
   _emitMetric('npc_ambient_started',{a:a.res.id,b:b.res.id,max}); return true; }
 function _advanceAmb(){ const C=_ambConv; if(!C||C.pending) return; const now=clock.elapsedTime; const speaker=C.who, listener=C.other;
   const useAI = NPC_CFG.aiEnabled && NPC_CFG.ambientAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
-  function done(line,ai,fb){ line=_cap180(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
+  function done(line,ai,fb){ line=_capBub(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
     const turn={ t:Math.round(clock.elapsedTime), a:C.a.res.id, b:C.b.res.id, who:speaker.res.id, text:line, ai:!!ai, fb:!!fb };
     C.turns.push(turn); _pushTranscript(turn); if(fb) _npcBudget.fallbackTurns++; if(ai) _npcBudget.aiTurns++;
     _emitMetric('npc_ambient_turn',{who:speaker.res.id,ai:!!ai,fb:!!fb,len:line.length});

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -330,7 +330,10 @@ ok(/if\(document\.hidden\)\{ if\(_ambConv\) _endAmb\('hidden'\); return; \}/.tes
 ok(/hardMaxTurns:10/.test(npcBlock), 'ambient conversations are hard-capped at 10 turns');
 ok(/pairCooldownMin:20, pairCooldownMax:60/.test(npcBlock), 'a resident pair has a 20–60s cooldown before chatting again');
 ok(/maxConcurrent:1/.test(npcBlock), 'at most one ambient conversation runs at a time');
-ok(/_cap180/.test(npcBlock) && /slice\(0,180\)/.test(npcBlock), 'each ambient line is capped at 180 chars');
+ok(/_capBub\(line\)/.test(npcBlock), 'ambient bubble text runs through the bubble-friendly clean cap (_capBub), not a raw 180-char slice');
+ok(/function _capBub\(s\)\{[\s\S]*?lastIndexOf\(' '\)[\s\S]*?\}/.test(npcBlock), '_capBub trims at a sentence/word boundary so a bubble line never gets cut mid-word');
+ok(/function makeResBubble\(\)\{[\s\S]*?const ML=5/.test(npcBlock), 'resident speech bubble renders up to 5 lines (a full conversational line shows instead of a 3-line cut)');
+ok(/_cap180/.test(npcBlock) && /slice\(0,180\)/.test(npcBlock), 'player-chat lines keep the 180-char cap for the DOM panel');
 // 12d — budget: exhaustion forces the free scripted fallback, degradation trims turns
 ok(/function _budgetExhausted\(\)/.test(npcBlock) && /function _budgetLow\(\)/.test(npcBlock), 'client budget mirror exposes low + exhausted checks');
 ok(/NPC_CFG\.aiEnabled && NPC_CFG\.ambientAiEnabled && !_budgetExhausted\(\)/.test(npcBlock), 'AI ambient turn is gated on budget-not-exhausted');


### PR DESCRIPTION
## Problem

A resident NPC's ambient speech bubble was being chopped in the middle of a word (e.g. `…화분 덕에 더…`).

**Root cause — a mismatch between two layers:**
- The client bubble (`makeResBubble`) rendered **at most 3 lines** on a small canvas and hard-truncated the 3rd line with a mid-word `…`.
- The worker prompt told the AI it could write up to **180 characters**, and **ambient AI is live in production** (`NPC_FLAGS` KV `liveToggle` → confirmed `aiEnabled:true, ambientEnabled:true`), so real NPC lines ran far longer than 3 lines could hold.

## Fix (both ends)

**Client — `index.html`**
- Enlarge `makeResBubble` to `448×252`, up to **5 lines**, 24px, so a full short line fits; re-anchor the sprite (`y 4.55`) so nothing clips at the top.
- Add **`_capBub`** — an ambient-only clean cap (≤80 chars) that trims only at a sentence/clause/word boundary and appends `…` **only when it actually trims** (never inside a word). Player chat in the DOM panel keeps the fuller `_cap180`.

**Worker — `cloudflare-taxi/src/grounded.js`** (deployed)
- Shared persona guard **“180 characters” → “90 characters”**; ambient prompt asks for **~60 characters**; server response capped **role-aware** (`ambient 90 / player 180`) so ambient lines come back bubble-sized natively.

## Preserved
Hidden-tab freeze, visitor-chat freeze, pair cooldown, budget/env gating, 10-turn hard ceiling, `motionEnabled` locomotion, and the lifelike LOW_END walking pace (1.50.2).

## Verified
- Hermetic: **smoke 176 · council 130 · live 56/0**, `scholars.js` + `grounded.js` syntax-clean, inline module syntax-checked.
- Chrome mobile **390×844** (LOW_END forced) + desktop **1440×900**: a 79-char line renders as **4 full lines, no ellipsis** (`…바라보네요.`); a 108-char AI line trims to a clean 77-char clause (`…퍼지고,`) then wraps to 4 lines — no mid-word cuts, **0 console errors**.
- Deployed `repolis-taxi` now returns short complete ambient lines (~27–28 chars, e.g. `카이, 오늘은 웹 골목 화단이 유난히 싱그럽더라 🌿`).

CHANGELOG: **[1.50.3]**.