### PR TITLE
feat: residents gather into a group circle and take turns (not just 1:1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.56.0] — 2026-07-07
+
+### 🗣️ Residents gather into a circle — everyone takes a turn, not just two
+- **What's new.** When townspeople meet, they no longer talk strictly **1:1**. A gathering now grows into a small **group circle** and the speaking turn **round-robins through every member**, so three or four residents genuinely converse together instead of a bystander standing mute. Emergent, not staged: usually two chat, but nearby cooldown-free neighbours **join in** when the town clusters (plaza, benches), and everyone gets a line.
+- **How it forms.** The engine still picks the closest eligible **seed pair**, then grows the circle with residents within a gather radius (`groupR` — 20u desktop / 15u LOW_END) of the pair, capped at **maxGroup** (4 desktop / 3 mobile & LOW_END). Members walk to the shared **circle centre** (the group centroid) during the approach phase and settle into a ring at talk distance — they never pile onto one partner. Listeners face **whoever is speaking**; the speaker addresses the circle.
+- **Fair turns, still capped.** The turn budget scales gently with circle size (`base + (members − 2)`) but the **hard cap of 10 turns** is untouched, as are `maxConcurrent: 1` (one gathering at a time), the **5–10s** turn gap, and the AI/scripted split. A bigger circle just earns a few more turns so everyone speaks.
+- **Cheap by design.** Grouping adds **zero network cost**: it reuses the existing scripted speech bank and the same AI path (one speaker + one listener per turn), so no worker change and no extra spend. Budget-low still degrades to short scripted turns.
+- **Preserved.** Hidden-tab stop, pair cooldown (20–60s) **plus** a new per-resident cooldown so every circle member rests a beat before re-gathering, visitor-chat freeze, LOW_END locomotion, greeting/idle-emote warmth, and the AI env-gating / daily budget caps are all intact.
+- **Debug.** `?dbg` adds `window.__gather([ids])` (force a named/nearest group to gather and talk) and `window.__conv()` (inspect the live circle — members, speaker, phase, centre, turn/max); `window.__npcState()` now reports `maxGroup` / `groupR` / `groupSize`.
+
 ## [1.55.0] — 2026-07-06
 
 ### 👋 Residents notice you now — a wave, a hello, and quiet little moods

--- a/index.html
+++ b/index.html
@@ -4334,11 +4334,11 @@ const NPC_CFG={ modeEnabled:true, visualEnabled:true,
   scriptedAmbient:true, scriptedPlayerChat:true,                        // the free fallback — always available, no cost
   minTurns:4, maxTurns:6, hardMaxTurns:10, degradeMaxTurns:4,
   gapMin:5, gapMax:10, pairCooldownMin:20, pairCooldownMax:60, guestCooldownSec:8,
-  activeMin:3, activeMax:10, maxConcurrent:1, motionEnabled:true, worker:null };
-if(IS_MOBILE) NPC_CFG.maxTurns=5;
+  activeMin:3, activeMax:10, maxConcurrent:1, maxGroup:4, motionEnabled:true, worker:null };
+if(IS_MOBILE){ NPC_CFG.maxTurns=5; NPC_CFG.maxGroup=3; }                 // a smaller circle keeps the phones readable
 if(LOW_END){                                                            // low-end: keep the town ALIVE — movement stays on (slowed), chatter just gets rarer + shorter
   NPC_CFG.minTurns=3; NPC_CFG.maxTurns=4; NPC_CFG.degradeMaxTurns=3;    // shorter conversations
-  NPC_CFG.gapMin=8; NPC_CFG.gapMax=14; NPC_CFG.maxConcurrent=1;         // slower turn cadence, still one conversation at a time
+  NPC_CFG.gapMin=8; NPC_CFG.gapMax=14; NPC_CFG.maxConcurrent=1; NPC_CFG.maxGroup=3;   // slower turn cadence, one gathering at a time, smaller circle
 }                                                                       // NOTE: scriptedAmbient stays TRUE and motionEnabled stays TRUE — residents must still wander
 const RESIDENTS=[
   { id:'sol', zone:'ai', color:0x9ab8ff, accent:0xbcd0ff, tone:'curious·cost-aware',
@@ -4453,7 +4453,7 @@ const RES_REACH=3.4; const RESIDENTS_LIVE=[]; let nearResident=null;
 const RES_MOVE={ wanderSpd:(LOW_END?0.9:(IS_MOBILE?0.95:1.05)), meetSpd:(LOW_END?1.4:(IS_MOBILE?1.7:2.4)),
   roamR:6.5, pauseMin:2.5, pauseMax:7.0,
   restChance:(LOW_END?0.28:0.4), restMin:8, restMax:16, seatSeek:15,   // townsfolk occasionally stroll to a free bench and sit a while before wandering on
-  talkDist:4.2, meetMax:(LOW_END?48:58), approachMax:(LOW_END?20:16), arrive:0.5, gait:2.2 };
+  talkDist:4.2, meetMax:(LOW_END?48:58), approachMax:(LOW_END?20:16), arrive:0.5, gait:2.2, groupR:(LOW_END?15:20) };
 // ---- resident warmth: notice the visitor (a wave + short hello) and show the occasional solo life-emote ----
 // pure-visual · zero-cost · zero-network: greetings/emotes are client-side bubbles, edge-triggered + cooldown-gated so they never spam.
 // LOW_END keeps the full warmth but spaces the solo emotes out further — the cost/perf saving stays on the AI-conversation side, never on this.
@@ -4498,8 +4498,8 @@ function _budgetLow(){ const B=_npcBudget; if(B.blocked) return true; if(B.daily
 function _budgetExhausted(){ const B=_npcBudget; if(B.blocked) return true; if(B.dailyTurnMax>0 && B.turnsToday>=B.dailyTurnMax) return true; if(B.dayCapUsd>0 && B.remainingUsd<=0) return true; return false; }
 function _emitMetric(name,meta){ try{ if(typeof track==='function') track(name, meta||{}); }catch(e){} }
 
-// ---- turn-by-turn ambient engine (1 conversation max; scripted default; hidden-tab + budget aware) ----
-let _ambConv=null, _ambNextAt=9, _guestCdUntil=0; const _pairCd=new Map(); const _npcTranscript=[];
+// ---- turn-by-turn ambient engine (1 gathering max; a nearby cluster forms a CIRCLE and everyone takes turns; scripted default; hidden-tab + budget aware) ----
+let _ambConv=null, _ambNextAt=9, _guestCdUntil=0; const _pairCd=new Map(), _resCd=new Map(); const _npcTranscript=[];
 function _resChatActive(){ try{ return !!(activeNpc&&activeNpc.resident&&chatEl&&!chatEl.classList.contains('hidden')); }catch(e){ return false; } }
 function _pairKey(a,b){ return [a.res.id,b.res.id].sort().join('|'); }
 function _cap180(s){ return String(s||'').replace(/\s+/g,' ').trim().slice(0,180); }
@@ -4512,29 +4512,41 @@ function _capBub(s){ s=String(s||'').replace(/\s+/g,' ').trim(); const MAX=80;  
 function _pushTranscript(t){ _npcTranscript.push(t); if(_npcTranscript.length>60) _npcTranscript.shift(); }
 function _scriptLine(L){ const bank=(L.res.amb&&(L.res.amb[LANG]||L.res.amb.ko))||['\u2026']; let i=(Math.random()*bank.length)|0; if(bank.length>1 && i===L.lastLine) i=(i+1)%bank.length; L.lastLine=i; return bank[i]; }
 function _ambientAllowed(){ return NPC_CFG.modeEnabled && !document.hidden && !_resChatActive() && RESIDENTS_LIVE.length>=NPC_CFG.activeMin && (NPC_CFG.scriptedAmbient || (NPC_CFG.aiEnabled&&NPC_CFG.ambientAiEnabled)); }
-function _endAmb(reason){ const C=_ambConv; _ambConv=null; if(C){ _pairCd.set(_pairKey(C.a,C.b), clock.elapsedTime + NPC_CFG.pairCooldownMin + Math.random()*(NPC_CFG.pairCooldownMax-NPC_CFG.pairCooldownMin));
-    _emitMetric('npc_ambient_finished',{a:C.a.res.id,b:C.b.res.id,turns:C.turns.length,reason}); } _ambNextAt=clock.elapsedTime + 10 + Math.random()*16; }
-function _startAmb(a,b){ const now=clock.elapsedTime;
-  if(!a){ let best=null,bd=Infinity; const P=RESIDENTS_LIVE;
-    for(let i=0;i<P.length;i++) for(let j=i+1;j<P.length;j++){ const A=P[i],B=P[j]; if((_pairCd.get(_pairKey(A,B))||0)>now) continue; const dist=A.group.position.distanceTo(B.group.position); if(dist>RES_MOVE.meetMax) continue; const dd=dist+Math.random()*22; if(dd<bd){ bd=dd; best=[A,B]; } }
-    if(!best) return false; a=best[0]; b=best[1]; }
-  const degrade=_budgetLow(); const max=Math.max(2, Math.min(NPC_CFG.hardMaxTurns, degrade?NPC_CFG.degradeMaxTurns:(NPC_CFG.minTurns+((Math.random()*(NPC_CFG.maxTurns-NPC_CFG.minTurns+1))|0))));
-  const near=a.group.position.distanceTo(b.group.position)<=RES_MOVE.talkDist+0.6;
-  _ambConv={ a,b, who:a, other:b, i:0, max, topic:(a.res.topics&&a.res.topics[0])||a.res.zone, phase:near?'talk':'approach', approachUntil:now+RES_MOVE.approachMax, nextAt:near?now+0.6:Infinity, turns:[], pending:false };
-  _emitMetric('npc_ambient_started',{a:a.res.id,b:b.res.id,max}); return true; }
-function _advanceAmb(){ const C=_ambConv; if(!C||C.pending) return; const now=clock.elapsedTime; const speaker=C.who, listener=C.other;
+function _endAmb(reason){ const C=_ambConv; _ambConv=null; if(C){ const until=clock.elapsedTime + NPC_CFG.pairCooldownMin + Math.random()*(NPC_CFG.pairCooldownMax-NPC_CFG.pairCooldownMin);
+    _pairCd.set(_pairKey(C.a,C.b), until); for(const m of C.members) _resCd.set(m.res.id, until);   // every circle member rests a beat before joining another gathering (not just the seed pair)
+    _emitMetric('npc_ambient_finished',{a:C.a.res.id,b:C.b.res.id,size:C.members.length,turns:C.turns.length,reason}); } _ambNextAt=clock.elapsedTime + 10 + Math.random()*16; }
+function _startAmb(a,b){ const now=clock.elapsedTime; let members;
+  if(Array.isArray(a)) members=a.slice(); else if(a&&b) members=[a,b];
+  else { let best=null,bd=Infinity; const P=RESIDENTS_LIVE;   // 1) closest eligible seed pair (unchanged), 2) grow it into a circle with nearby cooldown-free neighbours so a gathering becomes a group chat, not just 1:1
+    for(let i=0;i<P.length;i++) for(let j=i+1;j<P.length;j++){ const A=P[i],B=P[j];
+      if((_pairCd.get(_pairKey(A,B))||0)>now || (_resCd.get(A.res.id)||0)>now || (_resCd.get(B.res.id)||0)>now) continue;
+      const dist=A.group.position.distanceTo(B.group.position); if(dist>RES_MOVE.meetMax) continue; const dd=dist+Math.random()*22; if(dd<bd){ bd=dd; best=[A,B]; } }
+    if(!best) return false; members=best;
+    const cap=Math.max(2, Math.min(NPC_CFG.maxGroup, P.length));
+    if(members.length<cap){ const mx=(members[0].group.position.x+members[1].group.position.x)/2, mz=(members[0].group.position.z+members[1].group.position.z)/2;
+      const extra=P.filter(L=>members.indexOf(L)<0 && (_resCd.get(L.res.id)||0)<=now && Math.hypot(L.group.position.x-mx,L.group.position.z-mz)<=RES_MOVE.groupR)
+        .sort((p,q)=>Math.hypot(p.group.position.x-mx,p.group.position.z-mz)-Math.hypot(q.group.position.x-mx,q.group.position.z-mz));
+      for(const L of extra){ if(members.length>=cap) break; members.push(L); } } }
+  if(members.length<2) return false;
+  const cx=members.reduce((s,m)=>s+m.group.position.x,0)/members.length, cz=members.reduce((s,m)=>s+m.group.position.z,0)/members.length;
+  const near=members.every(m=>Math.hypot(m.group.position.x-cx,m.group.position.z-cz)<=RES_MOVE.talkDist+0.6);
+  const degrade=_budgetLow(); const base=degrade?NPC_CFG.degradeMaxTurns:(NPC_CFG.minTurns+((Math.random()*(NPC_CFG.maxTurns-NPC_CFG.minTurns+1))|0));
+  const max=Math.max(2, Math.min(NPC_CFG.hardMaxTurns, base+(members.length-2)));   // a bigger circle earns a few more turns so everyone gets to speak — still hard-capped at 10
+  _ambConv={ members, a:members[0], b:members[1], center:{x:cx,z:cz}, si:0, prevWho:null, i:0, max, topic:(members[0].res.topics&&members[0].res.topics[0])||members[0].res.zone, phase:near?'talk':'approach', approachUntil:now+RES_MOVE.approachMax, nextAt:near?now+0.6:Infinity, turns:[], pending:false };
+  _emitMetric('npc_ambient_started',{a:members[0].res.id,b:members[1].res.id,size:members.length,members:members.map(m=>m.res.id),max}); return true; }
+function _advanceAmb(){ const C=_ambConv; if(!C||C.pending) return; const now=clock.elapsedTime; const speaker=C.members[C.si], listener=C.prevWho||C.members[(C.si+1)%C.members.length];
   const useAI = NPC_CFG.aiEnabled && NPC_CFG.ambientAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
   function done(line,ai,fb){ line=_capBub(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
     const turn={ t:Math.round(clock.elapsedTime), a:C.a.res.id, b:C.b.res.id, who:speaker.res.id, text:line, ai:!!ai, fb:!!fb };
     C.turns.push(turn); _pushTranscript(turn); if(fb) _npcBudget.fallbackTurns++; if(ai) _npcBudget.aiTurns++;
     _emitMetric('npc_ambient_turn',{who:speaker.res.id,ai:!!ai,fb:!!fb,len:line.length});
-    C.i++; C.who=listener; C.other=speaker; C.nextAt=now + NPC_CFG.gapMin + Math.random()*(NPC_CFG.gapMax-NPC_CFG.gapMin); if(C.i>=C.max) _endAmb('done'); }
+    C.i++; C.prevWho=speaker; C.si=(C.si+1)%C.members.length; C.nextAt=now + NPC_CFG.gapMin + Math.random()*(NPC_CFG.gapMax-NPC_CFG.gapMin); if(C.i>=C.max) _endAmb('done'); }   // the speaking turn round-robins through every circle member so all of them talk, not just two
   if(useAI){ C.pending=true; C.nextAt=now+9.5; _aiAmbientTurn(C,speaker,listener).then(line=>{ C.pending=false; if(line) done(line,true,false); else done(_scriptLine(speaker),false,true); }).catch(()=>{ C.pending=false; done(_scriptLine(speaker),false,true); }); }
   else done(_scriptLine(speaker),false,false); }
 function _ambientTick(){ const now=clock.elapsedTime;
   if(document.hidden){ if(_ambConv) _endAmb('hidden'); return; }
   if(_ambConv){ const C=_ambConv;
-    if(C.phase==='approach'){ if(C.a.group.position.distanceTo(C.b.group.position)<=RES_MOVE.talkDist+0.4 || now>=C.approachUntil){ C.phase='talk'; C.nextAt=now+0.5; } return; }
+    if(C.phase==='approach'){ if(C.members.every(m=>Math.hypot(m.group.position.x-C.center.x,m.group.position.z-C.center.z)<=RES_MOVE.talkDist+0.4) || now>=C.approachUntil){ C.phase='talk'; C.nextAt=now+0.5; } return; }
     if(now>=C.nextAt) _advanceAmb(); return; }
   if(!_ambientAllowed() || now<_guestCdUntil) return;
   if(now>=_ambNextAt) _startAmb(); }
@@ -4566,7 +4578,7 @@ function _resStand(L){ const g=L.group; g.position.y=0; if(g._legL){ g._legL.rot
 function _seatRelease(L){ if(L._rest&&L._rest.seat) L._rest.seat._occ=null; L._rest=null; }
 function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.elapsedTime; const C=_ambConv, hidden=document.hidden;
   for(const L of RESIDENTS_LIVE){ const g=L.group;
-    const inConv=C&&(C.a===L||C.b===L), partner=inConv?(C.a===L?C.b:C.a):null;
+    const inConv=C&&C.members.indexOf(L)>=0, speaker=C?C.members[C.si]:null;
     const chatBound=_resChatActive()&&activeNpc&&activeNpc.res===L.res; let moving=false;
     // warm welcome: the moment the visitor steps up, the resident notices — a wave + a short hello (edge-triggered + cooldown, so it never spams)
     if(!inConv && !chatBound && !hidden){
@@ -4584,7 +4596,7 @@ function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.
           if(g._armL){ g._armL.rotation.z+=(0.12-g._armL.rotation.z)*0.1; g._armR.rotation.z+=(0.12-g._armR.rotation.z)*0.1; } L.bub.update(dt); continue; } }   // stay seated
     }
     if(inConv && C.phase==='approach' && !hidden && NPC_CFG.motionEnabled){
-      if(g.position.distanceTo(partner.group.position)>RES_MOVE.talkDist){ _resWalk(L,partner.group.position.x,partner.group.position.z,RES_MOVE.meetSpd,dt); moving=true; }
+      if(Math.hypot(g.position.x-C.center.x,g.position.z-C.center.z)>RES_MOVE.talkDist){ _resWalk(L,C.center.x,C.center.z,RES_MOVE.meetSpd,dt); moving=true; }   // everyone converges on the shared circle centre, forming a ring (never piles onto one partner)
     } else if(!inConv && !chatBound && !hidden && NPC_CFG.motionEnabled){   // wander is NOT gated on LOW_END — low-end just moves slower (RES_MOVE.wanderSpd); only a hidden tab / chat / conversation stops it
       if(L._rest && L._rest.phase==='goto'){   // strolling over to the chosen bench, then sit
         if(_resWalk(L,L._rest.seat.x,L._rest.seat.z,L._wspd,dt)){ L._rest.phase='sit'; L._rest.until=tt+RES_MOVE.restMin+Math.random()*(RES_MOVE.restMax-RES_MOVE.restMin); _resSit(L,L._rest.seat); L.bub.update(dt); continue; } else moving=true;
@@ -4598,7 +4610,7 @@ function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.
       L._emoteCd=tt+RES_EMOTE_CD_MIN+Math.random()*(RES_EMOTE_CD_MAX-RES_EMOTE_CD_MIN);
       if(Math.random()<0.7){ L.bub.say(_resIdleEmote(), _hex(L.res.color)); L._gt=1.6; } }
     let tgt;
-    if(inConv && C.phase==='talk'){ tgt=Math.atan2(partner.group.position.x-g.position.x, partner.group.position.z-g.position.z); }
+    if(inConv && C.phase==='talk'){ const f=(L===speaker)?C.center:speaker.group.position; tgt=Math.atan2(f.x-g.position.x, f.z-g.position.z); }   // listeners turn to whoever's speaking; the speaker addresses the circle
     else { const dx=player.position.x-g.position.x, dz=player.position.z-g.position.z, d=Math.hypot(dx,dz); tgt=d<14?Math.atan2(dx,dz):L._baseRot+Math.sin(tt*0.4+L._ph)*0.2; }
     g.rotation.y=lerpA(g.rotation.y,tgt,0.06);
     if(g._legL){ g._legL.rotation.x*=0.8; g._legR.rotation.x*=0.8; }
@@ -6608,19 +6620,26 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     x:+L.group.position.x.toFixed(1), z:+L.group.position.z.toFixed(1), near:+player.position.distanceTo(L.group.position).toFixed(2)<=RES_REACH,
     pNear:!!L._pNear, greetIn:Math.max(0,+(L._greetCd-clock.elapsedTime).toFixed(1)) }));
   window.__npcRoutes=()=>RESIDENTS_LIVE.map(L=>({ id:L.res.id, zone:L.res.zone, pos:[+L.group.position.x.toFixed(1),+L.group.position.z.toFixed(1)], anchor:[+L.home.x.toFixed(1),+L.home.z.toFixed(1)], target:L._rt?[+L._rt.x.toFixed(1),+L._rt.z.toFixed(1)]:null, rest:L._rest?L._rest.phase:null, facing:+L._baseRot.toFixed(2) }));
-  window.__npcMoved=()=>RESIDENTS_LIVE.map(L=>({ id:L.res.id, dist:+(L._dist||0).toFixed(2), walking:!!L._rt||!!(_ambConv&&(_ambConv.a===L||_ambConv.b===L)&&_ambConv.phase==='approach') }));
+  window.__npcMoved=()=>RESIDENTS_LIVE.map(L=>({ id:L.res.id, dist:+(L._dist||0).toFixed(2), walking:!!L._rt||!!(_ambConv&&_ambConv.members.indexOf(L)>=0&&_ambConv.phase==='approach') }));
   window.__npcState=()=>({ mode:NPC_CFG.modeEnabled, visual:NPC_CFG.visualEnabled, ai:NPC_CFG.aiEnabled, ambientAi:NPC_CFG.ambientAiEnabled, playerAi:NPC_CFG.playerChatAiEnabled,
     scriptedAmbient:NPC_CFG.scriptedAmbient, lowEnd:LOW_END, mobile:IS_MOBILE, motionEnabled:NPC_CFG.motionEnabled, wanderSpd:+RES_MOVE.wanderSpd.toFixed(2), meetSpd:+RES_MOVE.meetSpd.toFixed(2), gapMin:NPC_CFG.gapMin, gapMax:NPC_CFG.gapMax, maxTurns:NPC_CFG.maxTurns,
     greetDist:RES_GREET_DIST, greetCd:[RES_GREET_CD_MIN,RES_GREET_CD_MAX], emoteCd:[RES_EMOTE_CD_MIN,RES_EMOTE_CD_MAX],
-    live:RESIDENTS_LIVE.length, max:MAX_RESIDENTS, moved:+RESIDENTS_LIVE.reduce((s,L)=>s+(L._dist||0),0).toFixed(1), resting:RESIDENTS_LIVE.filter(L=>L._rest).length, seats:SEATS.length, flora:GLOW_FLORA.length, active:!!_ambConv, hidden:document.hidden, worker:!!NPC_CFG.worker });
+    live:RESIDENTS_LIVE.length, max:MAX_RESIDENTS, maxGroup:NPC_CFG.maxGroup, groupR:RES_MOVE.groupR, groupSize:(_ambConv?_ambConv.members.length:0), moved:+RESIDENTS_LIVE.reduce((s,L)=>s+(L._dist||0),0).toFixed(1), resting:RESIDENTS_LIVE.filter(L=>L._rest).length, seats:SEATS.length, flora:GLOW_FLORA.length, active:!!_ambConv, hidden:document.hidden, worker:!!NPC_CFG.worker });
   window.__seats=()=>SEATS.map((s,i)=>({ i, pos:[+s.x.toFixed(1),+s.z.toFixed(1)], occupied:s._occ?s._occ.res.id:null }));
   window.__greet=(id)=>{ const L=id?RESIDENTS_LIVE.find(x=>x.res.id===id):RESIDENTS_LIVE.slice().sort((a,b)=>player.position.distanceTo(a.group.position)-player.position.distanceTo(b.group.position))[0];
     if(!L) return null; if(_resChatActive()&&activeNpc&&activeNpc.res===L.res) return { who:L.res.id, skipped:'chatBound' };   // never paint a greeting over a resident the visitor is mid-chat with
     L.bub.say(_resGreetLine(L.res), _hex(L.res.color)); L._gt=2.6; L._greetCd=clock.elapsedTime+RES_GREET_CD_MIN+Math.random()*(RES_GREET_CD_MAX-RES_GREET_CD_MIN);
     return { who:L.res.id, dist:+player.position.distanceTo(L.group.position).toFixed(2), greetDist:RES_GREET_DIST }; };
   window.__npcEncounter=(a,b)=>{ const A=RESIDENTS_LIVE.find(L=>L.res.id===a)||RESIDENTS_LIVE[0], B=RESIDENTS_LIVE.find(L=>L.res.id===b)||RESIDENTS_LIVE[1];
-    if(!A||!B||A===B) return {ok:false}; _pairCd.delete(_pairKey(A,B)); if(_ambConv) _endAmb('debug'); _startAmb(A,B); if(_ambConv){ _ambConv.phase='talk'; _ambConv.nextAt=0; _advanceAmb(); }
-    return { ok:true, a:A.res.id, b:B.res.id, max:_ambConv?_ambConv.max:0, i:_ambConv?_ambConv.i:1, last:_npcTranscript.slice(-1)[0]||null }; };
+    if(!A||!B||A===B) return {ok:false}; _pairCd.delete(_pairKey(A,B)); _resCd.delete(A.res.id); _resCd.delete(B.res.id); if(_ambConv) _endAmb('debug'); _startAmb(A,B); if(_ambConv){ _ambConv.phase='talk'; _ambConv.nextAt=0; _advanceAmb(); }
+    return { ok:true, a:A.res.id, b:B.res.id, size:_ambConv?_ambConv.members.length:0, max:_ambConv?_ambConv.max:0, i:_ambConv?_ambConv.i:1, last:_npcTranscript.slice(-1)[0]||null }; };
+  window.__conv=()=>_ambConv?{ members:_ambConv.members.map(m=>m.res.id), size:_ambConv.members.length, speaker:_ambConv.members[_ambConv.si].res.id, phase:_ambConv.phase, turn:_ambConv.i, max:_ambConv.max, center:[+_ambConv.center.x.toFixed(1),+_ambConv.center.z.toFixed(1)] }:null;
+  window.__gather=(ids)=>{ if(_ambConv) _endAmb('debug'); let mem;   // force a group gathering: pass explicit ids, or omit for the maxGroup residents nearest the first one
+    if(Array.isArray(ids)&&ids.length>=2) mem=ids.map(id=>RESIDENTS_LIVE.find(L=>L.res.id===id)).filter(Boolean);
+    else { const seed=RESIDENTS_LIVE[0]; mem=RESIDENTS_LIVE.slice().sort((p,q)=>seed.group.position.distanceTo(p.group.position)-seed.group.position.distanceTo(q.group.position)).slice(0,NPC_CFG.maxGroup); }
+    if(!mem||mem.length<2) return {ok:false}; for(const m of mem) _resCd.delete(m.res.id);
+    _startAmb(mem); if(_ambConv){ _ambConv.phase='talk'; _ambConv.nextAt=0; _advanceAmb(); }
+    return { ok:!!_ambConv, members:_ambConv?_ambConv.members.map(m=>m.res.id):[], size:_ambConv?_ambConv.members.length:0 }; };
   window.__npcBudget=()=>({ ...JSON.parse(JSON.stringify(_npcBudget)), low:_budgetLow(), exhausted:_budgetExhausted() });
   window.__npcTranscript=()=>_npcTranscript.slice(-20);
   window.__npcSim=(o)=>{ o=o||{}; ['remainingUsd','spentUsd','turnsToday','dailyTurnMax','dayCapUsd'].forEach(k=>{ if(typeof o[k]==='number') _npcBudget[k]=o[k]; });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -425,6 +425,20 @@ ok(/if\(!inConv && !chatBound && !L\._pNear && L\._gt<=0 && tt>=L\._emoteCd\)\{/
 ok(/const RES_EMOTE_CD_MIN=\(LOW_END\?46:30\), RES_EMOTE_CD_MAX=\(LOW_END\?90:64\);/.test(HTML), 'LOW_END keeps the greeting warmth but spaces solo emotes further (saving stays on the AI side)');
 ok(/window\.__greet=\(id\)=>/.test(HTML) && /greetDist:RES_GREET_DIST, greetCd:\[RES_GREET_CD_MIN,RES_GREET_CD_MAX\]/.test(HTML), '?dbg __greet hook + __npcState greet/emote config present');
 
+// 17 — resident group conversations: a nearby cluster forms a CIRCLE and everyone takes turns (not just 1:1)
+group('resident group conversations (gather → everyone talks)');
+ok(/maxGroup:4/.test(npcBlock), 'NPC_CFG carries a maxGroup so a gathering becomes a circle, not just a pair');
+ok(/if\(LOW_END\)\{[\s\S]*?NPC_CFG\.maxGroup=3;/.test(npcBlock), 'LOW_END + mobile cap the circle smaller (maxGroup 3) to stay light/readable');
+ok(/const groupR=|groupR:\(LOW_END\?15:20\)/.test(npcBlock), 'RES_MOVE carries a groupR gather radius so only genuinely-nearby folk join the circle');
+ok(/_ambConv=\{ members,/.test(npcBlock), 'ambient conversation holds a members[] array (N residents), not a fixed a/b pair');
+ok(/C\.si=\(C\.si\+1\)%C\.members\.length/.test(npcBlock), 'the speaking turn round-robins through every circle member so all of them talk');
+ok(/const cap=Math\.max\(2, Math\.min\(NPC_CFG\.maxGroup/.test(npcBlock), 'group size is clamped to maxGroup (nearby cooldown-free folk join, capped)');
+ok(/Math\.hypot\(g\.position\.x-C\.center\.x,g\.position\.z-C\.center\.z\)>RES_MOVE\.talkDist/.test(npcBlock), 'members converge on the shared circle centre during the approach phase (a ring, never a pile-up)');
+ok(/Math\.min\(NPC_CFG\.hardMaxTurns, base\+\(members\.length-2\)\)/.test(npcBlock), 'a bigger circle earns a few more turns but stays hard-capped at 10');
+ok(/for\(const m of C\.members\) _resCd\.set/.test(npcBlock), 'every member gets a cooldown when the gathering ends (whole circle rests, not just the seed pair)');
+ok(/window\.__conv=\(\)=>/.test(HTML) && /window\.__gather=/.test(HTML), '?dbg __conv/__gather hooks expose + force group conversations');
+ok(/if\(document\.hidden\)\{ if\(_ambConv\) _endAmb\('hidden'\); return; \}/.test(npcBlock) && /maxConcurrent:1/.test(npcBlock), 'group conversations preserve the hidden-tab stop and the one-gathering-at-a-time cap');
+
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');
 if (fail) { console.log('\nFailures:'); fails.forEach(f => console.log('  - ' + f)); }


### PR DESCRIPTION
## What & why

Residents used to talk strictly **1:1** — when three or four townspeople clustered, only two would exchange lines while the rest stood mute. This generalizes the ambient conversation engine so a gathering grows into a small **group circle** and the speaking turn **round-robins through every member**, so the whole group genuinely converses.

Addresses the request: *"모이면 서로 1:1 말고 다들 같이 대화할 수 있도록"* (when they gather, let everyone talk together, not just 1:1).

## How it works

- **Formation.** The engine still picks the closest eligible **seed pair**, then grows the circle with cooldown-free residents within a gather radius (`groupR` — 20u desktop / 15u LOW_END) of the pair midpoint, capped at **`maxGroup`** (4 desktop / 3 mobile & LOW_END). Emergent: usually 2 talk, but 3-4 join when the town clusters (plaza, benches).
- **Convergence.** Members walk to the shared **circle centre** (centroid) during the approach phase and settle into a ring at talk distance — they never pile onto one partner. Listeners face the current speaker; the speaker addresses the circle.
- **Fair turns, still capped.** Turn budget scales gently with size (`base + (members - 2)`), but the **hard cap of 10 turns** is untouched, as are `maxConcurrent: 1`, the 5-10s gap, and the AI/scripted split.

## Preserved
Hidden-tab stop, pair cooldown (20-60s) **plus** a new per-resident cooldown, visitor-chat freeze, LOW_END locomotion, greeting/idle-emote warmth, AI env-gating and daily budget caps. **Zero added network cost** — reuses the scripted bank and the existing one-speaker/one-listener AI path, so no worker change.

## Debug
- `window.__gather([ids])` — force a named/nearest group to gather and talk
- `window.__conv()` — inspect the live circle (members, speaker, phase, centre, turn/max)
- `window.__npcState()` now reports `maxGroup` / `groupR` / `groupSize`

## Verification
- `node scripts/smoke.mjs` -> **221** (+11 group-conversation guards)
- `node council/test.mjs` -> 130 · `node council/test-live.mjs` -> 56 · `node --check scholars.js` / `grounded.js` OK
- Browser (`?dbg=1`): 4-member circle forms; round-robin confirmed **sol->jun->nari->tae->sol**; each speaker's bubble displays (opacity -> 0.99); centre = centroid. Desktop + mobile 390x844, **0 console errors**; residents wander (5 moved >0.2 over 6s).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
