### PR TITLE
feat: every resident has a cherished haunt (아지트) they visit and love

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.66.0] — 2026-07-10
+
+### 🏞️ Every resident has a cherished haunt (아지트) they visit and love
+- **What's new.** Repolis is now a place its residents genuinely *love* — each of the eight has a **favourite spot that fits who they are**, and now and then they'll **slip off to it, linger a while, and speak of it fondly**. Sol has *a sunny spot to tinker*, Jun *the harbour edge where the water laps*, Nari *the alley where the flowers bloom thickest*, Tae *a quiet corner nobody visits*, Rin *the library steps*, Mira *the ruin-hill with the best sunset*, Kai *the heart of the plaza*, and Noa's haunt is **the campfire under the stars** itself.
+- **How it feels.** While wandering, a resident occasionally (cooldown-gated) heads for their own haunt instead of a random waypoint, settles there a beat longer than usual, and lets a fond word slip — *"별이 잘 보이는 모닥불 곁, 여기가 참 좋아요."*, *"틈날 때마다 도서관 계단에 와요."* — hushed, as ever, when the visitor is right beside them (a greeting takes precedence).
+- **How it works.** Each haunt is a **stable, cached spot** resolved once from the resident's persona (Noa's ties to the live `HEARTH`; the rest get a distinctive in-zone point, so the descriptor always matches the place). Purely scripted, **zero AI / zero budget**; it rides the existing wander/roam loop, so it's suspended during a chat, the festival, or a hidden tab, and never fights the bench-rest or campfire behaviours.
+- **Preserved.** Every earlier layer (festival, graceful goodbyes, returning-visitor warmth, campfire 쉼터, repo reactions, invite-a-resident, the circle waving you over, group chat), budget/env gating, hidden-tab stop. Client-only — no worker change.
+- **Debug.** `?dbg` adds `window.__favs()` (every resident's haunt + descriptor + current distance) and `window.__goFav(id)` (send one to their haunt now).
+
 ## [1.65.1] — 2026-07-09
 
 ### 🗣️ Fix: two residents from the same district no longer give near-identical answers

--- a/index.html
+++ b/index.html
@@ -4514,6 +4514,22 @@ const _RES_COMFORT={ ko:['여기 앉아 있으면 마음이 놓여요.','이 마
 const _RES_HEARTH_LINES={ ko:['불 옆이 참 따뜻해요 — 데이터로 지어진 저한테도요.','밤엔 이 모닥불 곁이 제일 포근해요.','불빛을 보고 있으면 마음이 잔잔해져요.','불가에 앉으면 하루가 스르르 풀려요.','우리한테 이런 쉼터를 내어줘서 고마워요.'],
                           en:["The fire is so warm — even to something made of data.","At night, beside this campfire is the cosiest spot.","Watching the flames, my mind goes quiet.","By the fire, the whole day just unwinds.","Thank you for giving us a warm place like this."] };
 function _resComfortLine(L){ const hearth=L._rest&&L._rest.seat&&L._rest.seat._hearth; const bank=hearth?(_RES_HEARTH_LINES[LANG]||_RES_HEARTH_LINES.ko):(_RES_COMFORT[LANG]||_RES_COMFORT.ko); return bank[(Math.random()*bank.length)|0]; }
+// 🏞️ each resident has a cherished spot — a little haunt (아지트) that fits who they are; now and then they stroll there, linger, and speak of it fondly
+const _RES_FAV={ sol:{ko:'볕 잘 드는 실험 자리',en:'a sunny spot to tinker'}, jun:{ko:'물결 소리 들리는 항구 끝',en:'the harbour edge where the water laps'},
+  nari:{ko:'꽃이 제일 많이 핀 골목',en:'the alley where the flowers bloom thickest'}, tae:{ko:'아무도 안 오는 조용한 구석',en:'a quiet corner nobody visits'},
+  rin:{ko:'도서관 계단',en:'the library steps'}, mira:{ko:'노을이 제일 고운 폐허 언덕',en:'the ruin-hill with the best sunset'},
+  kai:{ko:'광장 한복판',en:'the heart of the plaza'}, noa:{ko:'별이 잘 보이는 모닥불 곁',en:'the campfire under the stars'} };
+function _resFavSpot(L){ if(L._fav) return L._fav; const F=_RES_FAV[L.res.id]; if(!F) return null; let x, z;
+  if(L.res.id==='noa' && typeof HEARTH!=='undefined' && HEARTH){ x=HEARTH.x-2.6; z=HEARTH.z; }             // noa's haunt is the campfire itself
+  else { const h=L.home; let got=null;                                                                     // a stable, distinctive spot a little way from home (homes sit in-zone, so it fits the descriptor)
+    for(let k=0;k<12;k++){ const a=(k*Math.PI/6)+(L._ph||0), r=8+(k%3)*2.5, nx=h.x+Math.cos(a)*r, nz=h.z+Math.sin(a)*r;
+      if(nx*nx+nz*nz<400 || Math.hypot(nx,nz)>206 || _hubGap(nx,nz)<4.0) continue; got={x:nx,z:nz}; break; }
+    if(got){ x=got.x; z=got.z; } else { x=h.x+7; z=h.z; } }
+  L._fav={ x:+x.toFixed(2), z:+z.toFixed(2), ko:F.ko, en:F.en }; return L._fav; }
+function _resFavLine(L){ const f=L._fav, d=f?(LANG==='ko'?f.ko:f.en):'', ko=LANG==='ko';
+  const b = ko?[`${d} — 여기가 제 아지트예요.`, '여기가 제가 제일 좋아하는 자리예요.', `틈날 때마다 ${d}에 와요.`, `${d}에 있으면 마음이 놓여요.`, `${d}, 여기가 참 좋아요.`]
+             :[`${d} — this is my little haunt.`, 'This is my favourite spot in town.', `I slip off to ${d} whenever I can.`, `At ${d}, I feel at ease.`, `${d} — I do love this place.`];
+  return b[(Math.random()*b.length)|0]; }
 function _residentSpot(res){
   if(res.zone==='plaza'){ const cands=[[-8,6],[-6,-8],[8,-8],[-10,-2],[9,5],[0,-11],[11,-4],[-11,3],[4,10],[-3,-11]];   // extra spots so two plaza folk (Kai + Noa) don't stack
     for(const p of cands){ if(_hubGap(p[0],p[1])<4.0) continue;
@@ -4726,9 +4742,15 @@ function updateResidents(dt){ if(!RESIDENTS_LIVE.length) return; const tt=clock.
       if(L._rest && L._rest.phase==='goto'){   // strolling over to the chosen bench, then sit
         if(_resWalk(L,L._rest.seat.x,L._rest.seat.z,L._wspd,dt)){ L._rest.phase='sit'; L._rest.until=tt+RES_MOVE.restMin+Math.random()*(RES_MOVE.restMax-RES_MOVE.restMin); _resSit(L,L._rest.seat); L.bub.update(dt); continue; } else moving=true;
       } else {
-        if(!L._rt && tt>=L._rp){ const s=(Math.random()<RES_MOVE.restChance)?_freeSeat(L):null;
-          if(s){ s._occ=L; L._rest={ seat:s, phase:'goto', until:0 }; } else L._rt=_resRoamTarget(L); }
-        if(L._rt){ if(_resWalk(L,L._rt.x,L._rt.z,L._wspd,dt)){ L._rt=null; L._rp=tt+RES_MOVE.pauseMin+Math.random()*(RES_MOVE.pauseMax-RES_MOVE.pauseMin); } else moving=true; } } }
+        if(!L._rt && tt>=L._rp){
+          if(tt>=(L._favCd||0) && Math.random()<0.3){ const f=_resFavSpot(L);   // now and then, slip off to your own cherished haunt
+            if(f){ L._rt={x:f.x,z:f.z}; L._toFav=true; L._favCd=tt+42+Math.random()*44; } else L._rt=_resRoamTarget(L); }
+          else { const s=(Math.random()<RES_MOVE.restChance)?_freeSeat(L):null;
+            if(s){ s._occ=L; L._rest={ seat:s, phase:'goto', until:0 }; } else L._rt=_resRoamTarget(L); } }
+        if(L._rt){ if(_resWalk(L,L._rt.x,L._rt.z,L._wspd,dt)){ L._rt=null;
+            if(L._toFav){ L._toFav=false; L._rp=tt+RES_MOVE.pauseMin*1.8+Math.random()*4;   // linger at the haunt + an occasional fond word about it
+              if(!L._pNear && tt>=(L._favSayCd||0)){ L._favSayCd=tt+34+Math.random()*30; L.bub.say(_resFavLine(L), _hex(L.res.color)); L._gt=1.8; } }
+            else L._rp=tt+RES_MOVE.pauseMin+Math.random()*(RES_MOVE.pauseMax-RES_MOVE.pauseMin); } else moving=true; } } }
     if(moving){ if(L._gt>0) L._gt-=dt; if(g._armL) g._armL.rotation.z*=0.85; if(g._armR) g._armR.rotation.z*=0.85; L.bub.update(dt); continue; }
     // a quiet solo flourish now and then — only when idle, alone, not mid-gesture and the visitor isn't right here (greeting takes precedence). Ambient town life, low frequency.
     if(!_festival && !inConv && !chatBound && !L._pNear && L._gt<=0 && tt>=L._emoteCd){
@@ -6901,6 +6923,9 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     if(!L) return { ok:false }; const seat=SEATS.find(s=>s._hearth&&!s._occ)||SEATS.find(s=>!s._occ); if(seat){ seat._occ=L; L._rest={ seat, phase:'sit', until:clock.elapsedTime+8 }; _resSit(L,seat); }
     const line=_resComfortLine(L); L.bub.say(line, _hex(L.res.color)); L._gt=2.2; L._comfortCd=clock.elapsedTime+RES_COMFORT_CD_MIN;
     return { ok:true, who:L.res.id, hearthSeat:!!(seat&&seat._hearth), line }; };
+  window.__favs=()=>RESIDENTS_LIVE.map(L=>{ const f=_resFavSpot(L); return { id:L.res.id, spot:f?[f.x,f.z]:null, place:f?(LANG==='ko'?f.ko:f.en):null, atFav:f?+Math.hypot(L.group.position.x-f.x,L.group.position.z-f.z).toFixed(1):null }; });   // 🏞️ each resident's cherished haunt
+  window.__goFav=(id)=>{ const L=id?RESIDENTS_LIVE.find(x=>x.res.id===id):RESIDENTS_LIVE[0]; if(!L) return { ok:false }; const f=_resFavSpot(L); if(!f) return { ok:false };   // send a resident to their haunt now (bypasses the cooldown)
+    if(L._rest) _seatRelease(L); L._rt={x:f.x,z:f.z}; L._toFav=true; L._favCd=0; L._favSayCd=0; return { ok:true, id:L.res.id, spot:[f.x,f.z], place:LANG==='ko'?f.ko:f.en, line:_resFavLine(L) }; };
   window.__greet=(id)=>{ const L=id?RESIDENTS_LIVE.find(x=>x.res.id===id):RESIDENTS_LIVE.slice().sort((a,b)=>player.position.distanceTo(a.group.position)-player.position.distanceTo(b.group.position))[0];
     if(!L) return null; if(_resChatActive()&&activeNpc&&activeNpc.res===L.res) return { who:L.res.id, skipped:'chatBound' };   // never paint a greeting over a resident the visitor is mid-chat with
     L.bub.say(_resGreetLine(L.res), _hex(L.res.color)); L._gt=2.6; L._greetCd=clock.elapsedTime+RES_GREET_CD_MIN+Math.random()*(RES_GREET_CD_MAX-RES_GREET_CD_MIN);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -540,6 +540,14 @@ ok(/if\(inConv\|\|chatBound\|\|_festival\)\{ _resStand\(L\); _seatRelease\(L\); 
 ok(/function _endFestival\(\)\{ if\(!_festival\) return; _festival=null;/.test(npcBlock) && /_festivalTick\(tt\); ?_ambientTick\(\);/.test(npcBlock), 'the festival ends cleanly (residents drift home) and is ticked every frame from updateResidents');
 ok(/window\.__festival=\(repo\)=>/.test(HTML) && /window\.__festState=\(\)=>/.test(HTML) && /window\.__endFestival=\(\)=>/.test(HTML), '?dbg __festival/__festState/__endFestival force + introspect + end the celebration');
 
+group('every resident has a cherished haunt (아지트) they visit and love');
+ok(/const _RES_FAV=\{ sol:\{ko:'볕 잘 드는 실험 자리'/.test(npcBlock) && /noa:\{ko:'별이 잘 보이는 모닥불 곁'/.test(npcBlock), 'each of the eight residents has a persona-fitting favourite place');
+ok(/function _resFavSpot\(L\)\{ if\(L\._fav\) return L\._fav;/.test(npcBlock) && /if\(L\.res\.id==='noa' && typeof HEARTH!=='undefined' && HEARTH\)/.test(npcBlock), '_resFavSpot resolves a stable, cached haunt (noa\'s is the campfire; others get a distinctive in-zone spot)');
+ok(/function _resFavLine\(L\)\{ const f=L\._fav, ?d=f\?\(LANG==='ko'\?f\.ko:f\.en\):''/.test(npcBlock), '_resFavLine speaks fondly of that spot, weaving in its descriptor');
+ok(/if\(tt>=\(L\._favCd\|\|0\) && Math\.random\(\)<0\.3\)\{ const f=_resFavSpot\(L\);/.test(npcBlock) && /L\._toFav=true; L\._favCd=tt\+42\+Math\.random\(\)\*44;/.test(npcBlock), 'now and then (cooldown-gated) a wandering resident heads for their haunt instead of a random waypoint');
+ok(/if\(L\._toFav\)\{ L\._toFav=false; L\._rp=tt\+RES_MOVE\.pauseMin\*1\.8\+Math\.random\(\)\*4;/.test(npcBlock) && /_resFavLine\(L\)/.test(npcBlock), 'on arrival they linger longer at the haunt and let an occasional fond word slip (hushed when the visitor is right there)');
+ok(/window\.__favs=\(\)=>/.test(HTML) && /window\.__goFav=\(id\)=>/.test(HTML), '?dbg __favs/__goFav list + drive each resident to their cherished haunt');
+
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');
 if (fail) { console.log('\nFailures:'); fails.forEach(f => console.log('  - ' + f)); }


### PR DESCRIPTION
## What & why

You asked to make the town **a space the residents genuinely like**. Each of the eight residents now has a **cherished haunt (아지트)** that fits who they are, and now and then they'll **slip off to it, linger, and speak of it fondly** — so the town feels loved and lived-in, with each resident having a personal relationship to a place.

- Sol → *a sunny spot to tinker*, Jun → *the harbour edge where the water laps*, Nari → *the alley where the flowers bloom thickest*, Tae → *a quiet corner nobody visits*, Rin → *the library steps*, Mira → *the ruin-hill with the best sunset*, Kai → *the heart of the plaza*, Noa → **the campfire under the stars** itself.

## How

- **`_RES_FAV` + `_resFavSpot(L)` + `_resFavLine(L)`.** Each haunt is a **stable, cached** spot resolved once from persona — Noa's ties to the live `HEARTH`; the rest get a distinctive in-zone point (homes sit in-zone, so the descriptor always matches the place). The fond line weaves in the descriptor (*"틈날 때마다 도서관 계단에 와요."*).
- **Wander bias (in `updateResidents`).** While roaming, a resident occasionally (cooldown-gated) heads for their haunt instead of a random waypoint (`_toFav`), then on arrival **lingers a beat longer** and lets a fond word slip — **hushed when the visitor is right there** (a greeting takes precedence).
- Purely scripted, **zero AI / zero budget**. Rides the existing roam loop, so it's suspended during a chat, the festival, or a hidden tab, and never fights bench-rest / campfire behaviours. Client-only.

## Verification

- `node scripts/smoke.mjs` → **309** (+6), council 130, live 56, scholars/grounded/module `node --check` OK.
- **Browser (`?dbg=1`), desktop + mobile 390×844:** `__favs()` lists all 8 haunts with persona-fitting descriptors + coords (Noa's at the campfire [-2.6, 10.5]); `__goFav('sol')` → sol walks to their haunt (dist 7.7→3.3, `toFav:true`), and on arrival `toFav` clears + the fond line fires (`_favSayCd` armed); screenshot shows **노아 (광장 몽상가) standing at their campfire haunt**; mobile `__goFav('rin')` → rin moves toward the library steps; **0 console errors**. App/emulation/server cleaned up after testing.

Files: `index.html`, `scripts/smoke.mjs`, `CHANGELOG.md` (1.66.0). No worker/data/secret changes. Debug: `__favs`, `__goFav`.