### PR TITLE
feat(realtime): self-healing peer roster + private admin kick (no more ghost avatars)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.53.0] — 2026-07-04
+
+### 🧹 Ghost avatars can't haunt the city anymore — plus a private admin kick
+- **The bug.** A remote avatar only ever disappeared when the server sent an explicit `leave` (or the socket you own closed). If a single `leave` was ever missed — a network blip, a worker eviction — that avatar circled the plaza *forever* for everyone, with no way to clear it. (This is what `guest-7500` was: a stale ghost, not a live connection.)
+- **Self-healing roster.** The realtime worker (`repolis-rt`) now broadcasts an **authoritative `{t:'sync', ids, live}`** roster every ~15s (via a Durable Object alarm, only while anyone's connected). The client reconciles against it and drops any local avatar the server no longer knows about — so a missed `leave` heals itself within one sync cycle instead of lingering. Idempotent and false-cull-proof: idle-but-live peers stay because the server, not a client timer, is the source of truth.
+- **Admin kick tool (private).** New token-gated endpoints on the worker: `GET /__admin/peers` lists everyone in the room (`id, name, x, z, yaw` + live count), and `/__admin/kick?id=|name=[&ban=secs]` force-closes matching sockets (code 4001), broadcasts a `leave`, and can lay a short in-memory ban (≤1h) so a nuisance can't instantly reconnect. Gated behind an `ADMIN_KEY` secret — returns **501** if unset (fails safe), **403** on a bad key. Never committed.
+- **Debug helpers.** `window.__peers()` lists the avatars you're rendering; `window.__kickGhost(idOrName)` locally drops a stray one (or all, with no arg) — the next server sync keeps the real peers.
+- **Preserved.** Visitor counters (현재/오늘/누적, UTC day), the solo-mode fallback when `RT_DEFAULT` is empty, and the identical JSON-over-WebSocket protocol are all untouched. No new deps; still free-plan Durable Objects.
+
+### Verified
+- Hermetic block green: **smoke · council 130 · live 56/0**, `scholars.js` + `grounded.js` + `cloudflare/src/server.js` syntax-clean. Local `wrangler dev` integration test **11/11** (join visibility, admin auth 403/list, kick-by-name broadcast, ban refusal, periodic sync roster). Smoke gains a realtime ghost-cleanup guard.
+
 ## [1.52.0] — 2026-07-04
 
 ### 🌼 A plaza dreamer, benches to rest on, and roadside flowers that glow after dark

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -47,3 +47,34 @@ Then open the site pointed at it:
 - "today" uses the UTC date.
 - Same JSON-over-WebSocket protocol as `../party/repolis.js` and
   `../scripts/dev_realtime.mjs`, so the client is identical across all three.
+- The room broadcasts an authoritative `{t:'sync', ids, live}` roster every ~15s
+  (Durable Object alarm, only while someone's connected). The client drops any
+  avatar not in it, so a missed `leave` (network blip / worker eviction) can't
+  leave a **ghost avatar** circling forever — it self-heals within one cycle.
+
+## Admin (kick a stray / ghost avatar)
+
+Token-gated endpoints, off by default. Set a secret first (never commit it):
+
+```bash
+cd cloudflare
+npx wrangler secret put ADMIN_KEY      # paste a strong random value
+npx wrangler deploy
+```
+
+Then, from a trusted shell:
+
+```bash
+BASE=https://repolis-rt.<you>.workers.dev
+# who's in the room right now?
+curl "$BASE/__admin/peers?key=$ADMIN_KEY"
+# force-disconnect someone by display name (or id=), optionally ban ≤1h
+curl "$BASE/__admin/kick?key=$ADMIN_KEY&name=Guest-7500&ban=300"
+```
+
+`/__admin/peers` returns `{live, peers:[{id,name,x,z,yaw}], bans}`.
+`/__admin/kick` closes matching sockets (code 4001), broadcasts a `leave`, and
+with `&ban=<secs>` lays a short in-memory ban. Responses: **501** if `ADMIN_KEY`
+is unset (fails safe), **403** on a bad key, **400** with no `id`/`name`. The ban
+is in-memory (lost on DO eviction) — fine for short nuisance blocks, not a
+permanent ban list.

--- a/cloudflare/src/server.js
+++ b/cloudflare/src/server.js
@@ -17,6 +17,10 @@
 //   server -> { t:'join', peer, live, today, total, entriesToday, entriesTotal }
 //   server -> { t:'pos', id, x, z, yaw }
 //   server -> { t:'leave', id, live }
+//   server -> { t:'sync', ids:[...], live }   // authoritative roster (every ~15s); clients drop any avatar not listed
+//
+// Owner moderation (not part of the public client): GET /__admin/peers and
+// /__admin/kick?id=|name=[&ban=secs], both gated by the ADMIN_KEY secret.
 //
 // Counters: `today` and `total` (unique visitors today / all-time) are kept in
 // the Durable Object's SQLite storage, so they survive restarts. `live` is the
@@ -25,6 +29,11 @@
 
 const ENTRY_SEED_MULTIPLIER = 3.7;
 const COUNTER_BASIS = "UTC day / world unique guest / entry joins";
+// How often the room broadcasts its authoritative peer roster ({t:'sync'}). Clients
+// drop any avatar not in the roster, so a ghost (a peer whose one-shot `leave` was
+// missed by a client) self-heals within one interval instead of lingering forever.
+const SYNC_MS = 15000;
+const MAX_BAN_S = 3600; // safety ceiling for an admin kick's optional re-join ban
 
 export class RepolisRoom {
   constructor(state, env) {
@@ -32,6 +41,8 @@ export class RepolisRoom {
     this.env = env;
     this.sql = state.storage.sql;
     this.sessions = new Map(); // ws -> peer
+    this.bans = new Map();     // peer id / "name:<name>" -> ban-expiry ms (in-memory; short admin kicks)
+    this._alarmSet = false;    // is a roster-sync alarm currently scheduled?
     this.ready = false;        // schema + counters initialised?
     // Kill switch: a monthly cap on NEW connections so a traffic spike or abuse
     // can never push the bill past the included Workers Paid allowance. Tunable
@@ -200,6 +211,11 @@ export class RepolisRoom {
     if (url.pathname.endsWith("/__usage")) {
       return new Response(JSON.stringify(this.counterSnapshot()), { headers: { "content-type": "application/json" } });
     }
+    // Owner-only moderation (list live peers / kick a nuisance socket). Gated by the
+    // ADMIN_KEY secret — never exposed to the public client. See admin().
+    if (url.pathname.includes("/__admin/")) {
+      return this.admin(req, url);
+    }
     if (req.headers.get("Upgrade") !== "websocket") {
       return new Response("Repolis realtime OK", { status: 200 });
     }
@@ -216,6 +232,79 @@ export class RepolisRoom {
     return new Response(null, { status: 101, webSocket: client });
   }
 
+  // Owner-only moderation endpoint. Auth: ADMIN_KEY secret via ?key= or x-admin-key.
+  //   GET  /__admin/peers          -> { live, peers:[{id,name,x,z,yaw}] }
+  //   POST /__admin/kick?id=<id>   -> close matching socket(s), broadcast leave
+  //        /__admin/kick?name=<n>  -> match by display name (e.g. "Guest-7500")
+  //        &ban=<seconds>          -> also refuse that id/name re-joining for a bit (<=1h)
+  // Kicking only severs a live socket. A ghost avatar (already-gone peer still shown on
+  // some client because its `leave` was missed) has no socket here — the periodic
+  // {t:'sync'} roster removes those automatically; see alarm().
+  admin(req, url) {
+    const secret = this.env && this.env.ADMIN_KEY;
+    const key = url.searchParams.get("key") || req.headers.get("x-admin-key");
+    if (!secret) return this.json({ error: "ADMIN_KEY not set on the worker" }, 501);
+    if (key !== secret) return new Response("forbidden", { status: 403 });
+    const path = url.pathname;
+    if (path.endsWith("/__admin/peers")) {
+      const peers = [...this.sessions.values()].map((p) => ({ id: p.id, name: p.name, x: p.x, z: p.z, yaw: p.yaw }));
+      return this.json({ live: this.sessions.size, peers, bans: [...this.bans.keys()] });
+    }
+    if (path.endsWith("/__admin/kick")) {
+      const id = url.searchParams.get("id");
+      const name = url.searchParams.get("name");
+      if (!id && !name) return this.json({ error: "pass ?id= or ?name=" }, 400);
+      const banS = Math.min(MAX_BAN_S, Math.max(0, parseInt(url.searchParams.get("ban") || "0", 10) || 0));
+      const kicked = [];
+      for (const [ws, p] of [...this.sessions]) {
+        if ((id && p.id === id) || (name && p.name === name)) {
+          kicked.push({ id: p.id, name: p.name });
+          this.sessions.delete(ws);
+          if (banS) {
+            const until = Date.now() + banS * 1000;
+            this.bans.set(p.id, until);
+            this.bans.set("name:" + p.name, until);
+          }
+          try { ws.close(4001, "kicked"); } catch (e) { /* already closing */ }
+          this.broadcast({ t: "leave", id: p.id, live: this.sessions.size });
+        }
+      }
+      return this.json({ kicked, count: kicked.length, live: this.sessions.size, bannedFor: banS || null });
+    }
+    return this.json({ error: "unknown admin route", routes: ["/__admin/peers", "/__admin/kick"] }, 404);
+  }
+
+  json(obj, status = 200) {
+    return new Response(JSON.stringify(obj), { status, headers: { "content-type": "application/json" } });
+  }
+
+  isBanned(peer) {
+    const now = Date.now();
+    for (const k of [peer.id, "name:" + peer.name]) {
+      const until = this.bans.get(k);
+      if (until) { if (until > now) return true; this.bans.delete(k); }
+    }
+    return false;
+  }
+
+  // Keep exactly one roster-sync alarm scheduled while the room is populated. The
+  // alarm broadcasts the authoritative peer id list so ghost avatars self-heal; it
+  // reschedules itself until the room empties, then stops (no idle-room cost).
+  scheduleSync() {
+    if (this._alarmSet) return;
+    try { this.state.storage.setAlarm(Date.now() + SYNC_MS); this._alarmSet = true; }
+    catch (e) { this._alarmSet = false; /* storage/alarm unavailable — presence still works */ }
+  }
+
+  async alarm() {
+    this._alarmSet = false;
+    if (this.sessions.size > 0) {
+      const ids = [...this.sessions.values()].map((p) => p.id);
+      this.broadcast({ t: "sync", ids, live: this.sessions.size });
+      this.scheduleSync();
+    }
+  }
+
   wire(ws) {
     ws.addEventListener("message", (ev) => {
       let m;
@@ -228,8 +317,11 @@ export class RepolisRoom {
           x: +m.x || 0, z: +m.z || 0, yaw: +m.yaw || 0,
           color: m.color,
         };
+        // An admin kick can carry a short ban; refuse the re-join cleanly.
+        if (this.isBanned(peer)) { try { ws.close(4003, "banned"); } catch (e) { /* ignore */ } return; }
         const countEntry = !this.sessions.has(ws);
         this.sessions.set(ws, peer);
+        this.scheduleSync();   // ensure the ghost-clearing roster broadcast is running while anyone is here
         const { today, total, entriesToday, entriesTotal } = this.counts(peer.id, countEntry);
         const live = this.sessions.size;
         const stats = { live };
@@ -280,12 +372,13 @@ export default {
     const url = new URL(req.url);
     const isWS = req.headers.get("Upgrade") === "websocket";
     const isUsage = url.pathname.endsWith("/__usage");
-    if (!isWS && !isUsage) {
+    const isAdmin = url.pathname.includes("/__admin/");
+    if (!isWS && !isUsage && !isAdmin) {
       return new Response("Repolis realtime server — connect over WebSocket.", { status: 200 });
     }
     // Everyone shares one room; the last path segment names it (default "world").
-    // /__usage always reports the shared "world" room.
-    const room = isUsage ? "world" : (url.pathname.split("/").filter(Boolean).pop() || "world");
+    // /__usage and /__admin/* always target the shared "world" room.
+    const room = (isUsage || isAdmin) ? "world" : (url.pathname.split("/").filter(Boolean).pop() || "world");
     const id = env.REPOLIS_ROOM.idFromName(room);
     return env.REPOLIS_ROOM.get(id).fetch(req);
   },

--- a/index.html
+++ b/index.html
@@ -6351,6 +6351,7 @@ function rtHandle(m){
   else if(m.t==='join'){ addPeer(m.peer); applyStats(m); }
   else if(m.t==='pos'){ const p=peers.get(m.id); if(p){ p.tx=m.x; p.tz=m.z; p.tyaw=m.yaw; } }
   else if(m.t==='leave'){ removePeer(m.id); if(m.live!=null) setLive(m.live); }
+  else if(m.t==='sync'){ const ids=new Set(m.ids||[]); for(const id of [...peers.keys()]) if(!ids.has(id)) removePeer(id); if(m.live!=null) setLive(m.live); }   // authoritative roster: drop any ghost avatar the server no longer knows about
   else if(m.t==='stats'){ applyStats(m); }
   else if(m.t==='wave'){ const p=peers.get(m.id); if(p){ p.emoteT=EMOTES.wave.dur; p.emoteKind='wave'; emoteBubble(p.group,'wave'); if(m.to===guestId()) showWave(LANG==='ko'?`${p.name} 님이 인사했어요 👋`:`${p.name} waved at you 👋`); } }
   else if(m.t==='emote'){ const p=peers.get(m.id); if(p){ const E=EMOTES[m.kind]; if(E){ p.emoteT=E.dur; p.emoteKind=m.kind; emoteBubble(p.group,m.kind); } } }
@@ -6399,6 +6400,8 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
   window.__card=(name)=>{ const r=repoByKey(name); if(r){ openCard(r); return {repo:r.repo,license:r.license,open_issues:r.open_issues,release_tag:r.release_tag,archived:r.archived,chips:[...document.querySelectorAll('#cardChips .chip')].map(c=>c.textContent.trim())}; } return null; };
   window.__modal=()=>modalOpen;
   window.__rt=()=>({peers:peers.size, live:liveCountEl.textContent, total:allCountEl.textContent, entriesToday:entryCountEl?entryCountEl.textContent:null, entriesTotal:entryTotalCountEl?entryTotalCountEl.textContent:null, ws:rtSock?rtSock.readyState:-1});
+  window.__peers=()=>[...peers.entries()].map(([id,p])=>({id, name:p.name, x:+p.group.position.x.toFixed(1), z:+p.group.position.z.toFixed(1)}));   // live remote avatars I'm rendering
+  window.__kickGhost=(q)=>{ let n=0; for(const [id,p] of [...peers]){ if(q==null||id===q||p.name===q){ removePeer(id); n++; } } return {removed:n};};   // locally drop a lingering avatar by id/name (or all if no arg); server roster keeps real peers
   window.__peerSim=(x=4,z=-2)=>{ rtHandle({t:'join',peer:{id:'gSIM',name:'Tester',x,z,yaw:0,color:0x6fa8ef}}); const p=peers.get('gSIM'); p.group.updateMatrixWorld(true); const v=new THREE.Vector3(0,2.2,0).applyMatrix4(p.group.matrixWorld).project(camera); return {sx:Math.round((v.x*0.5+0.5)*innerWidth), sy:Math.round((-v.y*0.5+0.5)*innerHeight), armR:!!p.group._armR}; };
   window.__greet=(cx,cy)=>{ const g=peerAtScreen(cx,cy); if(g){ greetPeer(g.id,g.p); return {id:g.id, myEmoteT:+emoteT.toFixed(2), kind:emoteKind}; } return null; };
   window.__wave=(id)=>{ const t=id||[...peers.keys()][0]; if(!t) return null; rtHandle({t:'wave',id:t,to:guestId()}); return {by:t, peerEmoteT:+(peers.get(t)?.emoteT||0).toFixed(2), toast:greetToast.textContent}; };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -374,6 +374,10 @@ ok(/NPC_MODEL_DEFAULT \|\| "gpt-5\.4-mini"/.test(WORKER), 'provider adapter fall
 ok(/env\.NPC_DAY_CAP_USD/.test(WORKER) && !/COUNCIL_[A-Z_]*\s*\|\|\s*env\.NPC_/.test(WORKER), 'NPC budget uses the NPC_* namespace (separate from COUNCIL_*)');
 ok(/function npcMetric\(/.test(WORKER) && /env\.METRICS_URL/.test(WORKER), 'redacted fire-and-forget metrics emit (env.METRICS_URL) present');
 
+// 13 — realtime ghost cleanup: client reconciles against the server's authoritative roster
+ok(/m\.t==='sync'/.test(HTML) && /for\(const id of \[\.\.\.peers\.keys\(\)\]\) if\(!ids\.has\(id\)\) removePeer\(id\)/.test(HTML), "client drops any avatar missing from the server's authoritative sync roster (self-healing ghost cleanup)");
+ok(/window\.__peers=\(\)=>/.test(HTML) && /window\.__kickGhost=\(q\)=>/.test(HTML), 'realtime debug helpers (__peers / __kickGhost) are present for inspecting and dropping stray avatars');
+
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');
 if (fail) { console.log('\nFailures:'); fails.forEach(f => console.log('  - ' + f)); }


### PR DESCRIPTION
## Why
A remote avatar only ever disappeared when the server sent an explicit `leave` (or your own socket closed). A single missed `leave` — a network blip, a worker eviction — left that avatar circling the plaza **forever** for everyone, with no way to clear it. That's exactly what `guest-7500` was: a stale **ghost**, not a live connection (production `/__usage` showed `live:0`).

## What

**Server (`repolis-rt`)**
- Broadcasts an authoritative `{t:'sync', ids, live}` roster every ~15s via a Durable Object alarm — only while the room is populated (no idle-room cost, self-reschedules, stops when empty).
- Owner-only moderation gated by an `ADMIN_KEY` secret:
  - `GET /__admin/peers` → `{live, peers:[{id,name,x,z,yaw}], bans}`
  - `/__admin/kick?id=|name=[&ban=secs]` → force-closes matching sockets (code 4001), broadcasts `leave`, optional in-memory ban (≤1h).
  - Fails safe: **501** if `ADMIN_KEY` unset, **403** on bad key, **400** with no id/name. `join()` refuses a banned re-join (4003).

**Client (`index.html`)**
- Reconciles against the sync roster: drops any local avatar the server no longer knows about, so a missed `leave` self-heals within one cycle. Idempotent and false-cull-proof (server is source of truth, not a client timer).
- Debug helpers `window.__peers()` and `window.__kickGhost(idOrName)`.

**Docs / guards**
- `cloudflare/README.md` admin + sync section; `CHANGELOG.md` [1.53.0]; two new smoke guards.

## Verified
- **smoke 186 · council 130 · live 56/0**, `scholars.js` + `grounded.js` + `cloudflare/src/server.js` syntax-clean.
- Local `wrangler dev` integration test **11/11** (join visibility, admin auth 403/list, kick-by-name broadcast, ban refusal, periodic sync roster).
- Production: worker deployed, `ADMIN_KEY` secret set, `/__admin/peers` **403-gated** (no/bad key) and room confirmed **empty** → `guest-7500` was a ghost; the client sync fix clears it on reload for everyone.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>