### PR TITLE
fix(city): restore the player hero spotlight in every phase (day/dawn/dusk, not just night)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.54.1] — 2026-07-05
+
+### 🔦 The player spotlight is back — in every phase, not just at night
+- **What broke.** The hero fill light (`faceLight`) that makes your avatar pop was wired **night-only** (`night?16:0`) since it was introduced, and it's created *after* `initTimeOfDay()` runs — so with `setNightState` early-returning when the day/night state hasn't flipped, the light was **never lifted off 0 during the day**. While the opening scene was hardcoded to bright noon that went unnoticed, but once [1.54.0] made first entry follow the local clock, visitors landing at **day / dawn / dusk** got an unlit hero that washed into the background.
+- **The fix (small regression fix).** The fill light now stays on in **every** phase — a soft `6` by day / dawn / dusk, a bright `16` at night — and is **seeded to the current phase at build time** so a daytime entry is never left dark. It stays a *local* warm pool (point light, distance 15) around the avatar, so the hero reads as "me" without over-brightening the world.
+- **Preserved.** `skyPhaseForHour`, `initTimeOfDay`, the manual 🌙/☀️ `dayBtn` cycle, and every night-asset toggle (moon · stars · lit windows · glows) are untouched.
+- **Debug.** New `?dbg` hook `window.__playerLight([v])` reports (and can live-tune) the hero light's `intensity` / `on` / `isNight` / `phase`. `scripts/smoke.mjs` gains a guard so the day value can never regress back to 0.
+
+### Verified
+- Hermetic: `node scripts/smoke.mjs` **green** (adds 3 hero-light guards). Browser-checked desktop 1440×900 + mobile 390×844 (LOW_END), 0 console errors: hero fill light **on in all four phases** (`__playerLight` → day/dawn/dusk 6, night 16), subtle warm pool by day (world not over-brightened), dramatic spotlight at night; manual day↔night cycle still drives the light.
+
 ## [1.54.0] — 2026-07-04
 
 ### 🌅 First entry now matches your local clock — day / golden hour / night

--- a/index.html
+++ b/index.html
@@ -4056,7 +4056,7 @@ function setNightState(night){
   LAMP_GLOWS.forEach(o=>{ o.material.opacity = night? o._nightOp : 0; });
   WATER_NIGHT.value = night?1:0;
   NIGHT_GLOWS.forEach(o=>{ o.material.opacity = night? o._n : 0; });
-  if(faceLight) faceLight.intensity = night?16:0;
+  if(faceLight) faceLight.intensity = night?16:6;   // hero fill light: never 0 — dimmer by day/dawn/dusk, brighter at night so the avatar always reads against the background
   if(faceMat) faceMat.emissive.setHex(night?0x6a4f30:0x000000);
   npcFaces.forEach(m=>m.emissive.setHex(night?0x4a3a24:0x000000));   // softer than the player so the hero still reads brightest
   buildings.forEach(b=>{
@@ -4683,7 +4683,7 @@ const legL=new THREE.Group(); legL.position.set(-0.2,0.92,0); model.add(legL);
 const legR=legL.clone(); legR.position.x=0.2; model.add(legR);
 const blob=new THREE.Mesh(new THREE.CircleGeometry(1.0,28), new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0x07142e,transparent:true,opacity:0.32,depthWrite:false}));
 blob.rotation.x=-Math.PI/2; blob.position.y=0.03; player.add(blob); // soft contact shadow
-faceLight=new THREE.PointLight(0xfff0d8,0,15,1.5); faceLight.position.set(0,2.35,0.7); model.add(faceLight);
+faceLight=new THREE.PointLight(0xfff0d8, isNight?16:6, 15,1.5); faceLight.position.set(0,2.35,0.7); model.add(faceLight);   // built after initTimeOfDay(): seed to the current phase so day entry isn't stuck dark (setNightState early-returns when the state hasn't flipped)
 faceMat=head.material;
 player.position.set(2.6,0,-3.2);   // spawn beside the plaza fountain (not inside the basin)
 scene.add(player);
@@ -6421,6 +6421,7 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
   window.__sky=(t)=>{ if(t!==undefined){ skyAuto=false; skyT=skyTarget=((t%1)+1)%1; applySky(skyT); const nn=_nightAt(skyT); if(nn!==_nightState) setNightState(nn); } return {skyT:+skyT.toFixed(3),skyTarget:+skyTarget.toFixed(3),isNight,auto:skyAuto,phase:SKY_PHASES[skyPhaseIdx].name,sunVis:sunSky.visible}; };
   window.__skyCycle=()=>{ skyAuto=!skyAuto; lastAct=performance.now(); return skyAuto; };
   window.__skyForHour=(h)=>{ const i=skyPhaseForHour(h); return {hour:((h%24)+24)%24,idx:i,phase:SKY_PHASES[i].name,t:SKY_PHASES[i].t}; };
+  window.__playerLight=(v)=>{ if(v!=null&&faceLight) faceLight.intensity=+v; return {intensity:faceLight?+faceLight.intensity.toFixed(2):null, on:!!(faceLight&&faceLight.intensity>0), isNight, phase:SKY_PHASES[skyPhaseIdx].name, faceEmissive:faceMat?('#'+faceMat.emissive.getHexString()):null}; };   // inspect (or live-tune) the hero fill light
   window.__lib=()=>{ openCard(LIB); return true; };
   window.__libView=(back=20)=>{ player.position.set(0,0,LIB._z-LIB._cw-back); model.rotation.y=0; camYaw=Math.PI; camPitch=0.34; camDist=42; return {z:+player.position.z.toFixed(1)}; };
   window.__tp=(x,z,yaw=Math.PI,pitch=0.30,dist=24)=>{ player.position.set(x,0,z); model.rotation.y=Math.PI-yaw; camYaw=yaw; camPitch=pitch; camDist=dist; return {x,z}; };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -407,6 +407,12 @@ if (sphSrc) {
   ok(skyPhaseForHour(24) === skyPhaseForHour(0) && skyPhaseForHour(-1) === skyPhaseForHour(23), 'hour normalization wraps (24≡0, -1≡23)');
 }
 
+// 15 — player spotlight: the hero fill light must stay lit in every phase (regression guard: day was stuck at 0)
+group('player hero fill light (all phases)');
+ok(/faceLight\.intensity = night\?16:6;/.test(HTML), 'setNightState keeps the hero fill light on by day (6) — never drops to 0 — and brighter at night (16)');
+ok(/faceLight=new THREE\.PointLight\(0xfff0d8, isNight\?16:6,/.test(HTML), 'the hero fill light is seeded to the current phase at build (day entry is not left dark)');
+ok(/window\.__playerLight=/.test(HTML), '?dbg __playerLight hook present to inspect/tune the hero fill light');
+
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');
 if (fail) { console.log('\nFailures:'); fails.forEach(f => console.log('  - ' + f)); }


### PR DESCRIPTION
## Why (the regression)
The avatar's bright **hero fill light** (`faceLight`) was wired **night-only** (`night?16:0`) ever since it was introduced, and it's created *after* `initTimeOfDay()` runs. Because `setNightState` early-returns when the day/night state hasn't flipped, the light was **never lifted off `0` during the day**. The old hardcoded-noon first entry hid this — but once **[1.54.0]** made first entry follow the visitor's local clock, anyone arriving at **day / dawn / dusk** got an unlit hero that washed into the background (worst at golden hour).

## What (small regression fix, app code only)
- `setNightState`: `faceLight.intensity = night?16:6` — a soft daytime baseline instead of `0`, still brighter at night.
- **Seed the light to the current phase at build time** (`isNight?16:6`) so a daytime entry is never left dark despite the `setNightState` early-return.
- Stays a **local warm pool** (point light, distance 15) around the avatar — the world is **not** over-brightened.
- New `?dbg` hook `window.__playerLight([v])` to inspect / live-tune the hero light.
- `scripts/smoke.mjs`: 3 guards so the day value can't silently regress back to `0`.

## Preserved
`skyPhaseForHour`, `initTimeOfDay`, the manual 🌙/☀️ `dayBtn` cycle, and every night-asset toggle (moon · stars · lit windows · glows). No README/docs touched beyond the CHANGELOG entry for this fix.

## Verified
- `node scripts/smoke.mjs` → **green** (adds the 3 hero-light guards).
- Browser-checked **desktop 1440×900** + **mobile 390×844 (LOW_END)**, **0 console errors**:
  - `__playerLight` reports the light **on in all four phases** → day/dawn/dusk **6**, night **16**.
  - Day: subtle warm ground pool, hero reads, world not over-brightened.
  - Night: dramatic bright spotlight pool.
  - Manual day↔night cycle still drives the light (🌙→🌅, intensity follows).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>