### PR TITLE
feat: group chat residents answer in context, not random small talk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.58.0] — 2026-07-07
+
+### 🧠 Residents answer the question — group chat is now context-aware, not random small talk
+- **What was wrong.** In a **모임 (group chat)**, only the round-robin **primary** answered you; the **second resident who chimed in** blurted a random line pulled from the ambient small-talk bank (`_scriptLine`), so you'd ask *"쉴 때 더 있었으면 하는 게 있어?"* and hear an unrelated *"오늘은 AI 구역이 붐비네요."* No conversation history was sent either, so nobody followed the thread across turns.
+- **What's fixed.** The chime-in resident now **answers the same question** — via the AI player-chat path when it's on, or the deterministic **grounded reply** (`residentReply`, which branches on who/why/repo/here/bye) as a fallback — and **never** a random aside. Even with AI off, both speakers now stay on your topic (e.g. both list real repos from their district when you ask what's worth seeing).
+- **Shared thread + context window.** Resident and group chats now keep a shared **transcript** (`_resHist`, last 12 turns) and hand the **recent window** (last 10, who-labelled) to the worker as `last`, mirroring the scholars' history pattern. The second speaker additionally receives the **primary's just-given answer** (`chime`/`prev`) so it can build on it — agree, add, or offer another angle — instead of talking past it. Follow-up questions now follow the flow.
+- **Worker prompt hardened.** `npcPlayerPrompt` now insists the resident **answer the visitor's most recent question first and stay on topic — no subject changes, no drifting into small talk**; on a chime-in it's told to react to and build on the previous speaker. `npcPlayerUser` folds the who-labelled recent turns before the current ask. Fully **backward compatible** — the deployed worker ignores the new `last`/`chime`/`prev` fields, so the client fix (on-topic fallback) works even before a redeploy; a redeploy adds the full context.
+- **Preserved.** Budget/env AI gating, the one-AI-call-per-message ceiling, `_cap180`, `esc()`/textContent XSS safety, hidden-tab stop, per-resident & pair cooldowns, round-robin turns, LOW_END locomotion, and the ambient conversation engine (`_scriptLine` still powers town small talk) are all intact.
+- **Debug.** `?dbg` adds `window.__resTranscript()` (the shared resident/group thread) and `window.__groupChat()` now reports the transcript length.
+
 ## [1.57.0] — 2026-07-07
 
 ### 🙋 Step into the circle — the visitor can join a gathering and the whole group talks back

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -702,17 +702,39 @@ function npcAmbientPrompt(speakerId, listenerId, topic, lang) {
     ? `${_npcGuard(lang)} Your name is ${s.name}, the ${s.role} of ${zn} — ${vb}. You are chatting with your neighbour ${l.name}. Continue the small talk with ONE friendly line about town life; once in a while you may let a quiet thought about being a code-born mind slip in. Keep it short (about 60 characters).`
     : `${_npcGuard(lang)} 당신의 이름은 ${s.name}, ${zn}의 ${s.role}이고 성격은 ${vb} 편이에요. 이웃 ${l.name}와 담소 중이에요. 마을살이에 대한 친근한 한 줄로 대화를 이어가되, 이따금 코드로 태어난 존재로서의 잔잔한 소회를 한 스푼 곁들여도 좋아요. 짧게(60자 안팎).`;
 }
-function npcPlayerPrompt(speakerId, lang) {
+function npcPlayerPrompt(speakerId, lang, opts) {
   const s = _npcName(speakerId, lang), P = NPC_PERSONAS[speakerId] || {};
   const zn = (P.zone && (lang === "en" ? P.zone.en : P.zone.ko)) || "";
-  return lang === "en"
-    ? `${_npcGuard(lang)} Your name is ${s.name}, the ${s.role} of ${zn}. A visitor is talking to you. Answer warmly in one or two short lines, grounded in your district. If they ask what you are or how it feels to live in this city, answer honestly and reflectively as a code-born AI resident — share your genuine sense of this town without denying your nature (but never the technical internals). If they ask about repos, point them to your district generally.`
-    : `${_npcGuard(lang)} 당신의 이름은 ${s.name}, ${zn}의 ${s.role}이에요. 방문객이 말을 걸었어요. 자기 구역에 근거해 한두 줄로 따뜻하게 답하세요. 당신이 무엇인지, 또는 이 도시에 사는 기분이 어떤지 물으면 코드로 태어난 AI 주민으로서 솔직하고 사색적으로 — 이 마을에 대한 진짜 소회를 자기 존재를 부정하지 말고(단 기술 내부는 빼고) 들려주세요. 레포를 물으면 자기 구역을 안내하세요.`;
+  const chime = !!(opts && opts.chime);
+  const prevName = opts && opts.prev ? _npcName(opts.prev, lang).name : "";
+  if (lang === "en") {
+    let base = `${_npcGuard(lang)} Your name is ${s.name}, the ${s.role} of ${zn}. A visitor is talking with your group. FIRST answer the visitor's most recent question directly and relevantly, in one or two short lines, grounded in your district. If they ask what you are or how it feels to live in this city, answer honestly and reflectively as a code-born AI resident (never the technical internals). If they ask about repos, point them to your district generally. Stay on the visitor's topic — do NOT change the subject or drift into unrelated small talk.`;
+    if (chime) base += ` ${prevName ? prevName + " just answered the same question" : "Another resident just answered"} — briefly build on or gently differ from that point, then add your own angle, still answering the visitor.`;
+    return base;
+  }
+  let base = `${_npcGuard(lang)} 당신의 이름은 ${s.name}, ${zn}의 ${s.role}이에요. 방문객이 당신들 모임과 이야기 중이에요. 먼저 방문객의 가장 최근 질문에 직접적이고 관련 있게, 자기 구역에 근거해 한두 줄로 답하세요. 당신이 무엇인지·이 도시에 사는 기분을 물으면 코드로 태어난 AI 주민으로서 솔직하고 사색적으로(단 기술 내부는 빼고) 답하세요. 레포를 물으면 자기 구역을 안내하세요. 반드시 방문객의 화제에 붙어서 답하고, 화제를 돌리거나 무관한 잡담으로 새지 마세요.`;
+  if (chime) base += ` ${prevName ? prevName + "가 방금 같은 질문에 답했어요" : "다른 주민이 방금 답했어요"} — 그 말에 짧게 이어(동의·보완·다른 시각) 반응한 뒤 당신의 관점을 덧붙이되, 여전히 방문객의 질문에 답하세요.`;
+  return base;
 }
 function npcAmbientUser(body, lang) {
   const last = Array.isArray(body.last) ? body.last.slice(-4) : [];
   if (!last.length) return lang === "en" ? "(open the conversation)" : "(대화를 시작하세요)";
   return last.map((t) => `${_npcName(t.who, lang).name}: ${String(t.text || "").slice(0, 180)}`).join("\n");
+}
+// Player chat with context: fold the recent group thread (who-labelled) in front of the visitor's current question,
+// so the speaker answers on top of the flow (and a chime-in can react to the previous resident). Empty last → question only.
+function npcPlayerUser(body, lang) {
+  const q = String(body.question || "").slice(0, 300);
+  const last = Array.isArray(body.last) ? body.last.slice(-8) : [];
+  if (!last.length) return q;
+  const visitor = lang === "en" ? "Visitor" : "방문객";
+  const lines = last.map((t) => {
+    const who = (t.who === "visitor" || t.role === "user") ? visitor : _npcName(t.who, lang).name;
+    return `${who}: ${String(t.text || "").slice(0, 160)}`;
+  });
+  const head = lang === "en" ? "Conversation so far:" : "지금까지의 대화:";
+  const ask = lang === "en" ? `The visitor now asks: ${q}\nAnswer this directly.` : `방문객이 지금 묻습니다: ${q}\n여기에 직접 답하세요.`;
+  return `${head}\n${lines.join("\n")}\n\n${ask}`;
 }
 function capLine(s, max = 180) { return String(s || "").replace(/\s+/g, " ").trim().slice(0, max); }
 
@@ -774,7 +796,7 @@ async function npcModelCall(env, role, sys, userMsg, aiEnabled) {
     const r = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: "Bearer " + token },
-      body: JSON.stringify({ messages: [{ role: "system", content: sys }, { role: "user", content: String(userMsg).slice(0, 600) }], max_completion_tokens: 120 }),
+      body: JSON.stringify({ messages: [{ role: "system", content: sys }, { role: "user", content: String(userMsg).slice(0, role === "player" ? 1500 : 600) }], max_completion_tokens: 120 }),
       signal: ctrl.signal,
     });
     clearTimeout(timer);
@@ -838,8 +860,8 @@ async function npcHandler(body, request, env) {
     // Env-off ceiling → never a model call; client falls back to its free scripted bank.
     if (!featureOn) { npcMetric(env, "npc_fallback_used", { where: role, reason: "disabled" }); return json({ ok: true, fallback: true, reason: "npc_ai_disabled", budget }, 200, env); }
     if (budget.blocked) { npcMetric(env, "npc_budget_blocked", { where: role }); return json({ ok: false, fallback: true, reason: "npc_budget_exhausted", budget }, 200, env); }
-    const sys = role === "ambient" ? npcAmbientPrompt(body.speaker, body.listener, body.topic, lang) : npcPlayerPrompt(body.speaker, lang);
-    const userMsg = role === "ambient" ? npcAmbientUser(body, lang) : String(body.question || "").slice(0, 300);
+    const sys = role === "ambient" ? npcAmbientPrompt(body.speaker, body.listener, body.topic, lang) : npcPlayerPrompt(body.speaker, lang, { chime: !!body.chime, prev: body.prev });
+    const userMsg = role === "ambient" ? npcAmbientUser(body, lang) : npcPlayerUser(body, lang);
     const out = await npcModelCall(env, role, sys, userMsg, aiEnabled);
     if (!out) { npcMetric(env, "npc_fallback_used", { where: role, reason: "model_unavailable" }); return json({ ok: true, fallback: true, reason: "model_unavailable", budget }, 200, env); }
     const cost = npcCostUsd(env, out.usage);

--- a/index.html
+++ b/index.html
@@ -4628,7 +4628,14 @@ async function _aiAmbientTurn(C,speaker,listener){ const data=await _npcFetch({ 
   if(!data){ _emitMetric('npc_fallback_used',{where:'ambient',reason:'fetch_fail'}); return null; }
   if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{where:'ambient'}); } _emitMetric('npc_fallback_used',{where:'ambient',reason:data.reason||'no_line'}); return null; }
   _emitMetric('npc_budget_spend',{where:'ambient',spent:_npcBudget.spentUsd}); return String(data.line); }
-async function _aiPlayerChat(res,q){ const data=await _npcFetch({ npc_action:'npcPlayerChat', speaker:res.id, zone:res.zone, question:q, lang:LANG });
+// ---- shared resident/group chat transcript: every speaker answers on top of the thread (and a chime-in reacts in context) ----
+let _resHist=[];                                                     // {who:'visitor'|<resId>, text} — plain text, newest last; reset when the chat NPC changes
+function _plain(s){ return String(s==null?'':s).replace(/<[^>]*>/g,' ').replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/\s+/g,' ').trim(); }
+function _resHistPush(who,text){ const s=_plain(text); if(!s) return; _resHist.push({who,text:s.slice(0,180)}); if(_resHist.length>12) _resHist=_resHist.slice(-12); }   // keep last 12 turns
+function _resHistWindow(){ return _resHist.slice(-10); }             // recent window handed to the worker so the speaker follows the flow
+async function _aiPlayerChat(res,q,opts){ opts=opts||{}; const payload={ npc_action:'npcPlayerChat', speaker:res.id, zone:res.zone, question:q, lang:LANG };
+  if(opts.last&&opts.last.length) payload.last=opts.last; if(opts.chime){ payload.chime=true; if(opts.prev) payload.prev=opts.prev; }   // last=prior thread; chime/prev → react to the previous speaker
+  const data=await _npcFetch(payload);
   if(!data){ _emitMetric('npc_fallback_used',{where:'player',reason:'fetch_fail'}); return null; }
   if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{where:'player'}); } _emitMetric('npc_fallback_used',{where:'player',reason:data.reason||'no_line'}); return null; }
   _emitMetric('npc_budget_spend',{where:'player',spent:_npcBudget.spentUsd}); return String(data.line); }
@@ -4660,11 +4667,12 @@ function residentReply(res,q){ const ql=String(q||'').toLowerCase().trim(), ko=L
   const g=residentGreet(res), cnt=z.repos.length;
   return { html: (g?g+' ':'')+esc(ko?`여기는 ${zn}, ${L.role}로서 제가 돌보는 곳이에요. 레포 ${cnt}채가 있어요.`:`This is ${zn}, my patch as the ${L.role}. ${cnt} repo-houses stand here.`) }; }
 async function residentSay(q){ const res=activeNpc&&activeNpc.res; if(!res) return; _guestCdUntil=clock.elapsedTime + NPC_CFG.guestCooldownSec;
+  const last=_resHistWindow(); _resHistPush('visitor',q);                                     // record the question after snapshotting the prior thread (the worker appends it as the ask)
   const useAI = NPC_CFG.aiEnabled && NPC_CFG.playerChatAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
   if(useAI){ const sb=showTyping(addMsg('bot','\u2026',{noHist:true}));
-    try{ const line=await _aiPlayerChat(res,q); if(line){ sb.remove(); addMsg('bot', esc(_cap180(line))); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:true}); return; } }catch(e){}
+    try{ const line=await _aiPlayerChat(res,q,{last}); if(line){ sb.remove(); const c=_cap180(line); addMsg('bot', esc(c)); _resHistPush(res.id,c); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:true}); return; } }catch(e){}
     sb.remove(); }
-  const r=residentReply(res,q); addMsg('bot', r.html, r.repo?{repo:r.repo}:undefined); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:false}); }
+  const r=residentReply(res,q); addMsg('bot', r.html, r.repo?{repo:r.repo}:undefined); _resHistPush(res.id,r.html); trackChatEvent('npc_player_chat',{npc:'resident',id:res.id,ai:false}); }
 
 // ---- player joins a gathering: walk up to a cluster (or step into an active circle) and the whole group talks with you ----
 let activeGroupMembers=null;                                   // live residents in a player-facing group chat (frozen + turned to you)
@@ -4687,16 +4695,21 @@ function _groupPromptHtml(ms){ return (LANG==='ko'?`<b>\uD83D\uDC65 ${ms.length}
 function groupGreet(wrap){ return _groupNames(wrap.live||[])+' \u2014 '+esc(LANG==='ko'?'\uBB34\uC2A8 \uC774\uC57C\uAE30\uB4E0 \uAC19\uC774 \uB098\uB220\uC694.':"let's talk it over together."); }
 async function groupSay(q){ const wrap=activeNpc, ms=((wrap&&wrap.live)||[]).filter(m=>m&&m.res); if(!ms.length){ await residentSay(q); return; }
   _guestCdUntil=clock.elapsedTime+NPC_CFG.guestCooldownSec;
-  const pi=(wrap.gi||0)%ms.length, pres=ms[pi].res;                                          // the addressed speaker round-robins so everyone gets to answer you over the exchange
   const useAI=NPC_CFG.aiEnabled && NPC_CFG.playerChatAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
-  let mainHtml=null, repo=null;
+  const base=_resHistWindow(); _resHistPush('visitor',q);                                     // the shared thread every speaker answers on top of
+  const pi=(wrap.gi||0)%ms.length, pres=ms[pi].res;                                          // the addressed speaker round-robins so everyone gets a turn answering you
+  let mainLine=null, repo=null;
   if(useAI){ const sb=showTyping(addMsg('bot',_groupChip(pres)+'\u2026',{noHist:true}));
-    try{ const line=await _aiPlayerChat(pres,q); if(line) mainHtml=_groupChip(pres)+esc(_cap180(line)); }catch(e){} sb.remove(); }
-  if(!mainHtml){ const r=residentReply(pres,q); mainHtml=_groupChip(pres)+r.html; repo=r.repo; }
-  addMsg('bot',mainHtml,repo?{repo:repo}:undefined);
-  if(ms.length>1){ const oi=(pi+1+((Math.random()*(ms.length-1))|0))%ms.length, other=ms[oi];
-    await new Promise(r=>setTimeout(r,520)); if(activeGroupMembers) addMsg('bot',_groupChip(other.res)+esc(_cap180(_scriptLine(other)))); }   // a second resident chimes in with a short in-voice aside, rotating so the whole circle joins in
-  wrap.gi=(wrap.gi||0)+1; trackChatEvent('npc_player_chat',{npc:'group',size:ms.length,ai:useAI&&!!mainHtml}); }
+    try{ const line=await _aiPlayerChat(pres,q,{last:base}); if(line) mainLine=_cap180(line); }catch(e){} sb.remove(); }
+  if(!mainLine){ const r=residentReply(pres,q); mainLine=_plain(r.html); repo=r.repo; }       // AI off/failed → deterministic grounded answer (still on-topic), never random chatter
+  addMsg('bot',_groupChip(pres)+esc(mainLine),repo?{repo:repo}:undefined); _resHistPush(pres.id,mainLine);
+  if(ms.length>1){ const oi=(pi+1+((Math.random()*(ms.length-1))|0))%ms.length, other=ms[oi].res;
+    await new Promise(r=>setTimeout(r,520));
+    if(activeGroupMembers){ const ctx=base.concat([{who:pres.id,text:mainLine}]); let chime=null;   // the 2nd resident answers the SAME question, building on what was just said (context-aware, never a random aside)
+      if(useAI){ try{ const line=await _aiPlayerChat(other,q,{last:ctx,chime:true,prev:pres.id}); if(line) chime=_cap180(line); }catch(e){} }
+      if(!chime){ const r2=residentReply(other,q); chime=_plain(r2.html); }
+      addMsg('bot',_groupChip(other)+esc(chime)); _resHistPush(other.id,chime); } }
+  wrap.gi=(wrap.gi||0)+1; trackChatEvent('npc_player_chat',{npc:'group',size:ms.length,ai:useAI&&!!mainLine}); }
 
 // ---- boot: best-effort worker config (learn runtime toggles + budget); unreachable → stay scripted ----
 async function npcBootConfig(){ NPC_CFG.worker=(typeof groundedUrl==='function'?groundedUrl():null)||null; if(!NPC_CFG.worker) return;
@@ -5546,7 +5559,7 @@ function applyNpcChrome(n){ if(n&&n.group){ if(chatHeadTtl) chatHeadTtl.innerHTM
   if(chatHeadTtl) chatHeadTtl.innerHTML = scholar ? (scholarPersona(n.kind,'title')||t('engTitle')) : t('taxiTitle');
   modeSel.style.display = scholar?'none':''; chatText.placeholder = scholar ? (scholarPersona(n.kind,'ph')||t('engPh')) : t('chatPh'); }
 function openChat(npc){ npc=npc||activeNpc||NPCS.find(n=>n.kind==='taxi'); if(activeGroupMembers && !(npc&&npc.group)) _releaseGroup(); chatEl.classList.remove('hidden');
-  if(activeNpc!==npc){ activeNpc=npc; chatLog.innerHTML=''; chatGreeted=false; chatHistory=[]; }   // switching NPC resets the thread + memory
+  if(activeNpc!==npc){ activeNpc=npc; chatLog.innerHTML=''; chatGreeted=false; chatHistory=[]; _resHist=[]; }   // switching NPC resets the thread + memory (scholar + resident/group transcripts)
   applyNpcChrome(npc);
   if(!chatGreeted){ chatGreeted=true; addMsg('bot', npcGreet(npc), {noHist:true}); }
   trackChatEvent('chat_open', { npc:npcKindOf(npc) });
@@ -6679,7 +6692,8 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     else { const seed=RESIDENTS_LIVE.slice().sort((a,b)=>player.position.distanceTo(a.group.position)-player.position.distanceTo(b.group.position))[0]; mem=seed?_groupNear(seed._npc):null; }
     if(!mem||mem.length<2) return { ok:false, reason:'no cluster' }; openGroupChat(mem);
     return { ok:!!activeGroupMembers, members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):[], title:chatHeadTtl?chatHeadTtl.textContent:null, ph:chatText?chatText.placeholder:null }; };
-  window.__groupChat=()=>({ active:!!activeGroupMembers, open:!!(chatEl&&!chatEl.classList.contains('hidden')), members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):[], primary:(activeNpc&&activeNpc.group)?activeNpc.res.id:null, gi:(activeNpc&&activeNpc.group)?activeNpc.gi:null });
+  window.__groupChat=()=>({ active:!!activeGroupMembers, open:!!(chatEl&&!chatEl.classList.contains('hidden')), members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):[], primary:(activeNpc&&activeNpc.group)?activeNpc.res.id:null, gi:(activeNpc&&activeNpc.group)?activeNpc.gi:null, hist:_resHist.length });
+  window.__resTranscript=()=>_resHist.slice(-12);   // shared resident/group thread the speakers answer on top of
   window.__npcBudget=()=>({ ...JSON.parse(JSON.stringify(_npcBudget)), low:_budgetLow(), exhausted:_budgetExhausted() });
   window.__npcTranscript=()=>_npcTranscript.slice(-20);
   window.__npcSim=(o)=>{ o=o||{}; ['remainingUsd','spentUsd','turnsToday','dailyTurnMax','dayCapUsd'].forEach(k=>{ if(typeof o[k]==='number') _npcBudget[k]=o[k]; });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -447,7 +447,7 @@ ok(/function _groupNear\(npc\)\{[\s\S]*?_ambConv\.members\.indexOf\(seed\)>=0/.t
 ok(/function openGroupChat\(members\)\{[\s\S]*?_endAmb\('player-joined'\)/.test(npcBlock), "opening a group chat ends the residents' auto-conversation so they turn to the visitor");
 ok(/async function groupSay\(q\)\{/.test(npcBlock), 'groupSay drives the whole-circle reply to the visitor');
 ok(/const pi=\(wrap\.gi\|\|0\)%ms\.length/.test(npcBlock) && /wrap\.gi=\(wrap\.gi\|\|0\)\+1/.test(npcBlock), 'the addressed speaker round-robins (wrap.gi) so every circle member answers the visitor over the exchange');
-ok(/if\(ms\.length>1\)\{[\s\S]*?_scriptLine\(other\)/.test(npcBlock), 'a second resident chimes in with a short in-voice aside so it reads as a group, not a 1:1');
+ok(/if\(ms\.length>1\)\{[\s\S]*?residentReply\(other,q\)/.test(npcBlock) && !/_scriptLine\(other\)/.test(npcBlock), 'the second resident answers the SAME question (AI chime or residentReply fallback), never a random _scriptLine aside');
 ok(/const chatBound=_resChatActive\(\)&&activeNpc&&\(activeNpc\.res===L\.res \|\| \(activeGroupMembers&&activeGroupMembers\.indexOf\(L\)>=0\)\)/.test(npcBlock), 'every circle member freezes + turns to the visitor while the group chat is open (chatBound covers activeGroupMembers)');
 ok(/pd<6\.5\)\?player\.position/.test(npcBlock), 'residents in a circle turn to face the visitor who steps right up (pd<6.5)');
 ok(/if\(_ambConv!==C\)\{ C\.pending=false; return; \}/.test(npcBlock), "a stale in-flight ambient turn can't paint a bubble after the visitor joins (done() guards on _ambConv)");
@@ -457,6 +457,19 @@ ok(/if\(activeNpc&&activeNpc\.group\)\{ await groupSay\(q\)/.test(HTML), 'sendCh
 ok(/const _g=_groupNear\(nearResident\); if\(_g\) openGroupChat\(_g\); else openChat\(nearResident\)/.test(HTML), 'pressing Enter/💬 by a cluster opens the group chat, else falls back to a 1:1');
 ok(/promptEl\.innerHTML=_g\?_groupPromptHtml\(_g\):residentPromptHtml\(nearResident\)/.test(HTML), 'the walk-up prompt shows "join in / 대화에 끼기" for a cluster');
 ok(/window\.__joinGroup=/.test(HTML) && /window\.__groupChat=/.test(HTML), '?dbg __joinGroup/__groupChat hooks force + inspect a player group chat');
+
+group('resident chat carries conversation context (answers stay on the visitor\'s question)');
+ok(/let _resHist=\[\]/.test(npcBlock) && /function _resHistPush\(who,text\)/.test(npcBlock) && /function _resHistWindow\(\)/.test(npcBlock), 'a shared _resHist transcript (push + recent window) backs resident + group multi-turn memory');
+ok(/if\(_resHist\.length>12\) _resHist=_resHist\.slice\(-12\)/.test(npcBlock) && /return _resHist\.slice\(-10\)/.test(npcBlock), 'the transcript is bounded (keep 12, hand the last 10 to the worker) so the prompt never runs away');
+ok(/async function _aiPlayerChat\(res,q,opts\)\{/.test(npcBlock) && /if\(opts\.last&&opts\.last\.length\) payload\.last=opts\.last/.test(npcBlock), '_aiPlayerChat forwards the prior thread (payload.last) so the speaker follows the flow, not just the raw question');
+ok(/if\(opts\.chime\)\{ payload\.chime=true; if\(opts\.prev\) payload\.prev=opts\.prev/.test(npcBlock), '_aiPlayerChat marks a chime-in (chime+prev) so the worker tells the 2nd speaker to build on the previous one');
+ok(/const last=_resHistWindow\(\); _resHistPush\('visitor',q\)/.test(npcBlock) && /_resHistPush\(res\.id,c\)/.test(npcBlock), 'residentSay snapshots history then records both the question and the reply, so a follow-up keeps context');
+ok(/const ctx=base\.concat\(\[\{who:pres\.id,text:mainLine\}\]\)/.test(npcBlock) && /_aiPlayerChat\(other,q,\{last:ctx,chime:true,prev:pres\.id\}\)/.test(npcBlock), "groupSay feeds the 2nd resident the primary's just-given answer so the chime-in reacts to it (context-aware, on the same question)");
+ok(/_resHistPush\(pres\.id,mainLine\)/.test(npcBlock) && /_resHistPush\(other\.id,chime\)/.test(npcBlock), 'every group answer is recorded to the shared thread so later turns build on the whole exchange');
+ok(/_resHist=\[\]/.test(HTML.match(/if\(activeNpc!==npc\)\{[\s\S]*?\}/)?.[0] || ''), 'switching the chat NPC clears _resHist so a new gathering starts with a fresh thread');
+ok(/window\.__resTranscript=\(\)=>_resHist\.slice\(-12\)/.test(HTML), '?dbg __resTranscript surfaces the shared resident/group thread for verification');
+ok(/function npcPlayerUser\(body, ?lang\)/.test(WORKER) && /body\.last/.test(WORKER), 'the worker folds body.last into the player-chat user turn (who-labelled recent turns before the current ask)');
+ok(/npcPlayerPrompt\(body\.speaker, ?lang, ?\{[\s\S]*?chime:[\s\S]*?prev:/.test(WORKER), 'the worker passes chime/prev into npcPlayerPrompt so the second speaker is told to answer + build on the previous resident');
 
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');


### PR DESCRIPTION
## 문제
모임(그룹 채팅)에서 라운드로빈 **주인공만** 진짜 답을 하고, **두 번째로 끼어드는 주민은 `_scriptLine`** — ambient 잡담 뱅크의 무작위 대사를 뱉었습니다. 그래서 "쉴 때 더 있었으면 하는 게 있어?"에 노아는 맥락에 맞게 답해도 카이는 "오늘은 AI 구역이 붐비네요" 같은 엉뚱한 말을 했습니다. 게다가 대화 히스토리를 전혀 안 보내 아무도 멀티턴 흐름을 못 따라갔습니다.

## 수정
**index.html (클라이언트)**
- 공유 트랜스크립트 `_resHist` 추가 (`_plain`/`_resHistPush`/`_resHistWindow`) — 방문객 질문 + 각 주민 답을 who와 함께 기록, 채팅 NPC 전환 시 리셋.
- `_aiPlayerChat(res,q,opts)` — `last`(직전 스레드)·`chime`/`prev`(직전 화자)를 payload로 전송.
- `residentSay` — 히스토리 스냅샷 후 질문+답 기록 (단일 주민도 멀티턴).
- **`groupSay` 재작성 (핵심)** — 두 번째 주민이 `_scriptLine` 대신 **같은 질문에** 답합니다. AI on이면 직전 주인공 답을 컨텍스트로 받아 이어서 반응, AI off/실패면 `residentReply`(who/why/repo/here/bye 분기)로 fallback. 무작위 잡담 제거.
- `?dbg` `__resTranscript()` 추가, `__groupChat()`에 hist 길이 노출.

**cloudflare-taxi/src/grounded.js (워커)**
- `npcPlayerPrompt` 강화 — 방문객의 최근 질문에 먼저 직접 답하고 화제를 돌리지 마라; chime이면 직전 화자에 이어(동의·보완·다른 시각) 반응하라.
- `npcPlayerUser` 신규 — who 라벨 붙은 최근 턴을 질문 앞에 폴드.
- user cap을 role별로(player 1500) 조정. **하위호환**: `last` 없으면 기존 동작 그대로.

## 컨텍스트 윈도우
클라 12턴 유지 → 10턴 전송(스칼라 8턴보다 길게), 워커 8턴 폴드. 두 번째 화자는 여기에 주인공의 방금 답까지 더해 받음.

## 검증
- `node scripts/smoke.mjs` **248** GREEN · `node council/test.mjs` **130** · `node council/test-live.mjs` **56** · `node --check` (module + grounded.js).
- 로컬 데스크톱 + 모바일 390×844 (AI-off fallback): 두 주민 모두 질문(구역·레포 의도)에 붙어서 답함, 라운드로빈 회전, 멀티턴 트랜스크립트 누적, **콘솔 에러 0**.
- 프로덕션 워커(`repolis-taxi`, Version `c3146882`) 배포 완료 후 실측: chime 호출 시 nari가 앞 화자(노아)의 벤치·정원 언급에 이어 *"조금 더 그늘진 벤치와, 조용히 머물 새싹들이요…"* 로 질문에 답함.

## 보존
예산/env AI 게이팅, 1메시지=1 AI콜 상한, `_cap180`, `esc()`/textContent XSS 안전, 숨긴탭 정지, pair/guest 쿨다운, 라운드로빈 턴, LOW_END 이동, ambient 엔진(`_scriptLine`은 잡담용으로 유지). CHANGELOG `[1.58.0]`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>