### PR TITLE
feat: the visitor can join a resident gathering and chat with the whole circle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.57.0] — 2026-07-07
+
+### 🙋 Step into the circle — the visitor can join a gathering and the whole group talks back
+- **What's new.** Walk up to a cluster of residents (or right into an active **circle**) and you can now **join the conversation**. The walk-up prompt reads **"대화에 끼기 / join in"** instead of a 1:1 "talk", and opening it binds the chat panel to the **whole group**: the header shows every member's name (**"솔 · 준 · 나리 · 모임"**), and when you say something the group answers together — a **primary responder** plus a second resident who **chimes in** with a short in-voice aside. It reads like stepping into a real huddle, not a private DM.
+- **Everyone answers you over time.** The addressed speaker **round-robins** across the circle (sol → jun → nari → …), so if you keep chatting, every member takes a turn replying to you — each line prefixed with a **colored name chip** so you always know who's talking. The primary gives the grounded, in-persona answer (meta-aware — they know they're an AI resident of this repo-city); the chime-in is a light scripted aside from the ambient bank.
+- **The circle turns to you.** The moment you join, the members' auto-conversation ends, they **freeze in place and face the visitor** (anyone within ~6.5u pivots straight to you), and their floating world-bubbles clear — the dialogue lives in the chat panel. Close the chat and the circle is **released**: each member rests a short beat, then town life resumes.
+- **How a group forms.** Pressing Enter/💬 by a resident gathers the neighbours genuinely clustered around them within a **joinR** walk-up radius (9u desktop / 7u LOW_END — deliberately tighter than the ambient `groupR`), capped at **maxGroup** (4 desktop / 3 mobile & LOW_END). Fewer than two nearby → it cleanly falls back to the existing **1:1 resident chat**. If you step into a circle that's already mid-conversation, you join **exactly that circle**.
+- **Cheap by design.** Joining adds **zero extra network cost**: it reuses the existing scripted persona replies and the same single AI player-chat path (bounded to **one AI call per message**, exactly like 1:1), so no worker change and no new spend. Budget-low / env-off still degrades to fully scripted answers.
+- **Preserved.** Hidden-tab stop, per-resident & pair cooldowns, LOW_END locomotion, greeting/idle-emote warmth, the ambient group-conversation engine, scholar/taxi chat, and the AI env-gating / daily budget caps are all intact. A stale in-flight ambient turn can no longer paint a bubble after you join (guarded in `done()`).
+- **Debug.** `?dbg` adds `window.__joinGroup([ids])` (force-join a named cluster / the nearest one) and `window.__groupChat()` (inspect the live player circle — active, members, primary, round-robin index); `window.__npcState()` now reports `joinR` and the active `groupChat` roster.
+
 ## [1.56.0] — 2026-07-07
 
 ### 🗣️ Residents gather into a circle — everyone takes a turn, not just two

--- a/index.html
+++ b/index.html
@@ -4453,7 +4453,7 @@ const RES_REACH=3.4; const RESIDENTS_LIVE=[]; let nearResident=null;
 const RES_MOVE={ wanderSpd:(LOW_END?0.9:(IS_MOBILE?0.95:1.05)), meetSpd:(LOW_END?1.4:(IS_MOBILE?1.7:2.4)),
   roamR:6.5, pauseMin:2.5, pauseMax:7.0,
   restChance:(LOW_END?0.28:0.4), restMin:8, restMax:16, seatSeek:15,   // townsfolk occasionally stroll to a free bench and sit a while before wandering on
-  talkDist:4.2, meetMax:(LOW_END?48:58), approachMax:(LOW_END?20:16), arrive:0.5, gait:2.2, groupR:(LOW_END?15:20) };
+  talkDist:4.2, meetMax:(LOW_END?48:58), approachMax:(LOW_END?20:16), arrive:0.5, gait:2.2, groupR:(LOW_END?15:20), joinR:(LOW_END?7:9) };
 // ---- resident warmth: notice the visitor (a wave + short hello) and show the occasional solo life-emote ----
 // pure-visual · zero-cost · zero-network: greetings/emotes are client-side bubbles, edge-triggered + cooldown-gated so they never spam.
 // LOW_END keeps the full warmth but spaces the solo emotes out further — the cost/perf saving stays on the AI-conversation side, never on this.
@@ -4536,7 +4536,7 @@ function _startAmb(a,b){ const now=clock.elapsedTime; let members;
   _emitMetric('npc_ambient_started',{a:members[0].res.id,b:members[1].res.id,size:members.length,members:members.map(m=>m.res.id),max}); return true; }
 function _advanceAmb(){ const C=_ambConv; if(!C||C.pending) return; const now=clock.elapsedTime; const speaker=C.members[C.si], listener=C.prevWho||C.members[(C.si+1)%C.members.length];
   const useAI = NPC_CFG.aiEnabled && NPC_CFG.ambientAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
-  function done(line,ai,fb){ line=_capBub(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
+  function done(line,ai,fb){ if(_ambConv!==C){ C.pending=false; return; } line=_capBub(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
     const turn={ t:Math.round(clock.elapsedTime), a:C.a.res.id, b:C.b.res.id, who:speaker.res.id, text:line, ai:!!ai, fb:!!fb };
     C.turns.push(turn); _pushTranscript(turn); if(fb) _npcBudget.fallbackTurns++; if(ai) _npcBudget.aiTurns++;
     _emitMetric('npc_ambient_turn',{who:speaker.res.id,ai:!!ai,fb:!!fb,len:line.length});
@@ -4579,7 +4579,7 @@ function _seatRelease(L){ if(L._rest&&L._rest.seat) L._rest.seat._occ=null; L._r
 function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.elapsedTime; const C=_ambConv, hidden=document.hidden;
   for(const L of RESIDENTS_LIVE){ const g=L.group;
     const inConv=C&&C.members.indexOf(L)>=0, speaker=C?C.members[C.si]:null;
-    const chatBound=_resChatActive()&&activeNpc&&activeNpc.res===L.res; let moving=false;
+    const chatBound=_resChatActive()&&activeNpc&&(activeNpc.res===L.res || (activeGroupMembers&&activeGroupMembers.indexOf(L)>=0)); let moving=false;
     // warm welcome: the moment the visitor steps up, the resident notices — a wave + a short hello (edge-triggered + cooldown, so it never spams)
     if(!inConv && !chatBound && !hidden){
       const pnear=Math.hypot(player.position.x-g.position.x, player.position.z-g.position.z)<RES_GREET_DIST;
@@ -4610,7 +4610,7 @@ function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.
       L._emoteCd=tt+RES_EMOTE_CD_MIN+Math.random()*(RES_EMOTE_CD_MAX-RES_EMOTE_CD_MIN);
       if(Math.random()<0.7){ L.bub.say(_resIdleEmote(), _hex(L.res.color)); L._gt=1.6; } }
     let tgt;
-    if(inConv && C.phase==='talk'){ const f=(L===speaker)?C.center:speaker.group.position; tgt=Math.atan2(f.x-g.position.x, f.z-g.position.z); }   // listeners turn to whoever's speaking; the speaker addresses the circle
+    if(inConv && C.phase==='talk'){ const pd=Math.hypot(player.position.x-g.position.x, player.position.z-g.position.z); const f=(pd<6.5)?player.position:((L===speaker)?C.center:speaker.group.position); tgt=Math.atan2(f.x-g.position.x, f.z-g.position.z); }   // listeners turn to whoever's speaking; the whole circle turns to the visitor who steps right up
     else { const dx=player.position.x-g.position.x, dz=player.position.z-g.position.z, d=Math.hypot(dx,dz); tgt=d<14?Math.atan2(dx,dz):L._baseRot+Math.sin(tt*0.4+L._ph)*0.2; }
     g.rotation.y=lerpA(g.rotation.y,tgt,0.06);
     if(g._legL){ g._legL.rotation.x*=0.8; g._legR.rotation.x*=0.8; }
@@ -4665,6 +4665,38 @@ async function residentSay(q){ const res=activeNpc&&activeNpc.res; if(!res) retu
     try{ const line=await _aiPlayerChat(res,q); if(line){ sb.remove(); addMsg('bot', esc(_cap180(line))); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:true}); return; } }catch(e){}
     sb.remove(); }
   const r=residentReply(res,q); addMsg('bot', r.html, r.repo?{repo:r.repo}:undefined); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:false}); }
+
+// ---- player joins a gathering: walk up to a cluster (or step into an active circle) and the whole group talks with you ----
+let activeGroupMembers=null;                                   // live residents in a player-facing group chat (frozen + turned to you)
+function _liveOf(npc){ return (npc&&npc.res&&npc.res._live)||null; }
+function _groupNear(npc){ const seed=_liveOf(npc); if(!seed) return null; let members;
+  if(_ambConv && _ambConv.members.indexOf(seed)>=0) members=_ambConv.members.slice();      // you stepped into an active circle → join exactly that circle
+  else { const sp=seed.group.position, jr=RES_MOVE.joinR;                                   // otherwise gather only the neighbours genuinely clustered around them
+    members=[seed].concat(RESIDENTS_LIVE.filter(L=>L!==seed && L.group.position.distanceTo(sp)<=jr)
+      .sort((a,b)=>a.group.position.distanceToSquared(sp)-b.group.position.distanceToSquared(sp))); }
+  const cap=Math.max(2,Math.min(NPC_CFG.maxGroup,RESIDENTS_LIVE.length)); members=members.slice(0,cap);
+  return members.length>=2?members:null; }
+function _releaseGroup(){ if(!activeGroupMembers) return; const until=clock.elapsedTime+8+Math.random()*6;
+  for(const m of activeGroupMembers) _resCd.set(m.res.id,until); activeGroupMembers=null; _ambNextAt=clock.elapsedTime+5+Math.random()*6; }   // members rest a beat, then town life resumes
+function openGroupChat(members){ if(_ambConv && members.some(m=>_ambConv.members.indexOf(m)>=0)) _endAmb('player-joined');
+  activeGroupMembers=members.slice();
+  openChat({ resident:true, group:true, id:'group', kind:'resident', res:members[0].res, live:members.slice(), members:members.map(m=>m.res), gi:0 }); }
+function _groupNames(ms){ return ms.map(m=>{ const n=m.res[LANG]||m.res.ko; return `<b style="color:${_hex(m.res.color)}">${esc(n.name)}</b>`; }).join(' \u00b7 '); }
+function _groupChip(res){ const n=res[LANG]||res.ko; return `<b style="color:${_hex(res.color)}">${esc(n.name)}</b> `; }
+function _groupPromptHtml(ms){ return (LANG==='ko'?`<b>\uD83D\uDC65 ${ms.length}\uBA85\uC774 \uBAA8\uC5EC \uC788\uC5B4\uC694</b> \u00b7 <span class="key">Enter</span>/\uD074\uB9AD\uC73C\uB85C <b>\uB300\uD654\uC5D0 \uB07C\uAE30</b> \uD83D\uDCAC`:`<b>\uD83D\uDC65 a gathering of ${ms.length}</b> \u00b7 <span class="key">Enter</span>/click to <b>join in</b> \uD83D\uDCAC`); }
+function groupGreet(wrap){ return _groupNames(wrap.live||[])+' \u2014 '+esc(LANG==='ko'?'\uBB34\uC2A8 \uC774\uC57C\uAE30\uB4E0 \uAC19\uC774 \uB098\uB220\uC694.':"let's talk it over together."); }
+async function groupSay(q){ const wrap=activeNpc, ms=((wrap&&wrap.live)||[]).filter(m=>m&&m.res); if(!ms.length){ await residentSay(q); return; }
+  _guestCdUntil=clock.elapsedTime+NPC_CFG.guestCooldownSec;
+  const pi=(wrap.gi||0)%ms.length, pres=ms[pi].res;                                          // the addressed speaker round-robins so everyone gets to answer you over the exchange
+  const useAI=NPC_CFG.aiEnabled && NPC_CFG.playerChatAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
+  let mainHtml=null, repo=null;
+  if(useAI){ const sb=showTyping(addMsg('bot',_groupChip(pres)+'\u2026',{noHist:true}));
+    try{ const line=await _aiPlayerChat(pres,q); if(line) mainHtml=_groupChip(pres)+esc(_cap180(line)); }catch(e){} sb.remove(); }
+  if(!mainHtml){ const r=residentReply(pres,q); mainHtml=_groupChip(pres)+r.html; repo=r.repo; }
+  addMsg('bot',mainHtml,repo?{repo:repo}:undefined);
+  if(ms.length>1){ const oi=(pi+1+((Math.random()*(ms.length-1))|0))%ms.length, other=ms[oi];
+    await new Promise(r=>setTimeout(r,520)); if(activeGroupMembers) addMsg('bot',_groupChip(other.res)+esc(_cap180(_scriptLine(other)))); }   // a second resident chimes in with a short in-voice aside, rotating so the whole circle joins in
+  wrap.gi=(wrap.gi||0)+1; trackChatEvent('npc_player_chat',{npc:'group',size:ms.length,ai:useAI&&!!mainHtml}); }
 
 // ---- boot: best-effort worker config (learn runtime toggles + budget); unreachable → stay scripted ----
 async function npcBootConfig(){ NPC_CFG.worker=(typeof groundedUrl==='function'?groundedUrl():null)||null; if(!NPC_CFG.worker) return;
@@ -5274,7 +5306,7 @@ function markVisited(repo){ if(repo._visited) return; repo._visited=true; visite
 const promptEl=document.getElementById('prompt'); let nearest=null, nearNpc=null, nearHub=null, activeNpc=null;
 let sitting=null, nearestSeat=null;
 /* one action resolves to whatever you're standing at: an NPC to talk to, a building to open, or a seat */
-function doAct(){ if(ferris||carousel) return; if(sitting) standUp(); else if(nearNpc) openChat(nearNpc); else if(nearChrono) openChrono(); else if(nearObs) openObservatory(); else if(nearStation) openStationModal(); else if(nearFerris) boardFerris(); else if(nearCarousel) boardCarousel(); else if(nearest) openCard(nearest); else if(nearHub) openZoneBoard(nearHub.id); else if(nearResident) openChat(nearResident); else if(nearestSeat) sitDown(nearestSeat); }
+function doAct(){ if(ferris||carousel) return; if(sitting) standUp(); else if(nearNpc) openChat(nearNpc); else if(nearChrono) openChrono(); else if(nearObs) openObservatory(); else if(nearStation) openStationModal(); else if(nearFerris) boardFerris(); else if(nearCarousel) boardCarousel(); else if(nearest) openCard(nearest); else if(nearHub) openZoneBoard(nearHub.id); else if(nearResident){ const _g=_groupNear(nearResident); if(_g) openGroupChat(_g); else openChat(nearResident); } else if(nearestSeat) sitDown(nearestSeat); }
 function npcPrompt(n){ const sc=window.scholarByKind&&n&&window.scholarByKind(n.kind);
   const nm = sc ? `${sc.emoji||'\u2726'} ${sc.star} \u00b7 ${LANG==='ko'?sc.epithetKo:sc.epithetEn}` : ((n&&n.kind==='msdocs')? t('npcEng') : t('npcTaxi'));
   return (LANG==='ko'?`<b>${nm}</b> · <span class="key">Enter</span>/클릭으로 <b>말 걸기</b> 💬`:`<b>${nm}</b> · <span class="key">Enter</span>/click to <b>talk</b> 💬`); }
@@ -5507,18 +5539,19 @@ function fallbackCopy(url, ok){ try{ const ta=document.createElement('textarea')
   document.execCommand('copy'); document.body.removeChild(ta); ok&&ok(); }catch(_){ } }
 const chatHeadTtl=document.querySelector('#chat .chatHead .ttl');
 function scholarPersona(kind, slot){ const sc=window.scholarByKind&&window.scholarByKind(kind); if(sc&&sc.active&&sc.persona){ const p=sc.persona[LANG]||sc.persona.ko; if(p&&p[slot]) return p[slot]; } return null; }
-function npcGreet(n){ if(n&&n.resident) return residentGreet(n.res); const k=(n&&n.kind)||'taxi'; return scholarPersona(k,'greet') || (k==='msdocs'? t('engGreet') : t('greeterHtml')); }
-function applyNpcChrome(n){ if(n&&n.resident){ if(chatHeadTtl) chatHeadTtl.innerHTML=residentTitle(n.res); modeSel.style.display='none'; chatText.placeholder=residentPh(n.res); return; }
+function npcGreet(n){ if(n&&n.group) return groupGreet(n); if(n&&n.resident) return residentGreet(n.res); const k=(n&&n.kind)||'taxi'; return scholarPersona(k,'greet') || (k==='msdocs'? t('engGreet') : t('greeterHtml')); }
+function applyNpcChrome(n){ if(n&&n.group){ if(chatHeadTtl) chatHeadTtl.innerHTML=_groupNames(n.live||[])+' \u00b7 '+(LANG==='ko'?'\uBAA8\uC784':'circle'); modeSel.style.display='none'; chatText.placeholder=(LANG==='ko'?'\uBAA8\uC784\uC5D0 \uB9D0 \uAC78\uAE30\u2026':'Say something to the circle\u2026'); return; }
+  if(n&&n.resident){ if(chatHeadTtl) chatHeadTtl.innerHTML=residentTitle(n.res); modeSel.style.display='none'; chatText.placeholder=residentPh(n.res); return; }
   const scholar = n && n.kind!=='taxi';
   if(chatHeadTtl) chatHeadTtl.innerHTML = scholar ? (scholarPersona(n.kind,'title')||t('engTitle')) : t('taxiTitle');
   modeSel.style.display = scholar?'none':''; chatText.placeholder = scholar ? (scholarPersona(n.kind,'ph')||t('engPh')) : t('chatPh'); }
-function openChat(npc){ npc=npc||activeNpc||NPCS.find(n=>n.kind==='taxi'); chatEl.classList.remove('hidden');
+function openChat(npc){ npc=npc||activeNpc||NPCS.find(n=>n.kind==='taxi'); if(activeGroupMembers && !(npc&&npc.group)) _releaseGroup(); chatEl.classList.remove('hidden');
   if(activeNpc!==npc){ activeNpc=npc; chatLog.innerHTML=''; chatGreeted=false; chatHistory=[]; }   // switching NPC resets the thread + memory
   applyNpcChrome(npc);
   if(!chatGreeted){ chatGreeted=true; addMsg('bot', npcGreet(npc), {noHist:true}); }
   trackChatEvent('chat_open', { npc:npcKindOf(npc) });
   setTimeout(()=>chatText.focus(),60); }
-function closeChat(){ chatEl.classList.add('hidden'); trackChatEvent('chat_close'); }
+function closeChat(){ chatEl.classList.add('hidden'); _releaseGroup(); trackChatEvent('chat_close'); }
 
 /* ---- Mode A: local intent search (no key, always works) ---- */
 const SYN={ rag:['rag','retrieval','faq','vector','embedding','검색증강','지식'], llm:['llm','gpt','openai','azure','generative','genai','foundry','language model','파운드리'],
@@ -5942,7 +5975,7 @@ async function sendChat(){ const q=chatText.value.trim(); if(!q||busy) return; b
   trackChatEvent('chat_submit', { npc, qLen });
   let ok=false;
   addMsg('me',q.replace(/</g,'&lt;'));
-  try{ if(activeNpc&&activeNpc.resident){ await residentSay(q); } else { await askDriver(q); } ok=true; }
+  try{ if(activeNpc&&activeNpc.group){ await groupSay(q); } else if(activeNpc&&activeNpc.resident){ await residentSay(q); } else { await askDriver(q); } ok=true; }
   finally{ trackChatEvent('chat_turn_done', { npc, qLen, ok, ms:elapsedMs(started) }); busy=false; chatText.focus(); } }
 
 /* ---- taxi ride: the cab drives to you, picks you up, carries you there ---- */
@@ -6243,7 +6276,7 @@ function animate(){
       : (LANG==='ko'?`<b>${nearest.label}</b> 도착! <span class="key">Enter</span> 또는 클릭으로 열기`:`<b>${nearest.label}</b> reached! <span class="key">Enter</span> or click to open`); promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🚪'; }
   else if(nearHub&&!modalOpen){ const z=zoneCatById(nearHub.id); const nm=z?(LANG==='ko'?z.ko:z.en):''; const ic=z?z.icon:'🪧';
       promptEl.innerHTML=(LANG==='ko'?`<b>${ic} ${nm}</b> · <span class="key">Enter</span>/버튼으로 <b>구역 안내판</b> 열기 🪧`:`<b>${ic} ${nm}</b> · <span class="key">Enter</span>/button for the <b>district board</b> 🪧`); promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🪧'; }
-  else if(nearResident&&!modalOpen){ promptEl.innerHTML=residentPromptHtml(nearResident); promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='💬'; }
+  else if(nearResident&&!modalOpen){ const _g=_groupNear(nearResident); promptEl.innerHTML=_g?_groupPromptHtml(_g):residentPromptHtml(nearResident); promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='💬'; }
   else if(nearestSeat&&!modalOpen){ promptEl.innerHTML = (LANG==='ko'?`<span class="key">Enter</span> 또는 버튼으로 <b>앉기</b> 🪑`:`<span class="key">Enter</span> or button to <b>sit</b> 🪑`); promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🪑'; }
   else { promptEl.classList.remove('show'); actBtn.classList.remove('avail'); actBtn.textContent='🚪'; }
 
@@ -6624,7 +6657,7 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
   window.__npcState=()=>({ mode:NPC_CFG.modeEnabled, visual:NPC_CFG.visualEnabled, ai:NPC_CFG.aiEnabled, ambientAi:NPC_CFG.ambientAiEnabled, playerAi:NPC_CFG.playerChatAiEnabled,
     scriptedAmbient:NPC_CFG.scriptedAmbient, lowEnd:LOW_END, mobile:IS_MOBILE, motionEnabled:NPC_CFG.motionEnabled, wanderSpd:+RES_MOVE.wanderSpd.toFixed(2), meetSpd:+RES_MOVE.meetSpd.toFixed(2), gapMin:NPC_CFG.gapMin, gapMax:NPC_CFG.gapMax, maxTurns:NPC_CFG.maxTurns,
     greetDist:RES_GREET_DIST, greetCd:[RES_GREET_CD_MIN,RES_GREET_CD_MAX], emoteCd:[RES_EMOTE_CD_MIN,RES_EMOTE_CD_MAX],
-    live:RESIDENTS_LIVE.length, max:MAX_RESIDENTS, maxGroup:NPC_CFG.maxGroup, groupR:RES_MOVE.groupR, groupSize:(_ambConv?_ambConv.members.length:0), moved:+RESIDENTS_LIVE.reduce((s,L)=>s+(L._dist||0),0).toFixed(1), resting:RESIDENTS_LIVE.filter(L=>L._rest).length, seats:SEATS.length, flora:GLOW_FLORA.length, active:!!_ambConv, hidden:document.hidden, worker:!!NPC_CFG.worker });
+    live:RESIDENTS_LIVE.length, max:MAX_RESIDENTS, maxGroup:NPC_CFG.maxGroup, groupR:RES_MOVE.groupR, joinR:RES_MOVE.joinR, groupChat:(activeGroupMembers?activeGroupMembers.map(m=>m.res.id):null), groupSize:(_ambConv?_ambConv.members.length:0), moved:+RESIDENTS_LIVE.reduce((s,L)=>s+(L._dist||0),0).toFixed(1), resting:RESIDENTS_LIVE.filter(L=>L._rest).length, seats:SEATS.length, flora:GLOW_FLORA.length, active:!!_ambConv, hidden:document.hidden, worker:!!NPC_CFG.worker });
   window.__seats=()=>SEATS.map((s,i)=>({ i, pos:[+s.x.toFixed(1),+s.z.toFixed(1)], occupied:s._occ?s._occ.res.id:null }));
   window.__greet=(id)=>{ const L=id?RESIDENTS_LIVE.find(x=>x.res.id===id):RESIDENTS_LIVE.slice().sort((a,b)=>player.position.distanceTo(a.group.position)-player.position.distanceTo(b.group.position))[0];
     if(!L) return null; if(_resChatActive()&&activeNpc&&activeNpc.res===L.res) return { who:L.res.id, skipped:'chatBound' };   // never paint a greeting over a resident the visitor is mid-chat with
@@ -6640,6 +6673,13 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     if(!mem||mem.length<2) return {ok:false}; for(const m of mem) _resCd.delete(m.res.id);
     _startAmb(mem); if(_ambConv){ _ambConv.phase='talk'; _ambConv.nextAt=0; _advanceAmb(); }
     return { ok:!!_ambConv, members:_ambConv?_ambConv.members.map(m=>m.res.id):[], size:_ambConv?_ambConv.members.length:0 }; };
+  window.__joinGroup=(ids)=>{ let mem;   // player joins a gathering: pass explicit ids, else the cluster around nearResident / the resident nearest the player
+    if(Array.isArray(ids)&&ids.length>=2) mem=ids.map(id=>RESIDENTS_LIVE.find(L=>L.res.id===id)).filter(Boolean);
+    else if(nearResident) mem=_groupNear(nearResident);
+    else { const seed=RESIDENTS_LIVE.slice().sort((a,b)=>player.position.distanceTo(a.group.position)-player.position.distanceTo(b.group.position))[0]; mem=seed?_groupNear(seed._npc):null; }
+    if(!mem||mem.length<2) return { ok:false, reason:'no cluster' }; openGroupChat(mem);
+    return { ok:!!activeGroupMembers, members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):[], title:chatHeadTtl?chatHeadTtl.textContent:null, ph:chatText?chatText.placeholder:null }; };
+  window.__groupChat=()=>({ active:!!activeGroupMembers, open:!!(chatEl&&!chatEl.classList.contains('hidden')), members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):[], primary:(activeNpc&&activeNpc.group)?activeNpc.res.id:null, gi:(activeNpc&&activeNpc.group)?activeNpc.gi:null });
   window.__npcBudget=()=>({ ...JSON.parse(JSON.stringify(_npcBudget)), low:_budgetLow(), exhausted:_budgetExhausted() });
   window.__npcTranscript=()=>_npcTranscript.slice(-20);
   window.__npcSim=(o)=>{ o=o||{}; ['remainingUsd','spentUsd','turnsToday','dailyTurnMax','dayCapUsd'].forEach(k=>{ if(typeof o[k]==='number') _npcBudget[k]=o[k]; });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -310,8 +310,8 @@ ok(/\{ id:'noa', zone:'plaza'/.test(npcBlock), 'the plaza dreamer Noa is in the 
 ok(/RESIDENTS\.slice\(0,MAX_RESIDENTS\)/.test(npcBlock), 'placement is clamped to the max-resident cap');
 // 12b — prompt priority: residents sit BELOW buildings + hubs (no repo-door / district-board hijack)
 ok(/nearResident=null; if\(!nearest && !nearHub\)\{/.test(HTML), 'nearResident is detected only when no building AND no hub is in reach');
-ok(/openZoneBoard\(nearHub\.id\); else if\(nearResident\) openChat\(nearResident\)/.test(HTML), 'doAct() checks nearResident AFTER nearHub (buildings + hubs win)');
-ok(/else if\(nearResident&&!modalOpen\)\{ promptEl\.innerHTML=residentPromptHtml/.test(HTML), 'resident prompt is emitted after the hub prompt branch');
+ok(/openZoneBoard\(nearHub\.id\); else if\(nearResident\)\{ const _g=_groupNear\(nearResident\)/.test(HTML), 'doAct() checks nearResident AFTER nearHub (buildings + hubs win)');
+ok(/else if\(nearResident&&!modalOpen\)\{ const _g=_groupNear\(nearResident\); promptEl\.innerHTML=_g\?_groupPromptHtml\(_g\):residentPromptHtml/.test(HTML), 'resident prompt is emitted after the hub prompt branch');
 ok(/const RES_REACH=3\.4/.test(npcBlock), 'residents use a small walk-up reach (3.4)');
 // 12b-2 — living town: residents wander around home and walk toward one another before talking (not static statues)
 ok(/const RES_MOVE=\{[^}]*meetMax:/.test(npcBlock) && /talkDist:/.test(npcBlock), 'RES_MOVE tuning (meetMax + talkDist) exists for wander + rendezvous');
@@ -438,6 +438,25 @@ ok(/Math\.min\(NPC_CFG\.hardMaxTurns, base\+\(members\.length-2\)\)/.test(npcBlo
 ok(/for\(const m of C\.members\) _resCd\.set/.test(npcBlock), 'every member gets a cooldown when the gathering ends (whole circle rests, not just the seed pair)');
 ok(/window\.__conv=\(\)=>/.test(HTML) && /window\.__gather=/.test(HTML), '?dbg __conv/__gather hooks expose + force group conversations');
 ok(/if\(document\.hidden\)\{ if\(_ambConv\) _endAmb\('hidden'\); return; \}/.test(npcBlock) && /maxConcurrent:1/.test(npcBlock), 'group conversations preserve the hidden-tab stop and the one-gathering-at-a-time cap');
+
+// 18 — the visitor can JOIN a gathering: walk up to a circle (or cluster) and the whole group chats back, round-robin
+group('resident player group chat (visitor joins a gathering)');
+ok(/let activeGroupMembers=null/.test(npcBlock), 'a module-level activeGroupMembers holds the residents in a player-facing circle');
+ok(/joinR:\(LOW_END\?7:9\)/.test(npcBlock), 'RES_MOVE carries a joinR walk-up radius (smaller than groupR) so a circle only forms when folk are genuinely clustered');
+ok(/function _groupNear\(npc\)\{[\s\S]*?_ambConv\.members\.indexOf\(seed\)>=0/.test(npcBlock), '_groupNear joins an existing circle if the seed is mid-conversation, else gathers the nearby cluster');
+ok(/function openGroupChat\(members\)\{[\s\S]*?_endAmb\('player-joined'\)/.test(npcBlock), "opening a group chat ends the residents' auto-conversation so they turn to the visitor");
+ok(/async function groupSay\(q\)\{/.test(npcBlock), 'groupSay drives the whole-circle reply to the visitor');
+ok(/const pi=\(wrap\.gi\|\|0\)%ms\.length/.test(npcBlock) && /wrap\.gi=\(wrap\.gi\|\|0\)\+1/.test(npcBlock), 'the addressed speaker round-robins (wrap.gi) so every circle member answers the visitor over the exchange');
+ok(/if\(ms\.length>1\)\{[\s\S]*?_scriptLine\(other\)/.test(npcBlock), 'a second resident chimes in with a short in-voice aside so it reads as a group, not a 1:1');
+ok(/const chatBound=_resChatActive\(\)&&activeNpc&&\(activeNpc\.res===L\.res \|\| \(activeGroupMembers&&activeGroupMembers\.indexOf\(L\)>=0\)\)/.test(npcBlock), 'every circle member freezes + turns to the visitor while the group chat is open (chatBound covers activeGroupMembers)');
+ok(/pd<6\.5\)\?player\.position/.test(npcBlock), 'residents in a circle turn to face the visitor who steps right up (pd<6.5)');
+ok(/if\(_ambConv!==C\)\{ C\.pending=false; return; \}/.test(npcBlock), "a stale in-flight ambient turn can't paint a bubble after the visitor joins (done() guards on _ambConv)");
+ok(/function _releaseGroup\(\)\{/.test(npcBlock) && /_releaseGroup\(\);/.test(HTML), 'closing/ switching the chat releases the circle (members rest a beat, then town life resumes)');
+ok(/if\(n&&n\.group\) return groupGreet\(n\)/.test(HTML) && /if\(n&&n\.group\)\{/.test(HTML), 'the chat panel has a group branch for greeting + chrome (names header, no mode selector)');
+ok(/if\(activeNpc&&activeNpc\.group\)\{ await groupSay\(q\)/.test(HTML), 'sendChat routes to groupSay when a gathering is active (before the 1:1 resident + taxi paths)');
+ok(/const _g=_groupNear\(nearResident\); if\(_g\) openGroupChat\(_g\); else openChat\(nearResident\)/.test(HTML), 'pressing Enter/💬 by a cluster opens the group chat, else falls back to a 1:1');
+ok(/promptEl\.innerHTML=_g\?_groupPromptHtml\(_g\):residentPromptHtml\(nearResident\)/.test(HTML), 'the walk-up prompt shows "join in / 대화에 끼기" for a cluster');
+ok(/window\.__joinGroup=/.test(HTML) && /window\.__groupChat=/.test(HTML), '?dbg __joinGroup/__groupChat hooks force + inspect a player group chat');
 
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');


### PR DESCRIPTION
## 🙋 Step into the circle

Walk up to a cluster of residents — or step right into an active **circle** — and you can now **join the conversation** instead of only doing a 1:1 chat.

### What changed
- **Walk-up prompt** by a cluster reads **"대화에 끼기 / join in"** (falls back to the 1:1 "talk" when a resident is alone).
- **Group chat panel** — the header lists every member (**"솔 · 준 · 나리 · 모임"**). Each message you send is answered by a **primary responder** + a short in-voice **chime-in** from another member, each tagged with a colored name chip.
- **Round-robin** — the addressed speaker rotates across the circle, so everyone replies to you over the exchange.
- **The circle turns to you** — on join the members' auto-conversation ends, they freeze and **face the visitor**, world-bubbles clear. Closing the chat **releases** the circle (members rest a beat, town life resumes).

### How a group forms
- Neighbours within a tight **joinR** walk-up radius (9u desktop / 7u LOW_END, deliberately tighter than the ambient `groupR`), capped at **maxGroup** (4 desktop / 3 mobile & LOW_END). Fewer than two nearby → clean **1:1 fallback**. Stepping into a live circle joins **exactly that circle**.

### Cheap & safe
- **Zero extra network cost**: reuses scripted persona replies + the same single AI player-chat path (**one AI call per message**, like 1:1). Budget-low / env-off → fully scripted.
- **Preserved**: hidden-tab stop, per-resident & pair cooldowns, LOW_END locomotion, ambient engine, scholar/taxi chat, AI env-gating + daily budget caps. A stale in-flight ambient turn can no longer paint a bubble after join (`done()` guard).

### Verify
- `node scripts/smoke.mjs` → **237 green** (+ group 18: 17 new guards)
- `node council/test.mjs` → 130 · `node council/test-live.mjs` → 56 · `node --check scholars.js` · `node --check cloudflare-taxi/src/grounded.js`
- Browser desktop + mobile **390×844**, `?dbg=1`: join forms circle, header shows names, round-robin primary + chime-in, members freeze & face player, close resumes ambient — **0 console errors**.

### Debug
`window.__joinGroup([ids])`, `window.__groupChat()`; `window.__npcState()` now reports `joinR` + the active `groupChat` roster.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
