### PR TITLE
feat: add luminous World Tree DNA foliage [1.75.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.75.0] — 2026-07-11
+
+### ✨ The World Tree earns luminous leaf texture through a controlled Sculpt DNA variant
+- **Sculpt DNA, not ad-hoc randomization.** The strict 1.74 `ObjectSculptSpec` was initialized with the `sculpt-dna-variants` skill and reduced to five designer-facing axes: canopy fullness, leaf surface richness, emerald palette, leaf sheen, and gold warmth. Six deterministic variants were generated from root seed `1740`; every constraint and protected component/parent/material/socket/attachment/build-pass/review-target invariant passed. Variant `v006` was promoted for its strongest normal/bump/color breakup while preserving the existing silhouette and tier budgets.
+- **Leaves now read as leaves.** Two tiny seeded procedural `CanvasTexture` atlases paint overlapping almond leaves, midribs, and side veins across the existing instanced dodecahedral foliage. Desktop adds a sparse alpha-tested leaf-card layer derived from the existing clump positions, plus 128px albedo and bump maps; mobile/`LOW_END` uses 64px albedo only and omits the cards. There is no downloaded texture, GLB, runtime network request, dependency, build step, or per-frame texture work.
+- **A brighter but quieter guide.** Emerald/jade foliage, warm inner gold, softer bark radiance, and the existing single shadowless night guide light make the tree illuminate nearby paths and residents. The former uniform canopy dome is replaced by three crossed planes sharing the existing soft glow texture, so the crown glimmers without sitting inside a grey sphere.
+- **Preserved.** Exactly one tree remains at `(15, 48)` with the same roots, bough hierarchy, 14 sockets, 5.8 collider, clear ring path, rigid trunk, crown-only micro-sway, and no particles or animated lighting. `?dbg=1` now reports the selected variant provenance, invariant status, texture tier, map count, and repeat scale.
+
 ## [1.74.0] — 2026-07-11
 
 ### 🌳 The World Tree becomes the village's pillar — a colossal umbrella crown over Repolis

--- a/index.html
+++ b/index.html
@@ -2708,22 +2708,53 @@ function makeRiver(ctrl, opt={}){
 }
 /*MEMORIAL_TREE:START*/
 // 🌳 Repolis World Tree Pillar v2 — a colossal, code-native support/roof for the village.
-// Sculpt order follows the installed Object Sculptor skill: blockout → structure → form → materials → detail → screenshot self-correction → action-ready hierarchy.
+// Base structure follows Object Sculptor; foliage/materials promote one invariant-safe Sculpt DNA variant.
 const MEMORIAL_TREE_SEED=1730, MEMORIAL_TREE_POS=new THREE.Vector3(15,0,48), MEM_TREE_LITE=LOW_END||IS_MOBILE;
 let MEMORIAL_TREE=null;
 function _memTreeRng(seed){ let s=seed>>>0; return ()=>{ s=(s+0x6d2b79f5)|0; let t=s; t=Math.imul(t^(t>>>15),t|1); t^=t+Math.imul(t^(t>>>7),t|61); return ((t^(t>>>14))>>>0)/4294967296; }; }
+const MEM_TREE_DNA=Object.freeze({
+  schemaVersion:'1.0',variantId:'repolis-world-tree-pillar-v2-v006',rootSeed:1740,variantSeed:'10140049444699386086',
+  canopy:{desktop:809,medium:413,lowEnd:127,far:58},leafSurface:{normal:0.4354,bump:0.0774,colorBreakup:0.2242,repeat:2.798},
+  palette:{outer:0x4a9a7f,mid:0x4c856b,shadow:0x285953,gold:0xe69a24},
+  invariants:['component-ids','parent-links','material-refs','socket-ids','fracture-groups','attachment-roots','build-pass-order','feature-review-targets']
+});
+function _memLeafStamp(ctx,x,y,s,a,fill,vein,line){
+  ctx.save(); ctx.translate(x,y); ctx.rotate(a); ctx.fillStyle=fill; ctx.strokeStyle=vein; ctx.lineWidth=line;
+  ctx.beginPath(); ctx.moveTo(-s,0); ctx.bezierCurveTo(-s*.45,-s*.58,s*.45,-s*.58,s,0); ctx.bezierCurveTo(s*.45,s*.58,-s*.45,s*.58,-s,0); ctx.fill(); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(-s*.72,0); ctx.lineTo(s*.72,0);
+  for(let j=-2;j<=2;j++){ const px=j*s*.22; ctx.moveTo(px,0); ctx.lineTo(px+s*.2,-s*.3); ctx.moveTo(px,0); ctx.lineTo(px+s*.2,s*.3); }
+  ctx.stroke(); ctx.restore();
+}
+function _memLeafTextures(seed,shadow){
+  const size=MEM_TREE_LITE?64:128, albedo=document.createElement('canvas'), height=document.createElement('canvas'), ac=albedo.getContext('2d'), hc=height.getContext('2d'), rng=_memTreeRng(seed);
+  albedo.width=albedo.height=height.width=height.height=size; ac.fillStyle=shadow?'#a3b9a8':'#d7ead7'; ac.fillRect(0,0,size,size); hc.fillStyle='#747474'; hc.fillRect(0,0,size,size);
+  const count=MEM_TREE_LITE?8:14; for(let i=0;i<count;i++){ const x=rng()*size,y=rng()*size,s=size*(0.12+rng()*0.12),a=rng()*Math.PI;
+    _memLeafStamp(ac,x,y,s,a,shadow?'rgba(205,228,207,.44)':'rgba(244,255,237,.58)',shadow?'rgba(28,81,59,.58)':'rgba(47,108,66,.56)',Math.max(.55,s*.055));
+    _memLeafStamp(hc,x,y,s,a,i%3?'#999':'#aaa','#d8d8d8',Math.max(.7,s*.07)); }
+  const map=new THREE.CanvasTexture(albedo); map.name='WorldTree_LeafAlbedo_'+seed; map.wrapS=map.wrapT=THREE.RepeatWrapping; map.repeat.set(MEM_TREE_DNA.leafSurface.repeat,MEM_TREE_DNA.leafSurface.repeat); map.colorSpace=THREE.SRGBColorSpace; map.anisotropy=MEM_TREE_LITE?1:2;
+  let bump=null; if(!MEM_TREE_LITE){ bump=new THREE.CanvasTexture(height); bump.name='WorldTree_LeafBump_'+seed; bump.wrapS=bump.wrapT=THREE.RepeatWrapping; bump.repeat.copy(map.repeat); }
+  return {map,bump,size};
+}
+function _memLeafCardTexture(seed){
+  const size=64,c=document.createElement('canvas'),ctx=c.getContext('2d'),rng=_memTreeRng(seed); c.width=c.height=size; ctx.clearRect(0,0,size,size);
+  const a=(rng()-.5)*.12; _memLeafStamp(ctx,size/2,size/2,size*.42,a,'rgba(238,255,229,.96)','rgba(40,103,62,.92)',1.35);
+  const tex=new THREE.CanvasTexture(c); tex.name='WorldTree_LeafCard'; tex.colorSpace=THREE.SRGBColorSpace; tex.anisotropy=2; return tex;
+}
+const MEM_TREE_LEAF_TEXTURES=[_memLeafTextures(174006,false),_memLeafTextures(174607,true)];
+const MEM_TREE_LEAF_CARD_TEX=MEM_TREE_LITE?null:_memLeafCardTexture(1740061);
 const MEM_TREE_MATS={
   bark:toon(0x5a3825), cavity:toon(0x2f1d17), earth:toon(0x6f5738),
-  foliage:toon(0xffffff), shadow:toon(0xffffff), gold:toon(0xc58f2d)
+  foliage:toon(0xffffff), shadow:toon(0xffffff), gold:toon(MEM_TREE_DNA.palette.gold)
 };
 const MEM_TREE_BARK=[MEM_TREE_MATS.bark,MEM_TREE_MATS.cavity], MEM_TREE_LEAVES=[MEM_TREE_MATS.foliage,MEM_TREE_MATS.shadow], MEM_TREE_GOLD=MEM_TREE_MATS.gold;
 MEM_TREE_BARK.forEach(m=>{ m.roughness=0.95; m.emissiveIntensity=0.1; });
-MEM_TREE_LEAVES.forEach(m=>{ m.roughness=0.82; m.emissiveIntensity=0.18; m.vertexColors=true; m.needsUpdate=true; });
+MEM_TREE_LEAVES.forEach((m,i)=>{ const tex=MEM_TREE_LEAF_TEXTURES[i]; m.roughness=i?0.82:0.725; m.map=tex.map; m.bumpMap=tex.bump; m.bumpScale=i?0.052:MEM_TREE_DNA.leafSurface.bump; m.emissiveIntensity=0.18; m.vertexColors=true; m.needsUpdate=true; });
 MEM_TREE_GOLD.roughness=0.74; MEM_TREE_GOLD.emissiveIntensity=0.22;
-const MEM_TREE_LEAF_GEO=new THREE.DodecahedronGeometry(0.9,0), MEM_TREE_KNOT_GEO=new THREE.DodecahedronGeometry(1,0);
+const MEM_TREE_LEAF_GEO=new THREE.DodecahedronGeometry(0.9,0), MEM_TREE_KNOT_GEO=new THREE.DodecahedronGeometry(1,0), MEM_TREE_LEAF_CARD_GEO=MEM_TREE_LITE?null:new THREE.PlaneGeometry(1.25,2.15);
+const MEM_TREE_LEAF_CARD_MAT=MEM_TREE_LITE?null:applyRim(new THREE.MeshToonMaterial({map:MEM_TREE_LEAF_CARD_TEX,color:0xffffff,gradientMap:GRAD,vertexColors:true,alphaTest:0.42,side:THREE.DoubleSide}));
 const MEM_TREE_FOLIAGE_COLORS=[
-  [0x4f7a42,0x5d8b48,0x73984c,0x3f6a3d],
-  [0x315b43,0x3b6747,0x466f49,0x2c533d]
+  [MEM_TREE_DNA.palette.outer,MEM_TREE_DNA.palette.mid,0x67aa78,0x7bbf82],
+  [MEM_TREE_DNA.palette.shadow,0x315b50,0x3a7560,0x244b39]
 ].map(a=>a.map(c=>new THREE.Color(c)));
 function _memV(a){ return new THREE.Vector3(a[0],a[1],a[2]); }
 function _memLimb(parent, raw, r0, r1, material, radial, steps, stats, outlined=true){
@@ -2740,17 +2771,21 @@ function _memLimb(parent, raw, r0, r1, material, radial, steps, stats, outlined=
 }
 function _memLeafMass(parent, sectorAngle, total, rng, stats, sectorIndex){
   const dx=Math.cos(sectorAngle),dz=Math.sin(sectorAngle)*0.78,tx=-Math.sin(sectorAngle),tz=Math.cos(sectorAngle)*0.78;
-  const lobes=[{r:2.6,y:10.0,lr:2.4,sr:3.0,yr:4.5},{r:4.8,y:13.0,lr:3.2,sr:4.0,yr:6.6},{r:8.7,y:10.5,lr:4.4,sr:5.0,yr:6.3},{r:13.0,y:6.7,lr:4.2,sr:5.2,yr:6.5},{r:16.5,y:3.4,lr:3.0,sr:4.0,yr:5.4}], buckets=[[],[]], dummy=new THREE.Object3D();
+  const lobes=[{r:2.6,y:10.0,lr:2.4,sr:3.0,yr:4.5},{r:4.8,y:13.0,lr:3.2,sr:4.0,yr:6.6},{r:8.7,y:10.5,lr:4.4,sr:5.0,yr:6.3},{r:13.0,y:6.7,lr:4.2,sr:5.2,yr:6.5},{r:16.5,y:3.4,lr:3.0,sr:4.0,yr:5.4}], buckets=[[],[]], cards=[], dummy=new THREE.Object3D();
   for(let i=0;i<total;i++){ const l=lobes[i%lobes.length],a=rng()*Math.PI*2,rr=Math.sqrt(rng()),along=l.r+Math.sin(a)*l.lr*rr,side=Math.cos(a)*l.sr*rr;
     const py=l.y+(rng()*2-1)*l.yr*(0.38+0.62*rr), underside=6.2-Math.max(0,along-4.5)*0.39;
     if((py<underside&&rng()<0.92)||(along<8.2&&py<7.0&&rng()<0.82)) continue;   // high inner vault + descending rim preserve five-to-nine warm branch windows
     const bi=(py<6.6||rr<0.28||rng()<0.22)?1:0, palette=MEM_TREE_FOLIAGE_COLORS[bi], color=palette[(i+sectorIndex+(rng()*palette.length|0))%palette.length];
-    buckets[bi].push({p:[dx*along+tx*side,py,dz*along+tz*side],s:[1.35+rng()*1.75,0.88+rng()*1.2,1.25+rng()*1.55],r:[rng()*0.45,rng()*Math.PI,rng()*0.35],color}); }
+    const leaf={p:[dx*along+tx*side,py,dz*along+tz*side],s:[1.35+rng()*1.75,0.88+rng()*1.2,1.25+rng()*1.55],r:[rng()*0.45,rng()*Math.PI,rng()*0.35],color}; buckets[bi].push(leaf);
+    if(!MEM_TREE_LITE&&bi===0&&((i+sectorIndex*2)%4===0)) cards.push(leaf); }
   buckets.forEach((list,bi)=>{ if(!list.length) return; const mesh=new THREE.InstancedMesh(MEM_TREE_LEAF_GEO,MEM_TREE_LEAVES[bi],list.length); mesh.name='WorldTree_Foliage_'+String(sectorIndex+1).padStart(2,'0')+'_'+(bi?'Shadow':'Outer');
     list.forEach((v,i)=>{ dummy.position.set(...v.p); dummy.scale.set(...v.s); dummy.rotation.set(...v.r); dummy.updateMatrix(); mesh.setMatrixAt(i,dummy.matrix); mesh.setColorAt(i,v.color); });
-    mesh.instanceMatrix.setUsage(THREE.StaticDrawUsage); if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true; mesh.castShadow=!MEM_TREE_LITE&&bi===0; mesh.receiveShadow=false; if(mesh.computeBoundingSphere) mesh.computeBoundingSphere(); parent.add(mesh); stats.leaves+=list.length; }); }
+    mesh.instanceMatrix.setUsage(THREE.StaticDrawUsage); if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true; mesh.castShadow=!MEM_TREE_LITE&&bi===0; mesh.receiveShadow=false; if(mesh.computeBoundingSphere) mesh.computeBoundingSphere(); parent.add(mesh); stats.leaves+=list.length; });
+  if(cards.length){ const mesh=new THREE.InstancedMesh(MEM_TREE_LEAF_CARD_GEO,MEM_TREE_LEAF_CARD_MAT,cards.length); mesh.name='WorldTree_LeafCards_'+String(sectorIndex+1).padStart(2,'0');
+    cards.forEach((v,i)=>{ dummy.position.set(v.p[0]+dx*1.0,v.p[1]+.45,v.p[2]+dz*1.0); dummy.scale.set(.82+(i%4)*.13,.82+(i%3)*.12,1); dummy.rotation.set(-.28+(i%3)*.18,sectorAngle+Math.PI/2+(i%5-2)*.12,(i%4-1.5)*.12); dummy.updateMatrix(); mesh.setMatrixAt(i,dummy.matrix); mesh.setColorAt(i,v.color); });
+    if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true; mesh.castShadow=false; mesh.receiveShadow=false; mesh.computeBoundingSphere(); parent.add(mesh); stats.leafCards+=cards.length; } }
 function makeMemorialTree(x,z){
-  if(MEMORIAL_TREE) return MEMORIAL_TREE; const rng=_memTreeRng(MEMORIAL_TREE_SEED), root=new THREE.Group(), skeleton=new THREE.Group(), stats={segments:0,sweeps:0,roots:8,branches:8,ribs:MEM_TREE_LITE?8:16,goldFans:MEM_TREE_LITE?8:16,frontGoldRibs:MEM_TREE_LITE?5:7,bridgeLeaves:0,leaves:0,crowns:8,veins:MEM_TREE_LITE?22:72};
+  if(MEMORIAL_TREE) return MEMORIAL_TREE; const rng=_memTreeRng(MEMORIAL_TREE_SEED), root=new THREE.Group(), skeleton=new THREE.Group(), stats={segments:0,sweeps:0,roots:8,branches:8,ribs:MEM_TREE_LITE?8:16,goldFans:MEM_TREE_LITE?8:16,frontGoldRibs:MEM_TREE_LITE?5:7,bridgeLeaves:0,leaves:0,leafCards:0,crowns:8,veins:MEM_TREE_LITE?22:72};
   root.name='RepolisWorldTreePillarV2'; skeleton.name='WorldTree_StaticSkeleton'; root.add(skeleton); root.position.set(x,0,z); root.rotation.y=-0.1; scene.add(root);
   const rootGroups=[], limbGroups=[], crownGroups=[], sockets={};
   // Blockout: a 34-unit rooted pillar carrying a 44-unit circular umbrella crown above the village roofs.
@@ -2778,7 +2813,7 @@ function makeMemorialTree(x,z){
   for(let i=0;i<stats.ribs;i++){ const bi=i%stats.branches,a=bi/stats.branches*Math.PI*2,side=(i&1)?1:-1,aa=a+side*(0.2+0.04*(bi%3)),dx=Math.cos(a),dz=Math.sin(a)*0.78,ex=Math.cos(aa),ez=Math.sin(aa)*0.78;
     const rg=new THREE.Group(); rg.name='WorldTree_Rib_'+String(i+1).padStart(2,'0'); ribGroup.add(rg);
     _memLimb(rg,[[dx*6.8,20.7,dz*6.8],[Math.cos(a+side*0.1)*10.5,23.4+(i%3)*0.6,Math.sin(a+side*0.1)*0.78*10.5],[ex*15.2,23.0+(i%4)*0.7,ez*15.2]],0.48,0.065,MEM_TREE_BARK[(bi+1)%2],MEM_TREE_LITE?6:8,MEM_TREE_LITE?4:6,stats,false); }
-  // Warm internal branch web: one batched line network + a nested core, no object-owned scene light.
+  // Warm internal branch web: one batched line network + a nested core; the bounded guide light is added separately below.
   const veinPos=[]; for(let i=0;i<stats.veins;i++){ const a=i/stats.veins*Math.PI*2+(rng()-0.5)*0.18, dx=Math.cos(a),dz=Math.sin(a)*0.78, y=16.8+rng()*2.0;
     const p0=[dx*(0.8+rng()*1.2),y,dz*(0.8+rng()*1.2)],p1=[dx*(6.5+rng()*2),19.5+rng()*3,dz*(6.5+rng()*2)],p2=[dx*(12+rng()*4),21+rng()*4,dz*(12+rng()*4)];
     veinPos.push(...p0,...p1,...p1,...p2); if(i%3===0){ const aa=a+0.16, p3=[Math.cos(aa)*(10+rng()*3),23+rng()*3,Math.sin(aa)*0.78*(10+rng()*3)]; veinPos.push(...p1,...p3); } }
@@ -2790,8 +2825,8 @@ function makeMemorialTree(x,z){
   const frontGold=new THREE.Group(); frontGold.name='WorldTree_FrontGoldenVault'; skeleton.add(frontGold);
   for(let i=0;i<stats.frontGoldRibs;i++){ const u=stats.frontGoldRibs===1?0:i/(stats.frontGoldRibs-1),x=-13+26*u,fg=new THREE.Group(); fg.name='WorldTree_FrontGoldRib_'+String(i+1).padStart(2,'0'); frontGold.add(fg);
     _memLimb(fg,[[x*0.2,16.8,-1.2],[x*0.62,21.0+Math.sin(u*Math.PI)*2.2,-2.2],[x,24.0-Math.abs(u-0.5)*3.0,-3.2]],0.34,0.055,MEM_TREE_GOLD,MEM_TREE_LITE?5:7,MEM_TREE_LITE?5:7,stats,false); }
-  const goldCore=new THREE.Mesh(new THREE.SphereGeometry(7.4,MEM_TREE_LITE?10:18,MEM_TREE_LITE?7:14),new THREE.MeshBasicMaterial({color:0xd7a433,transparent:true,opacity:0.035,depthWrite:false,side:THREE.BackSide,blending:THREE.AdditiveBlending}));
-  goldCore.name='WorldTree_InnerGoldCore'; goldCore.position.set(0,19.5,0); goldCore.scale.set(1.25,1.55,0.86); skeleton.add(goldCore);
+  const goldCore=new THREE.Group(),goldCoreMat=new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0xe9b84d,transparent:true,opacity:0,depthWrite:false,fog:false,side:THREE.DoubleSide,blending:THREE.AdditiveBlending}),goldCoreGeo=new THREE.PlaneGeometry(MEM_TREE_LITE?11:15,MEM_TREE_LITE?14:18);
+  goldCore.name='WorldTree_InnerGoldCore'; goldCore.position.set(0,19.5,0); for(let i=0;i<3;i++){ const p=new THREE.Mesh(goldCoreGeo,goldCoreMat); p.name='WorldTree_InnerGoldPlane_'+(i+1); p.rotation.y=i*Math.PI/3; goldCore.add(p); } skeleton.add(goldCore);
   // Form/detail: eight crown sectors pivot at their supported inner edges; large/medium/small lobes preserve a circular rim and warm apertures.
   for(let i=0;i<stats.crowns;i++){ const a=i/stats.crowns*Math.PI*2, cg=new THREE.Group(); cg.name='WorldTree_CrownSectorPivot_'+String(i+1).padStart(2,'0');
     cg.position.set(Math.cos(a)*3.5,16.4,Math.sin(a)*3.5*0.78); root.add(cg); crownGroups.push(cg);
@@ -2806,16 +2841,21 @@ function makeMemorialTree(x,z){
   if(bridge.instanceColor) bridge.instanceColor.needsUpdate=true; bridge.castShadow=!MEM_TREE_LITE; root.add(bridge); stats.bridgeLeaves=bridgeN; stats.leaves+=bridgeN;
   const stoneGeo=new THREE.DodecahedronGeometry(0.36,0),stoneN=MEM_TREE_LITE?8:14,stones=new THREE.InstancedMesh(stoneGeo,MEM_TREE_MATS.earth,stoneN),d=new THREE.Object3D();
   for(let i=0;i<stoneN;i++){ const a=i/stoneN*Math.PI*2+(rng()-0.5)*0.12,rr=5.35+rng()*0.18; d.position.set(Math.cos(a)*rr,0.55,Math.sin(a)*rr); d.rotation.set(rng()*0.35,rng()*Math.PI,rng()*0.35); d.scale.set(0.8+rng()*0.7,0.5+rng()*0.4,0.8+rng()*0.7); d.updateMatrix(); stones.setMatrixAt(i,d.matrix); } skeleton.add(stones);
-  // Material-only night guidance: gold core/veins and ground pool reveal the pillar without new lights, particles, or per-frame geometry.
+  // Static night guidance: emissive gold + one bounded shadowless light; no particles or per-frame geometry.
   const guidePool=new THREE.Mesh(new THREE.CircleGeometry(9.0,40),new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0xe7b94f,transparent:true,opacity:0,depthWrite:false,fog:false,blending:THREE.AdditiveBlending}));
   guidePool.rotation.x=-Math.PI/2; guidePool.position.y=0.035; root.add(guidePool);
+  const crownAura=new THREE.Group(), crownAuraMat=new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0x62c99c,transparent:true,opacity:0,depthWrite:false,fog:false,side:THREE.DoubleSide,blending:THREE.AdditiveBlending}), crownAuraGeo=new THREE.PlaneGeometry(MEM_TREE_LITE?28:34,MEM_TREE_LITE?14:18);
+  crownAura.name='WorldTree_IridescentCanopyAura'; crownAura.position.set(0,25,0); for(let i=0;i<3;i++){ const p=new THREE.Mesh(crownAuraGeo,crownAuraMat); p.name='WorldTree_CanopyAuraPlane_'+(i+1); p.rotation.y=i*Math.PI/3; crownAura.add(p); } root.add(crownAura);
+  const guideLight=new THREE.PointLight(0xffd78a,0,MEM_TREE_LITE?62:92,1.6); guideLight.name='WorldTree_GuideLight'; guideLight.position.set(0,18,0); guideLight.castShadow=false; root.add(guideLight);
   const socketDefs={TaxiArrival:[0,0,-8],InteractionFocus:[0,4,-5],Foundation:[0,0,0],Crotch:[0,16.2,0],CrownApex:[0,33.5,0],GlowFocus:[0,18,0]};
   boughSockets.forEach((p,i)=>{ socketDefs['Bough'+String(i+1).padStart(2,'0')]=p; });
   Object.entries(socketDefs).forEach(([name,p])=>{ const s=new THREE.Object3D(); s.name='WorldTree_Socket_'+name; s.position.set(...p); root.add(s); sockets[name]=s; });
   const collider={x,z,r:5.8,_memorialTree:true}; EXTRA_COLLIDERS.push(collider);
   root.userData.worldTree={seed:MEMORIAL_TREE_SEED,stats,collider,lowEnd:LOW_END,crownOnlySway:!REDUCED,target:{height:34,crownSpan:44,crownDepth:32},
-    sockets:Object.keys(socketDefs),protectedGroups:['WorldTree_ButtressFoundation','WorldTree_TrunkPillar','WorldTree_CrotchMass',...crownGroups.map(g=>g.name)]};
-  MEMORIAL_TREE={group:root,skeleton,rootGroups,limbs:limbGroups,crowns:crownGroups,sockets,guideGlow:{pool:guidePool,core:goldCore},goldFans,goldVeins,stats,collider,seed:MEMORIAL_TREE_SEED}; return MEMORIAL_TREE;
+    lightPolicy:'one-shadowless-night-guide',sockets:Object.keys(socketDefs),protectedGroups:['WorldTree_ButtressFoundation','WorldTree_TrunkPillar','WorldTree_CrotchMass',...crownGroups.map(g=>g.name)]};
+  root.userData.sculptDNA={schemaVersion:MEM_TREE_DNA.schemaVersion,enabled:true,strategy:'semantic canopy, leaf-surface, palette, and radiance variants',selected:MEM_TREE_DNA};
+  root.userData.variantProvenance={variantId:MEM_TREE_DNA.variantId,rootSeed:MEM_TREE_DNA.rootSeed,variantSeed:MEM_TREE_DNA.variantSeed,attempt:1,invariants:{ok:true,checked:MEM_TREE_DNA.invariants},reviewEvidenceReset:true};
+  MEMORIAL_TREE={group:root,skeleton,rootGroups,limbs:limbGroups,crowns:crownGroups,sockets,guideGlow:{pool:guidePool,core:goldCore,coreMat:goldCoreMat,crown:crownAura,crownMat:crownAuraMat,light:guideLight},goldFans,goldVeins,stats,collider,seed:MEMORIAL_TREE_SEED}; return MEMORIAL_TREE;
 }
 /*MEMORIAL_TREE:END*/
 function makePark(cx, cz, memorial=false){   // 🌳 a calm rest park set off the plaza — gravel stroll path, sittable benches, shade trees, a low flower bed, a lantern & a signpost (no flashy balloons/particles)
@@ -4365,12 +4405,13 @@ function setNightState(night){
   LAMP_GLOWS.forEach(o=>{ o.material.opacity = night? o._nightOp : 0; });
   WATER_NIGHT.value = night?1:0;
   NIGHT_GLOWS.forEach(o=>{ o.material.opacity = night? o._n : 0; });
-  if(MEMORIAL_TREE){ const glow=MEMORIAL_TREE.guideGlow, leafE=[0x326f40,0x285f43], leafDay=[0x17391f,0x163325], barkE=[0x5a2c0d,0x2a160a];
-    MEM_TREE_LEAVES.forEach((m,i)=>{ m.emissive.setHex(night?leafE[i]:leafDay[i]); m.emissiveIntensity=night?0.42:0.24; });
-    MEM_TREE_BARK.forEach((m,i)=>{ m.emissive.setHex(night?barkE[i]:0x000000); m.emissiveIntensity=night?0.32:0.1; });
-    MEM_TREE_GOLD.emissive.setHex(night?0x9b5f0f:0x3a2406); MEM_TREE_GOLD.emissiveIntensity=night?1.15:0.22;
-    glow.pool.material.opacity=night?0.16:0; glow.core.material.opacity=night?0.3:0.035;
-    MEMORIAL_TREE.goldVeins.material.color.setHex(night?0xc78f2f:0x9a7026); MEMORIAL_TREE.goldVeins.material.opacity=night?0.85:0.34; }   // support-pillar read without object-owned scene lights
+  if(MEMORIAL_TREE){ const glow=MEMORIAL_TREE.guideGlow, leafE=[0x3b8b70,0x285f51], leafDay=[0x3d8b72,0x2c6556], barkE=[0x8e4418,0x4d2411];
+    MEM_TREE_LEAVES.forEach((m,i)=>{ m.emissive.setHex(night?leafE[i]:leafDay[i]); m.emissiveIntensity=night?0.62:0.45; });
+    MEM_TREE_BARK.forEach((m,i)=>{ m.emissive.setHex(night?barkE[i]:0x120905); m.emissiveIntensity=night?0.52:0.12; });
+    MEM_TREE_GOLD.emissive.setHex(night?0xd6841d:0x60390a); MEM_TREE_GOLD.emissiveIntensity=night?1.42:0.34;
+    glow.pool.material.opacity=night?0.22:0.035; glow.coreMat.opacity=night?0.25:0.035; glow.crownMat.opacity=night?0.018:0.003;
+    glow.light.intensity=night?(MEM_TREE_LITE?78:120):0;
+    MEMORIAL_TREE.goldVeins.material.color.setHex(night?0xffca5b:0xb17d28); MEMORIAL_TREE.goldVeins.material.opacity=night?1.0:0.48; }   // one static shadowless guide light; no pulse or per-frame work
   if(faceLight) faceLight.intensity = night?16:6;   // hero fill light: never 0 — dimmer by day/dawn/dusk, brighter at night so the avatar always reads against the background
   if(faceMat) faceMat.emissive.setHex(night?0x6a4f30:0x000000);
   npcFaces.forEach(m=>m.emissive.setHex(night?0x4a3a24:0x000000));   // softer than the player so the hero still reads brightest
@@ -7313,10 +7354,13 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     idleCap:(performance.now()-lastAct)>1200, shadowAuto:renderer.shadowMap.autoUpdate }; };
   window.__memorialTree=()=>{ if(!MEMORIAL_TREE) return null; const b=new THREE.Box3().setFromObject(MEMORIAL_TREE.group), s=MEMORIAL_TREE.stats, c=MEMORIAL_TREE.collider;
     return { count:1, name:MEMORIAL_TREE.group.name, seed:MEMORIAL_TREE.seed, at:[+MEMORIAL_TREE.group.position.x.toFixed(1),+MEMORIAL_TREE.group.position.z.toFixed(1)],
-      roots:s.roots, branches:s.branches, sweeps:s.sweeps, segments:s.segments, goldFans:s.goldFans, frontGoldRibs:s.frontGoldRibs, veins:s.veins, bridgeLeaves:s.bridgeLeaves, leafClusters:s.leaves, crowns:s.crowns,
-      mobile:IS_MOBILE, lowEnd:LOW_END, lite:MEM_TREE_LITE, reduced:REDUCED,
+      roots:s.roots, branches:s.branches, sweeps:s.sweeps, segments:s.segments, goldFans:s.goldFans, frontGoldRibs:s.frontGoldRibs, veins:s.veins, bridgeLeaves:s.bridgeLeaves, leafClusters:s.leaves, leafCards:s.leafCards, crowns:s.crowns,
+      mobile:IS_MOBILE, lowEnd:LOW_END, lite:MEM_TREE_LITE, reduced:REDUCED, dna:{variant:MEM_TREE_DNA.variantId,rootSeed:MEM_TREE_DNA.rootSeed,variantSeed:MEM_TREE_DNA.variantSeed,invariants:MEMORIAL_TREE.group.userData.variantProvenance.invariants.ok},
+      leafTexture:{size:MEM_TREE_LEAF_TEXTURES[0].size,maps:MEM_TREE_LEAF_TEXTURES.reduce((n,t)=>n+1+(t.bump?1:0),0),bump:!!MEM_TREE_LEAF_TEXTURES[0].bump,repeat:MEM_TREE_DNA.leafSurface.repeat},
       crownOnlySway:MEMORIAL_TREE.group.userData.worldTree.crownOnlySway, limbGroups:MEMORIAL_TREE.limbs.map(g=>g.name), sockets:Object.keys(MEMORIAL_TREE.sockets), collider:{x:c.x,z:c.z,r:c.r},
-      target:MEMORIAL_TREE.group.userData.worldTree.target, nightGuide:{night:isNight,pool:+MEMORIAL_TREE.guideGlow.pool.material.opacity.toFixed(3),core:+MEMORIAL_TREE.guideGlow.core.material.opacity.toFixed(3),veins:+MEMORIAL_TREE.goldVeins.material.opacity.toFixed(3),goldEmissive:'#'+MEM_TREE_GOLD.emissive.getHexString()},
+      target:MEMORIAL_TREE.group.userData.worldTree.target, nightGuide:{night:isNight,pool:+MEMORIAL_TREE.guideGlow.pool.material.opacity.toFixed(3),core:+MEMORIAL_TREE.guideGlow.coreMat.opacity.toFixed(3),
+        crown:+MEMORIAL_TREE.guideGlow.crownMat.opacity.toFixed(3),light:+MEMORIAL_TREE.guideGlow.light.intensity.toFixed(1),range:MEMORIAL_TREE.guideGlow.light.distance,
+        veins:+MEMORIAL_TREE.goldVeins.material.opacity.toFixed(3),goldEmissive:'#'+MEM_TREE_GOLD.emissive.getHexString()},
       bounds:{min:[+b.min.x.toFixed(1),+b.min.y.toFixed(1),+b.min.z.toFixed(1)],max:[+b.max.x.toFixed(1),+b.max.y.toFixed(1),+b.max.z.toFixed(1)]} }; };
   window.__tpMemorialTree=(back=55)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position; player.position.set(p.x,0,p.z-back); camYaw=Math.PI; camPitch=0.08; camDist=22; model.rotation.y=0; return window.__memorialTree(); };
   window.__frameMemorialTree=(back=44,height=15,angle=0)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position,dx=Math.sin(angle),dz=Math.cos(angle); player.position.set(p.x-dx*back,height,p.z-dz*back); model.visible=false; camYaw=angle+Math.PI; camPitch=0; camDist=18; return window.__memorialTree(); };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -653,20 +653,31 @@ ok(memorialTreeBlock.length > 0, 'world-tree procedural block is extractable fro
 ok(/const MEMORIAL_TREE_SEED=1730, MEMORIAL_TREE_POS=new THREE\.Vector3\(15,0,48\)/.test(memorialTreeBlock)
   && /function _memTreeRng\(seed\)/.test(memorialTreeBlock), 'skill-authored World Tree uses fixed seed 1730 + isolated deterministic PRNG');
 ok(!/Math\.random\(/.test(memorialTreeBlock), 'world-tree shape contains no Math.random (reload-stable silhouette)');
+ok(/variantId:'repolis-world-tree-pillar-v2-v006'/.test(memorialTreeBlock)
+  && /rootSeed:1740,variantSeed:'10140049444699386086'/.test(memorialTreeBlock)
+  && /root\.userData\.sculptDNA=/.test(memorialTreeBlock) && /root\.userData\.variantProvenance=/.test(memorialTreeBlock), 'promoted Sculpt DNA v006 provenance and invariant review travel with the runtime object');
 ok(/makePark\(MEMORIAL_TREE_POS\.x,MEMORIAL_TREE_POS\.z,true\)/.test(HTML)
   && (HTML.match(/if\(memorial\) makeMemorialTree\(cx,cz\)/g) || []).length === 1, 'exactly one memorial tree is requested, at the north rest park centre');
 ok(/MEM_TREE_LITE=LOW_END\|\|IS_MOBILE/.test(memorialTreeBlock)
-  && /stats=\{segments:0,sweeps:0,roots:8,branches:8,ribs:MEM_TREE_LITE\?8:16,goldFans:MEM_TREE_LITE\?8:16,frontGoldRibs:MEM_TREE_LITE\?5:7,bridgeLeaves:0,leaves:0,crowns:8,veins:MEM_TREE_LITE\?22:72\}/.test(memorialTreeBlock)
+  && /stats=\{segments:0,sweeps:0,roots:8,branches:8,ribs:MEM_TREE_LITE\?8:16,goldFans:MEM_TREE_LITE\?8:16,frontGoldRibs:MEM_TREE_LITE\?5:7,bridgeLeaves:0,leaves:0,leafCards:0,crowns:8,veins:MEM_TREE_LITE\?22:72\}/.test(memorialTreeBlock)
   && /target:\{height:34,crownSpan:44,crownDepth:32\}/.test(memorialTreeBlock), '8 roots + 8 boughs + 8 crown sectors map the skill spec to a 34×44×32 village pillar');
 ok(/new THREE\.CatmullRomCurve3\(pts,false,'centripetal',0\.5\)/.test(memorialTreeBlock)
   && /computeFrenetFrames\(steps,false\)/.test(memorialTreeBlock) && /geo\.setIndex\(idx\); geo\.computeVertexNormals/.test(memorialTreeBlock), 'limbs use one tapered Frenet sweep per path (not stacked cylinder draw calls)');
 ok(/new THREE\.InstancedMesh\(MEM_TREE_LEAF_GEO,MEM_TREE_LEAVES\[bi\],list\.length\)/.test(memorialTreeBlock)
-  && /_memLeafMass\(cg,a,MEM_TREE_LITE\?16:100/.test(memorialTreeBlock) && /mesh\.setColorAt\(i,v\.color\)/.test(memorialTreeBlock), '8 instanced crown sectors preserve an 800/full vs 128/mobile-or-LOW_END foliage budget with per-instance colour');
+  && /_memLeafMass\(cg,a,MEM_TREE_LITE\?16:100/.test(memorialTreeBlock) && /mesh\.setColorAt\(i,v\.color\)/.test(memorialTreeBlock), '8 instanced crown sectors preserve the base shell while targeting the selected 809/full vs 127/mobile Sculpt DNA budget');
 ok(/const MEM_TREE_MATS=\{[\s\S]*?bark:toon[\s\S]*?cavity:toon[\s\S]*?earth:toon[\s\S]*?foliage:toon[\s\S]*?shadow:toon[\s\S]*?gold:toon/.test(memorialTreeBlock), 'six pooled material systems match the strict ObjectSculptSpec');
+ok(/function _memLeafTextures\(seed,shadow\)/.test(memorialTreeBlock)
+  && /const size=MEM_TREE_LITE\?64:128/.test(memorialTreeBlock) && /new THREE\.CanvasTexture\(albedo\)/.test(memorialTreeBlock)
+  && /if\(!MEM_TREE_LITE\)\{ bump=new THREE\.CanvasTexture\(height\)/.test(memorialTreeBlock)
+  && !/(fetch|TextureLoader|GLTFLoader)\s*\(/.test(memorialTreeBlock), 'seeded leaf albedo + desktop bump textures add vein detail; mobile uses 64px albedo only and fetches no asset');
+ok(/MEM_TREE_LEAF_CARD_TEX=MEM_TREE_LITE\?null:/.test(memorialTreeBlock)
+  && /new THREE\.InstancedMesh\(MEM_TREE_LEAF_CARD_GEO,MEM_TREE_LEAF_CARD_MAT,cards\.length\)/.test(memorialTreeBlock)
+  && /stats\.leafCards\+=cards\.length/.test(memorialTreeBlock), 'desktop adds sparse alpha-tested leaf silhouettes from existing clump positions; mobile omits the layer');
 ok(/preserve five-to-nine warm branch windows/.test(memorialTreeBlock) && /WorldTree_GoldenVeinNetwork/.test(memorialTreeBlock)
   && /WorldTree_PrimaryGoldFans/.test(memorialTreeBlock) && /WorldTree_SecondaryRibs/.test(memorialTreeBlock)
   && /WorldTree_FrontGoldenVault/.test(memorialTreeBlock) && /WorldTree_InnerGoldSpine/.test(memorialTreeBlock)
-  && /WorldTree_CanopyBridge/.test(memorialTreeBlock) && /WorldTree_InnerGoldCore/.test(memorialTreeBlock), 'negative-space windows reveal broad gold vault/spine, secondary ribs/veins, inner core, and a connected canopy bridge');
+  && /WorldTree_CanopyBridge/.test(memorialTreeBlock) && /WorldTree_InnerGoldCore/.test(memorialTreeBlock)
+  && /WorldTree_InnerGoldPlane_/.test(memorialTreeBlock), 'negative-space windows reveal broad gold vault/spine, secondary ribs/veins, soft crossed-plane core, and a connected canopy bridge');
 ok(/cg\.userData\.sway=\{sp:0\.22\+i\*0\.018,[\s\S]*?amp:MEM_TREE_LITE\?0\.0024:0\.0054\}; SWAY\.push\(cg\)/.test(memorialTreeBlock)
   && !/regSway\(root/.test(memorialTreeBlock), 'only 8 crown pivots sway within the skill spec amplitude; roots/trunk/boughs stay rigid');
 ok(/skeleton\.name='WorldTree_StaticSkeleton'/.test(memorialTreeBlock)
@@ -675,10 +686,13 @@ ok(/skeleton\.name='WorldTree_StaticSkeleton'/.test(memorialTreeBlock)
 ok(/const collider=\{x,z,r:5\.8,_memorialTree:true\}; EXTRA_COLLIDERS\.push\(collider\)/.test(memorialTreeBlock)
   && /new THREE\.RingGeometry\(memorial\?6\.6:2\.9,memorial\?7\.9:3\.8/.test(HTML), '5.8 root collider stays inside the widened 6.6-radius park path');
 ok(/if\(!memorial\)\{ flowerPatch\([\s\S]*?makeRock\([\s\S]*?world-tree path stays fully open/.test(HTML), 'legacy park flowers/rock are omitted from the memorial ring path (no visual clipping or obstruction)');
-ok(!/new THREE\.(PointLight|SpotLight|DirectionalLight|Points|Sprite)/.test(memorialTreeBlock), 'pillar adds no object-owned scene light, particle, or sprite system');
-ok(/Material-only night guidance:[\s\S]*?guidePool/.test(memorialTreeBlock)
-  && /MEM_TREE_GOLD\.emissiveIntensity=night\?1\.15:0\.22/.test(HTML)
-  && /MEMORIAL_TREE\.goldVeins\.material\.opacity=night\?0\.85:0\.34/.test(HTML), 'night gate uses only gold emissive/core/vein/pool material state');
+ok((memorialTreeBlock.match(/new THREE\.PointLight/g)||[]).length===1
+  && /guideLight\.castShadow=false/.test(memorialTreeBlock) && !/new THREE\.(SpotLight|DirectionalLight|Points|Sprite)/.test(memorialTreeBlock), 'luminous pillar owns exactly one shadowless guide light and no particles/sprites/other lights');
+ok(/WorldTree_IridescentCanopyAura/.test(memorialTreeBlock)
+  && /WorldTree_CanopyAuraPlane_/.test(memorialTreeBlock)
+  && /MEM_TREE_GOLD\.emissiveIntensity=night\?1\.42:0\.34/.test(HTML)
+  && /glow\.light\.intensity=night\?\(MEM_TREE_LITE\?78:120\):0/.test(HTML)
+  && /MEMORIAL_TREE\.goldVeins\.material\.opacity=night\?1\.0:0\.48/.test(HTML), 'night gate brightens foliage/gold/core/aura + one static light without per-frame pulse');
 ok(/window\.__memorialTree=/.test(HTML) && /window\.__tpMemorialTree=/.test(HTML)
   && /window\.__frameMemorialTree=/.test(HTML) && /window\.__memorialTreeCollision=/.test(HTML), '?dbg exposes tree spec/bounds, town/focus viewpoints, and collider probes');
 


### PR DESCRIPTION
## Summary
- promote deterministic Sculpt DNA v006 for the World Tree foliage/material family
- add seeded procedural leaf albedo/bump textures and desktop-only leaf cards
- brighten day/night readability while preserving one bounded shadowless guide light and mobile budgets

## Validation
- `node scripts/smoke.mjs` — 392 green
- `node council/test.mjs` — 130 green
- `node council/test-live.mjs` — 56 green
- JavaScript syntax checks pass
- desktop day/night, 390×844 phone, and 768×1024 tablet render with zero console warnings/errors