### PR TITLE
feat: graceful goodbyes — the circle waves you off, and no gathering is a trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.64.0] — 2026-07-09
+
+### 👋 Graceful goodbyes — the circle waves you off, and no gathering is a trap
+- **What's new.** Conversations now have a natural *ending*, not just a beginning. Say goodbye — **"잘 가"**, **"고마웠어요"**, **"see you"** — and the residents wave you off with a warm farewell (**"살펴 가요 — 또 들러요!"**, **"또 봐요, 반가웠어요!"**), then the chat **gently closes** and the circle disperses back into town life. It's the missing other half of the social loop (we could grow a gathering with invites; now it can end warmly too).
+- **A circle is never a trap.** After a few turns in a group of 3+, a non-primary resident may **excuse themselves** and drift off (**"나 이만 가볼게요, 또 얘기해요!"**) — they wave, leave the header, and resume wandering on their own. The lead is handed on if the primary leaves, and a circle never shrinks below two, so the conversation always holds together.
+- **How it works.** A farewell detector (`_RES_BYE_CUE`) runs first in both `groupSay` and `residentSay`; the group path has up to two members say goodbye + everyone waves, then `closeChat()` (which releases the group) fires after a short beat. `_residentLeave` removes a member in place, reassigns the primary/turn index, refreshes the header, and lets them wander off (no longer chatBound). Purely scripted, **zero AI / zero budget**; works fully AI-off.
+- **Preserved.** Every earlier layer (returning-visitor warmth, campfire 쉼터, repo reactions, invite-a-resident, the circle waving you over, context-aware group chat), budget/env gating, hidden-tab stop, cooldowns. Client-only — no worker change.
+- **Debug.** `?dbg` adds `window.__farewell(q)` / `window.__byeMatch(q)` (drive + introspect the goodbye) and `window.__leaveGroup(id)` (force a member to excuse themselves).
+
 ## [1.63.0] — 2026-07-08
 
 ### 🪪 The town remembers you — a warmer welcome for a familiar face

--- a/index.html
+++ b/index.html
@@ -4758,6 +4758,7 @@ function residentReply(res,q){ const ql=String(q||'').toLowerCase().trim(), ko=L
   const g=residentGreet(res), cnt=z.repos.length;
   return { html: (g?g+' ':'')+esc(ko?`여기는 ${zn}, ${L.role}로서 제가 돌보는 곳이에요. 레포 ${cnt}채가 있어요.`:`This is ${zn}, my patch as the ${L.role}. ${cnt} repo-houses stand here.`) }; }
 async function residentSay(q){ const res=activeNpc&&activeNpc.res; if(!res) return; _guestCdUntil=clock.elapsedTime + NPC_CFG.guestCooldownSec;
+  if(await _maybeFarewell(q)) return;                                                            // "잘 가요" → a warm goodbye + wave, and the chat gently closes
   if(await _maybeInvite(q)) return;                                                            // name another resident (with an invite cue) → this 1:1 grows into a 모임 they both join
   const last=_resHistWindow(); _resHistPush('visitor',q);                                     // record the question after snapshotting the prior thread (the worker appends it as the ask)
   const useAI = NPC_CFG.aiEnabled && NPC_CFG.playerChatAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
@@ -4828,8 +4829,35 @@ async function _maybeInvite(q){ const cand=_inviteTarget(q); if(!cand) return fa
   await new Promise(r=>setTimeout(r,480)); if(!activeGroupMembers) return true;                    // chat closed mid-invite
   const g=_inviteGreetLine(cand); addMsg('bot',_groupChip(cand)+esc(g)); _resHistPush(cand.id,g);
   trackChatEvent('npc_group_invite',{id:cand.id,size:(activeGroupMembers||[]).length,from:wasGroup?'group':'solo'}); return true; }
+// ---- graceful goodbyes: say "잘 가" and the circle waves you off + gently parts; and after a while a resident may excuse themselves, so a gathering is never a trap ----
+const _RES_BYE_CUE=/(잘\s*가|잘\s*있|안녕히|또\s*(봐|만나|와|보|뵈)|다음에|이만|가\s*볼게|갈게|들어가|수고|고마웠|즐거웠|bye|goodbye|see\s*you|see\s*ya|later|farewell|take\s*care|gotta\s*go)/i;
+function _farewellLine(res){ const ko=LANG==='ko', b= ko?['살펴 가요 — 또 들러요!','잘 가요, 오늘 즐거웠어요!','다음에 또 얘기해요!','조심히 가요. 여긴 늘 여기 있을게요.','또 봐요, 반가웠어요!']
+                                        :['Take care — come by again!','Bye for now, this was lovely!',"Let's talk again soon!",'Safe travels — we\u2019ll be right here.','See you around!'];
+  return b[(Math.random()*b.length)|0]; }
+function _leaveLine(res){ const ko=LANG==='ko', b= ko?['나 이만 가볼게요, 또 얘기해요!','저는 슬슬 가봐야겠어요. 즐거웠어요!','먼저 일어날게요 — 다음에 또!','저쪽 좀 둘러보고 올게요.']
+                                     :['I should head off — let\u2019s talk again!','I\u2019ll slip away now, this was fun!','Gonna get going — catch you later!','I\u2019ll go look around over there.'];
+  return b[(Math.random()*b.length)|0]; }
+function _residentLeave(L){ const wrap=activeNpc; if(!wrap||!wrap.group||!activeGroupMembers||activeGroupMembers.length<=2||!L) return false;   // never shrink a circle below 2
+  const res=L.res; wrap.live=wrap.live.filter(m=>m!==L); wrap.members=wrap.members.filter(r=>r!==res); activeGroupMembers=wrap.live.slice();
+  if(wrap.res===res && wrap.live[0]) wrap.res=wrap.live[0].res;                                   // if the primary left, hand the lead to someone still here
+  wrap.gi=(wrap.gi||0)%Math.max(1,wrap.live.length); applyNpcChrome(wrap);
+  L._gt=2.6; L._rt=null; L._rp=clock.elapsedTime; L._greetCd=clock.elapsedTime+RES_GREET_CD_MIN;   // a wave, then (no longer chatBound) they wander off on their own
+  _resCd.set(res.id, clock.elapsedTime+10+Math.random()*8); return true; }
+async function _maybeFarewell(q){ if(!_RES_BYE_CUE.test(String(q||''))) return false;
+  const wrap=activeNpc; if(!wrap||!wrap.resident) return false; _resHistPush('visitor',q);
+  const ms=(activeGroupMembers||[]).filter(m=>m&&m.res);
+  if(wrap.group && ms.length){                                                                   // the whole circle says goodbye, waves, then gently parts
+    const speakers=ms.slice(0, Math.min(2, ms.length));
+    for(let i=0;i<speakers.length;i++){ if(i){ await new Promise(r=>setTimeout(r,460)); if(!activeGroupMembers) return true; }
+      const L=speakers[i], line=_farewellLine(L.res); addMsg('bot',_groupChip(L.res)+esc(line)); _resHistPush(L.res.id,_plain(line)); L._gt=2.6; }
+    for(const m of ms) m._gt=2.6; trackChatEvent('npc_group_farewell',{size:ms.length});
+    setTimeout(()=>{ try{ closeChat(); }catch(e){} }, 1500); return true; }
+  const res=wrap.res; if(res&&res._live){ const line=_farewellLine(res); addMsg('bot',esc(line)); _resHistPush(res.id,_plain(line)); res._live._gt=2.6;
+    trackChatEvent('npc_resident_farewell',{id:res.id}); setTimeout(()=>{ try{ closeChat(); }catch(e){} }, 1400); return true; }
+  return false; }
 async function groupSay(q){ const wrap=activeNpc, ms=((wrap&&wrap.live)||[]).filter(m=>m&&m.res); if(!ms.length){ await residentSay(q); return; }
   _guestCdUntil=clock.elapsedTime+NPC_CFG.guestCooldownSec;
+  if(await _maybeFarewell(q)) return;                                                            // "잘 가!" → the circle waves you off and gently parts
   if(await _maybeInvite(q)) return;                                                              // "린도 부를까?" → the named resident walks in and joins the circle
 
   const useAI=NPC_CFG.aiEnabled && NPC_CFG.playerChatAiEnabled && !_budgetExhausted() && NPC_CFG.worker;
@@ -4846,6 +4874,10 @@ async function groupSay(q){ const wrap=activeNpc, ms=((wrap&&wrap.live)||[]).fil
       if(useAI){ try{ const line=await _aiPlayerChat(other,q,{last:ctx,chime:true,prev:pres.id}); if(line) chime=_cap180(line); }catch(e){} }
       if(!chime){ const r2=residentReply(other,q); chime=_plain(r2.html); }
       addMsg('bot',_groupChip(other)+esc(chime)); _resHistPush(other.id,chime); } }
+  if(ms.length>2 && (wrap.gi||0)>=3 && activeGroupMembers && activeGroupMembers.length>2 && Math.random()<0.22){   // after a few turns, someone may drift off — a circle is never a trap
+    await new Promise(r=>setTimeout(r,560));
+    if(activeGroupMembers && activeGroupMembers.length>2){ const leaver=ms.find(m=>m.res!==pres && activeGroupMembers.indexOf(m)>=0);
+      if(leaver){ const bye=_leaveLine(leaver.res); addMsg('bot',_groupChip(leaver.res)+esc(bye)); _resHistPush(leaver.res.id,_plain(bye)); _residentLeave(leaver); } } }
   wrap.gi=(wrap.gi||0)+1; trackChatEvent('npc_player_chat',{npc:'group',size:ms.length,ai:useAI&&!!mainLine}); }
 
 // ---- boot: best-effort worker config (learn runtime toggles + budget); unreachable → stay scripted ----
@@ -6874,6 +6906,11 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     const ok=_inviteResident(res); if(ok){ const g=_inviteGreetLine(res); addMsg('bot',_groupChip(res)+esc(g)); _resHistPush(res.id,g); }
     return { ok, joined:id, walking:!!res._live._joinWalk, members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):null, title:chatHeadTtl?chatHeadTtl.textContent:null }; };
   window.__inviteMatch=(q)=>{ const c=_inviteTarget(q); return { cue:_RES_INV_CUE.test(String(q||'')), match:c?c.id:null }; };   // introspect the name+cue detector without side effects
+  window.__farewell=(q)=>{ const handled=_RES_BYE_CUE.test(String(q||'잘 가')); if(handled) _maybeFarewell(q||'잘 가'); return { bye:handled, members:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):null }; };   // 👋 force / test the goodbye flow (waves + gentle close)
+  window.__byeMatch=(q)=>_RES_BYE_CUE.test(String(q||''));   // introspect the farewell detector without side effects
+  window.__leaveGroup=(id)=>{ const L=id?RESIDENTS_LIVE.find(x=>x.res.id===id):(activeGroupMembers&&activeGroupMembers[activeGroupMembers.length-1]); if(!L) return { ok:false, reason:'no member' };   // force one member to excuse themselves and wander off
+    const before=activeGroupMembers?activeGroupMembers.map(m=>m.res.id):null; const ok=_residentLeave(L);
+    return { ok, left:ok?L.res.id:null, before, after:activeGroupMembers?activeGroupMembers.map(m=>m.res.id):null, title:chatHeadTtl?chatHeadTtl.textContent:null }; };
   window.__npcBudget=()=>({ ...JSON.parse(JSON.stringify(_npcBudget)), low:_budgetLow(), exhausted:_budgetExhausted() });
   window.__npcTranscript=()=>_npcTranscript.slice(-20);
   window.__npcSim=(o)=>{ o=o||{}; ['remainingUsd','spentUsd','turnsToday','dailyTurnMax','dayCapUsd'].forEach(k=>{ if(typeof o[k]==='number') _npcBudget[k]=o[k]; });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -521,6 +521,15 @@ ok(/function _welcomeBackLine\(\)\{/.test(npcBlock) && /n>=5\?/.test(npcBlock) &
 ok(/const rb=VISITOR\.returning; if\(rb\)\{ setTimeout\(\(\)=>\{ try\{ showWave\(_welcomeBackLine\(\),3600\)/.test(HTML) && /}, ?rb\?4700:1000\)/.test(HTML), 'entering town shows the welcome-back toast first, and defers the daily-course banner so the two never clash');
 ok(/window\.__visitor=\(\)=>/.test(HTML) && /window\.__setVisitor=\(o\)=>/.test(HTML) && /window\.__welcomeBack=\(\)=>/.test(HTML), '?dbg __visitor/__setVisitor/__welcomeBack read + preview the returning-visitor warmth without a reload');
 
+group('graceful goodbyes — the circle waves you off, and no gathering is a trap');
+ok(/const _RES_BYE_CUE=\/\(잘\\s\*가/.test(npcBlock) && /function _farewellLine\(res\)/.test(npcBlock), 'a farewell detector + warm goodbye bank back the "say bye and they wave you off" flow');
+ok(/async function _maybeFarewell\(q\)\{ if\(!_RES_BYE_CUE\.test/.test(npcBlock) && /setTimeout\(\(\)=>\{ try\{ closeChat\(\); \}catch\(e\)\{\} \}, ?1500\)/.test(npcBlock), 'a goodbye makes the circle say farewell + wave, then the chat gently closes (closeChat releases the group)');
+ok(/async function groupSay\(q\)\{[\s\S]*?if\(await _maybeFarewell\(q\)\) return;/.test(npcBlock) && /async function residentSay\(q\)\{[\s\S]*?if\(await _maybeFarewell\(q\)\) return;/.test(npcBlock), 'both groupSay and residentSay honour a goodbye before anything else');
+ok(/function _residentLeave\(L\)\{ const wrap=activeNpc; if\(!wrap\|\|!wrap\.group\|\|!activeGroupMembers\|\|activeGroupMembers\.length<=2/.test(npcBlock), '_residentLeave never shrinks a circle below 2, and hands the lead on if the primary leaves');
+ok(/if\(ms\.length>2 && \(wrap\.gi\|\|0\)>=3 && activeGroupMembers && activeGroupMembers\.length>2 && Math\.random\(\)<0\.22\)/.test(npcBlock) && /_residentLeave\(leaver\)/.test(npcBlock), 'after a few turns in a 3+ circle, a non-primary resident may excuse themselves and wander off');
+ok(/L\._gt=2\.6; L\._rt=null; L\._rp=clock\.elapsedTime;/.test(npcBlock), 'a leaving resident waves, then (no longer chatBound) resumes wandering on their own');
+ok(/window\.__farewell=\(q\)=>/.test(HTML) && /window\.__byeMatch=\(q\)=>/.test(HTML) && /window\.__leaveGroup=\(id\)=>/.test(HTML), '?dbg __farewell/__byeMatch/__leaveGroup drive + introspect the goodbye and member-leave flows');
+
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');
 if (fail) { console.log('\nFailures:'); fails.forEach(f => console.log('  - ' + f)); }


### PR DESCRIPTION
## What & why

The missing other half of the social loop. We could **grow** a gathering (invites, a circle waving you over); now a conversation can also **end warmly**. Say goodbye and the residents wave you off, then the chat gently closes — and a circle is never a trap, because a resident can excuse themselves after a while.

## How

- **Farewell (`_RES_BYE_CUE` + `_maybeFarewell`).** Runs *first* in both `groupSay` and `residentSay`. On a goodbye (**잘 가 / 고마웠어요 / bye / see you / …**): the group path has up to two members say a warm farewell (**"살펴 가요 — 또 들러요!"**) and everyone waves, then `closeChat()` (which releases the group back to town life) fires after a short beat. The 1:1 path mirrors it.
- **A circle is never a trap (`_residentLeave`, Part B).** After a few turns in a 3+ group, a non-primary resident may excuse themselves (**"나 이만 가볼게요, 또 얘기해요!"**) — they wave, are removed from the header in place, the lead is handed on if the primary leaves, the group **never shrinks below two**, and they resume wandering (no longer chatBound).
- Purely scripted, **zero AI / zero budget**; works fully AI-off. Client-only.

## Verification

- `node scripts/smoke.mjs` → **295** (+7), council 130, live 56, scholars/grounded/module `node --check` OK.
- **Browser (`?dbg=1`, AI-off), desktop + mobile 390×844:** the bye detector matches goodbyes and *not* invites/questions; sending "잘 가!" in a 3-member circle → 노아 + 카이 farewell + wave, then the **chat closes and the group releases**; a 1:1 "고마웠어요, 잘 있어요!" → 솔 farewell then close; `__leaveGroup()` shrinks a 4-circle (header updates each time) and is **refused at 2**; mobile farewell + close works; **0 console errors**. App/emulation/server cleaned up after testing.

Files: `index.html`, `scripts/smoke.mjs`, `CHANGELOG.md` (1.64.0). No worker/data/secret changes. Debug: `__farewell`, `__byeMatch`, `__leaveGroup`.