### PR TITLE
docs: surface the daily self-refresh as a maintenance-signal badge

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -8,6 +8,7 @@
 
 [![라이브 데모](https://img.shields.io/badge/Live%20demo-Repolis-4fb4c2?style=for-the-badge&logo=googlechrome&logoColor=white)](https://hyeonsangjeon.github.io/Repolis/)
 [![Pages](https://img.shields.io/github/deployments/hyeonsangjeon/Repolis/github-pages?style=for-the-badge&label=Pages&logo=githubpages&logoColor=white)](https://hyeonsangjeon.github.io/Repolis/)
+[![매일 갱신](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=for-the-badge&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=for-the-badge&logo=three.js&logoColor=white)](https://threejs.org)
 [![Single file](https://img.shields.io/badge/build-single%20index.html-83bb59?style=for-the-badge)](index.html)
 [![Last commit](https://img.shields.io/github/last-commit/hyeonsangjeon/Repolis?style=for-the-badge&color=b3a07f)](https://github.com/hyeonsangjeon/Repolis/commits)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Live demo](https://img.shields.io/badge/Live%20demo-Repolis-4fb4c2?style=for-the-badge&logo=googlechrome&logoColor=white)](https://hyeonsangjeon.github.io/Repolis/)
 [![Pages](https://img.shields.io/github/deployments/hyeonsangjeon/Repolis/github-pages?style=for-the-badge&label=Pages&logo=githubpages&logoColor=white)](https://hyeonsangjeon.github.io/Repolis/)
+[![Daily refresh](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=for-the-badge&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=for-the-badge&logo=three.js&logoColor=white)](https://threejs.org)
 [![Single file](https://img.shields.io/badge/build-single%20index.html-83bb59?style=for-the-badge)](index.html)
 [![Last commit](https://img.shields.io/github/last-commit/hyeonsangjeon/Repolis?style=for-the-badge&color=b3a07f)](https://github.com/hyeonsangjeon/Repolis/commits)


### PR DESCRIPTION
## What & why

Follow-up to a GitHub-traffic daily brief suggesting **README first-screen conversion** work. On review, that work is **already done** — both READMEs already open with a one-line value prop, 7 badges (Live demo · Pages · Three.js · single-file · last-commit · stars · MIT), the demo GIF, a **"Start here →/여기서 시작 →"** block with all three CTAs (Live demo · Run locally · Fork), and a no-build quickstart. So this is deliberately a **minimal, one-badge** change rather than a rewrite.

The single acceptance-criterion item not yet surfaced is a **maintenance/automation signal** — and Repolis's signature one is that **the city rebuilds itself daily from live traffic**. This adds a `daily refresh` GitHub-Actions status badge (for the `Refresh Repolis data` workflow) right next to the Pages badge, in `README.md` and `README.ko.md`.

- The workflow has passed **12+ consecutive days** (verified via `gh run list`), and the shields endpoint currently resolves to `build: passing` — so the badge is a **green, positive** trust signal, not a risk.
- It's the most on-brand maintenance signal for this project (a self-updating city), reinforcing the clone/star conversion the brief is about.

## Not done (reasoned no-op)

The brief's other suggestions (value prop, 3-step quickstart, demo/output, CTAs, run command) are already present and in EN/KO parity, so no changes there. No app/data/secret changes.

## Verification

- Badge endpoint resolves (`build: passing`); links point to the workflow's Actions page. `node scripts/smoke.mjs` → **295** green (index.html untouched). EN/KO symmetric (one badge line each). Docs-only.

Files: `README.md`, `README.ko.md` (+1 line each).