### PR TITLE
docs(readme): group a "Start here" 3-CTA row on the first screen (Live demo · Run locally · Fork your own)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -21,7 +21,9 @@
 
 <a href="https://hyeonsangjeon.github.io/Repolis/"><img src="assets/demo.ko.gif" alt="Repolis: 내 GitHub 레포가 3D 도시로 — 택시에게 &quot;제일 인기있는 레포&quot;라고 말해 그 집까지 타고 가서 카드를 열고 GitHub로 바로 이동하는 데모" width="86%"></a>
 
-<sub>▶ <a href="https://hyeonsangjeon.github.io/Repolis/"><b>라이브 데모</b></a> · Built with Three.js · 한 개의 <code>index.html</code></sub>
+<b>여기서 시작 →</b>&nbsp; ▶ <a href="https://hyeonsangjeon.github.io/Repolis/"><b>라이브 데모</b></a> &nbsp;·&nbsp; 💻 <a href="#로컬에서-바로-띄우기-빌드-없음"><b>로컬에서 실행</b></a> &nbsp;·&nbsp; 🏙️ <a href="#-직접-띄우기"><b>내 도시로 포크 / 직접 띄우기</b></a>
+
+<sub>가입 없이, 빌드 없이 · Three.js로 제작 · 단 하나의 <code>index.html</code></sub>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Don't know where to go? Just tell the 🚕 **LLM taxi driver** — say _"take me
 
 <a href="https://hyeonsangjeon.github.io/Repolis/"><img src="assets/demo.gif" alt="Repolis: see your GitHub repos as a 3D city, tell the taxi &quot;most popular&quot;, ride to that repo's house, open its card, and jump straight to it on GitHub" width="86%"></a>
 
-<sub>▶ <a href="https://hyeonsangjeon.github.io/Repolis/"><b>Live demo</b></a> · Built with Three.js · one single <code>index.html</code></sub>
+<b>Start here →</b>&nbsp; ▶ <a href="https://hyeonsangjeon.github.io/Repolis/"><b>Live demo</b></a> &nbsp;·&nbsp; 💻 <a href="#try-it-locally-no-build-step"><b>Run locally</b></a> &nbsp;·&nbsp; 🏙️ <a href="#-run-your-own"><b>Fork / build your own city</b></a>
+
+<sub>No sign‑up, no build step · Built with Three.js · one single <code>index.html</code></sub>
 
 </div>
 


### PR DESCRIPTION
## Why
A visitor landing from GitHub could see the **Live demo**, but the **"run / fork with my own repos"** path wasn't on the first screen, and the three next-step actions weren't grouped. New arrivals had to scroll into the body to find how to try it themselves.

## What (small conversion polish)
Replaced the GIF caption line (in both READMEs) with one scannable **`Start here →`** row that groups all three next steps, directly under the demo GIF:

- ▶ **Live demo** → the live site
- 💻 **Run locally** → `#try-it-locally-no-build-step`
- 🏙️ **Fork / build your own city** → `#-run-your-own`

…and demoted the tech tagline to a small sub-line (*"No sign-up, no build step · Built with Three.js · one single index.html"*).

## Guardrails honored
- **No large rewrite** — 6 insertions / 2 deletions across the two files.
- **Nothing removed** — every feature / worldview / AI-scholar / resident / Kronos section is untouched; the change only reorders the first-screen entry.
- **No app code or generated data touched** (`index.html`, `repos.json`, `assets/*.json`, secrets/`local.data` all untouched). No sensitive values in the diff.
- **EN ⇄ KO in sync** — `README.md` and `README.ko.md` mirror each other.

## Verified
- Anchor slugs computed with the real **`github-slugger`** — all four (`#-run-your-own`, `#try-it-locally-no-build-step`, `#-직접-띄우기`, `#로컬에서-바로-띄우기-빌드-없음`) match their target headings exactly, no collisions.
- `node scripts/smoke.mjs` → **186 green** (README-only change, no code regression).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>