### PR TITLE
feat: integrate Solar Archive World Tree [1.77.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.77.0] — 2026-07-11
+
+### ☀️ Solar Archive World Tree — the plugin flagship, alive inside Repolis
+- **The production tree itself.** Repolis now imports the native `createRepolisHero.js` output from **threejs-sculpt-dna v0.4.0** byte-for-byte (SHA-256 `65bd7fc…d0e3`) and instantiates deterministic **Solar Archive** seed `20260711`. The old hand-authored v3 implementation is removed rather than hidden behind the new model.
+- **Natural canopy continuity.** The former large cyan/brown floating clumps are replaced by **3,016 small instanced leaves** anchored to **15 macro → 56 secondary → 112 merged fine branches**. The gradual diameter ladder, dense overlapping sprays, 10% cyan ratio, and warm Solar palette make one continuous ancient crown while retaining its luminous World Tree identity.
+- **No effect downgrade.** Desktop and mobile both use the factory's `full` stage: 220 moss instances, 72 branch-following glyphs, constellation nodes/links, hanging lights, generated bark PBR, root glow, energy pulse, leaf motion, and living-system sway all remain active. The source factory stays immutable; Repolis owns only a thin placement/integration adapter.
+- **Independent Christmas-tree lighting.** The normal town render remains untouched. A selective pre-pass renders only the factory energy network, glyphs, constellation ornaments, leaf sprays, and pulsing PointLight with the live demo bloom `0.5 / 0.36 / 0.88`; bark, roots, ground, and moss stay town-lit and serve only as depth occluders. Nearby buildings, props, the player, and residents also enter the pre-pass as black depth occluders, so neon cannot overexpose town surfaces or draw hidden branches over foreground objects. Day alone calms ornament intensity and bloom.
+- **Park integration.** Uniform scale `2.0` produces approximately `32.3 × 28.1 × 17.0` instanced-mesh-aware visible bounds at the same north park `(15, 48)`. The complete root island gets an 11.6-radius collider inside a widened 12.2-radius clear ring; benches, lantern, and sign move outside it. Six Repolis compatibility sockets plus eight factory branch sockets preserve 14 action-ready anchors.
+- **Measured cost.** Full Solar Archive generation is roughly 65–95 ms with **68,904 tree triangles / 124 draws** on both desktop and mobile. This intentionally increases the previous mobile v3 tree from 8,666 / 77 to retain all plugin effects. The base town renders directly, while a cached local-occluder bloom pass and one additive quad avoid a second full-town copy; final 390×844 cadence is **58 FPS** (`17.25 ms` average, `17.7 ms` p95), with a nonblank canvas and zero console errors.
+- **Fresh visual gate.** The supplied live mobile screenshots are the acceptance references. Side-by-side review passes root/fork continuity, radial branch hierarchy, gold network, bark readability, constellation ornaments, and mobile crown continuity; the plugin's canonical strict spec and Sculpt DNA validate with zero warnings, and its own 34 tests pass.
+
 ## [1.76.0] — 2026-07-11
 
 ### 🌳 The World Tree completes a full sculpt pipeline — rooted structure, real PBR, restrained radiance

--- a/assets/world-tree/createRepolisHero.js
+++ b/assets/world-tree/createRepolisHero.js
@@ -1,0 +1,1068 @@
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+export const REPOLIS_VARIANTS = [
+  {
+    id: 'golden-canopy',
+    label: 'Golden Canopy',
+    foliageDensity: 1,
+    cyanRatio: 0.16,
+    amber: '#E7A33A',
+    cyan: '#44DCE8',
+    energy: '#FFC55A',
+    branchWarmth: 1,
+  },
+  {
+    id: 'solar-archive',
+    label: 'Solar Archive',
+    foliageDensity: 1.16,
+    cyanRatio: 0.1,
+    amber: '#F5BD54',
+    cyan: '#79F3FF',
+    energy: '#FFE39A',
+    branchWarmth: 1.08,
+  },
+  {
+    id: 'aurora-index',
+    label: 'Aurora Index',
+    foliageDensity: 0.92,
+    cyanRatio: 0.34,
+    amber: '#D98A2E',
+    cyan: '#35E8FF',
+    energy: '#FFB13B',
+    branchWarmth: 0.92,
+  },
+];
+
+export const REPOLIS_STAGES = [
+  'blockout',
+  'structural-pass',
+  'form-refinement',
+  'material-pass',
+  'surface-pass',
+  'full',
+];
+
+const STAGE_LEVEL = Object.fromEntries(
+  REPOLIS_STAGES.map((stage, index) => [stage, index]),
+);
+
+function hashString(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededRandom(seed) {
+  let state = typeof seed === 'number' ? seed >>> 0 : hashString(String(seed));
+  return {
+    next() {
+      state += 0x6D2B79F5;
+      let value = state;
+      value = Math.imul(value ^ value >>> 15, value | 1);
+      value ^= value + Math.imul(value ^ value >>> 7, value | 61);
+      return ((value ^ value >>> 14) >>> 0) / 4294967296;
+    },
+    range(minimum, maximum) {
+      return minimum + (maximum - minimum) * this.next();
+    },
+    signed() {
+      return this.next() * 2 - 1;
+    },
+    pick(values) {
+      return values[Math.min(values.length - 1, Math.floor(this.next() * values.length))];
+    },
+  };
+}
+
+function hash2d(x, y, seed) {
+  let value = Math.imul(x + seed * 17, 374761393) ^ Math.imul(y + seed * 31, 668265263);
+  value = Math.imul(value ^ value >>> 13, 1274126177);
+  return ((value ^ value >>> 16) >>> 0) / 4294967295;
+}
+
+function smoothstep(value) {
+  return value * value * (3 - 2 * value);
+}
+
+function valueNoise(x, y, seed) {
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const tx = smoothstep(x - x0);
+  const ty = smoothstep(y - y0);
+  const a = hash2d(x0, y0, seed);
+  const b = hash2d(x0 + 1, y0, seed);
+  const c = hash2d(x0, y0 + 1, seed);
+  const d = hash2d(x0 + 1, y0 + 1, seed);
+  return THREE.MathUtils.lerp(
+    THREE.MathUtils.lerp(a, b, tx),
+    THREE.MathUtils.lerp(c, d, tx),
+    ty,
+  );
+}
+
+function fractalNoise(x, y, seed) {
+  let value = 0;
+  let amplitude = 0.58;
+  let frequency = 1;
+  let total = 0;
+  for (let octave = 0; octave < 4; octave += 1) {
+    value += valueNoise(x * frequency, y * frequency, seed + octave * 101) * amplitude;
+    total += amplitude;
+    amplitude *= 0.5;
+    frequency *= 2.15;
+  }
+  return value / total;
+}
+
+function dataTexture(data, width, height, colorSpace = THREE.NoColorSpace) {
+  const texture = new THREE.DataTexture(data, width, height, THREE.RGBAFormat);
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(1.6, 1.05);
+  texture.colorSpace = colorSpace;
+  texture.anisotropy = 8;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function createBarkTextures(seed, size = 512) {
+  const pixelCount = size * size;
+  const albedo = new Uint8Array(pixelCount * 4);
+  const roughness = new Uint8Array(pixelCount * 4);
+  const height = new Uint8Array(pixelCount * 4);
+  const normal = new Uint8Array(pixelCount * 4);
+  const ao = new Uint8Array(pixelCount * 4);
+  const heightField = new Float32Array(pixelCount);
+  const roughnessField = new Float32Array(pixelCount);
+  const write = (target, offset, red, green, blue, alpha = 255) => {
+    target[offset] = Math.max(0, Math.min(255, Math.round(red)));
+    target[offset + 1] = Math.max(0, Math.min(255, Math.round(green)));
+    target[offset + 2] = Math.max(0, Math.min(255, Math.round(blue)));
+    target[offset + 3] = alpha;
+  };
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const index = y * size + x;
+      const u = x / size;
+      const v = y / size;
+      const macro = fractalNoise(u * 3.2, v * 2.1, seed + 17);
+      const meso = fractalNoise(u * 16.0, v * 7.0, seed + 37);
+      const micro = fractalNoise(u * 70.0, v * 35.0, seed + 71);
+      const verticalRidge = Math.pow(Math.abs(Math.sin((u * 18 + macro * 1.9) * Math.PI)), 1.7);
+      const fissure = Math.pow(Math.abs(Math.sin((u * 7.5 + meso * 0.75) * Math.PI)), 4.5);
+      const barkHeight = THREE.MathUtils.clamp(
+        0.2 + macro * 0.35 + meso * 0.18 + micro * 0.05 + verticalRidge * 0.22 - fissure * 0.16,
+        0,
+        1,
+      );
+      heightField[index] = barkHeight;
+      const rough = THREE.MathUtils.clamp(0.62 + (1 - barkHeight) * 0.2 + micro * 0.13, 0, 1);
+      roughnessField[index] = rough;
+      const warm = THREE.MathUtils.clamp(0.58 + barkHeight * 0.45 + macro * 0.15, 0, 1.2);
+      const cavity = THREE.MathUtils.clamp((1 - barkHeight) * 0.8 + fissure * 0.25, 0, 1);
+      const offset = index * 4;
+      write(
+        albedo,
+        offset,
+        (58 + warm * 74) * (1 - cavity * 0.28),
+        (31 + warm * 45) * (1 - cavity * 0.34),
+        (18 + warm * 24) * (1 - cavity * 0.38),
+      );
+      write(roughness, offset, rough * 255, rough * 255, rough * 255);
+      write(height, offset, barkHeight * 255, barkHeight * 255, barkHeight * 255);
+    }
+  }
+
+  for (let y = 0; y < size; y += 1) {
+    const up = ((y - 1 + size) % size) * size;
+    const down = ((y + 1) % size) * size;
+    for (let x = 0; x < size; x += 1) {
+      const left = (x - 1 + size) % size;
+      const right = (x + 1) % size;
+      const index = y * size + x;
+      const dx = (heightField[y * size + right] - heightField[y * size + left]) * 3.6;
+      const dy = (heightField[down + x] - heightField[up + x]) * 2.5;
+      const vector = new THREE.Vector3(-dx, -dy, 1).normalize();
+      const neighborAverage = (
+        heightField[y * size + left]
+        + heightField[y * size + right]
+        + heightField[up + x]
+        + heightField[down + x]
+      ) * 0.25;
+      const cavity = Math.max(0, neighborAverage - heightField[index]);
+      const aoValue = THREE.MathUtils.clamp(
+        1 - cavity * 4.2 - (1 - heightField[index]) * 0.12,
+        0,
+        1,
+      );
+      const offset = index * 4;
+      write(
+        normal,
+        offset,
+        (vector.x * 0.5 + 0.5) * 255,
+        (vector.y * 0.5 + 0.5) * 255,
+        (vector.z * 0.5 + 0.5) * 255,
+      );
+      write(ao, offset, aoValue * 255, aoValue * 255, aoValue * 255);
+    }
+  }
+
+  return {
+    albedo: dataTexture(albedo, size, size, THREE.SRGBColorSpace),
+    roughness: dataTexture(roughness, size, size),
+    height: dataTexture(height, size, size),
+    normal: dataTexture(normal, size, size),
+    ao: dataTexture(ao, size, size),
+  };
+}
+
+function createLeafGeometry() {
+  const shape = new THREE.Shape();
+  shape.moveTo(0, -0.42);
+  shape.bezierCurveTo(0.34, -0.16, 0.3, 0.26, 0, 0.48);
+  shape.bezierCurveTo(-0.3, 0.26, -0.34, -0.16, 0, -0.42);
+  const geometry = new THREE.ShapeGeometry(shape, 2);
+  geometry.computeVertexNormals();
+  return geometry;
+}
+
+function createBranchGeometry(
+  points,
+  {
+    baseRadius,
+    tipRadius,
+    tubularSegments = 18,
+    radialSegments = 12,
+    seed = 1,
+    gnarled = 0.08,
+    rootFlare = 0,
+  },
+) {
+  const curve = new THREE.CatmullRomCurve3(
+    points.map((point) => point.clone()),
+    false,
+    'centripetal',
+    0.42,
+  );
+  const frames = curve.computeFrenetFrames(tubularSegments, false);
+  const positions = [];
+  const uvs = [];
+  const colors = [];
+  const indices = [];
+  const ring = radialSegments + 1;
+  const rng = seededRandom(seed);
+  const phaseA = rng.range(0, Math.PI * 2);
+  const phaseB = rng.range(0, Math.PI * 2);
+
+  for (let segment = 0; segment <= tubularSegments; segment += 1) {
+    const t = segment / tubularSegments;
+    const center = curve.getPointAt(t);
+    const normal = frames.normals[segment];
+    const binormal = frames.binormals[segment];
+    const taper = THREE.MathUtils.lerp(baseRadius, tipRadius, Math.pow(t, 0.86));
+    for (let side = 0; side <= radialSegments; side += 1) {
+      const angle = side / radialSegments * Math.PI * 2;
+      const flare = 1 + rootFlare * Math.exp(-t * 13) * (0.72 + Math.sin(angle * 2 + phaseA) * 0.28);
+      const ridges = (
+        1
+        + Math.sin(angle * 3 + phaseA + t * 5.2) * gnarled * 0.62
+        + Math.sin(angle * 7 + phaseB - t * 9.4) * gnarled * 0.28
+        + Math.sin(t * 37 + angle * 1.3) * gnarled * 0.15
+      );
+      const radius = taper * flare * ridges;
+      const offset = normal.clone().multiplyScalar(Math.cos(angle) * radius)
+        .addScaledVector(binormal, Math.sin(angle) * radius);
+      const vertex = center.clone().add(offset);
+      positions.push(vertex.x, vertex.y, vertex.z);
+      uvs.push(side / radialSegments, t);
+      const ridgeLight = THREE.MathUtils.clamp(0.72 + ridges * 0.19 + t * 0.06, 0.68, 1.08);
+      colors.push(ridgeLight, ridgeLight * 0.94, ridgeLight * 0.85);
+    }
+  }
+
+  for (let segment = 0; segment < tubularSegments; segment += 1) {
+    for (let side = 0; side < radialSegments; side += 1) {
+      const a = segment * ring + side;
+      const b = a + ring;
+      indices.push(a, b, a + 1, b, b + 1, a + 1);
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+  geometry.computeBoundingSphere();
+  return { geometry, curve };
+}
+
+function branch(
+  id,
+  parentId,
+  points,
+  baseRadius,
+  tipRadius,
+  importance = 'secondary',
+) {
+  return { id, parentId, points, baseRadius, tipRadius, importance };
+}
+
+function macroBranchSpecs() {
+  const vector = (x, y, z) => new THREE.Vector3(x, y, z);
+  return [
+    branch('trunk-core', 'root', [
+      vector(0, 0, 0), vector(-0.12, 1.7, 0.04), vector(0.12, 3.5, -0.04),
+      vector(-0.05, 5.3, 0.08), vector(0.18, 7.4, -0.02), vector(0.05, 9.5, 0.06),
+    ], 1.18, 0.34, 'trunk'),
+    branch('left-foundation', 'trunk-core', [
+      vector(-0.05, 3.15, 0), vector(-1.8, 4.4, 0.2), vector(-3.8, 5.45, 0.05),
+      vector(-6.1, 6.2, 0.35), vector(-8.0, 6.45, 0.15),
+    ], 0.72, 0.12, 'macro'),
+    branch('right-foundation', 'trunk-core', [
+      vector(0.05, 3.45, 0), vector(1.75, 4.7, -0.12), vector(3.7, 5.7, 0.15),
+      vector(5.9, 6.35, -0.2), vector(7.7, 6.65, 0.15),
+    ], 0.7, 0.12, 'macro'),
+    branch('left-crown', 'trunk-core', [
+      vector(-0.05, 5.0, 0), vector(-1.5, 6.3, -0.1), vector(-2.8, 7.9, 0.2),
+      vector(-4.8, 9.1, -0.05), vector(-6.5, 9.8, 0.35),
+    ], 0.58, 0.1, 'macro'),
+    branch('right-crown', 'trunk-core', [
+      vector(0.1, 5.45, 0), vector(1.4, 6.9, 0.16), vector(2.9, 8.3, -0.15),
+      vector(4.7, 9.35, 0.1), vector(6.2, 9.8, -0.25),
+    ], 0.57, 0.1, 'macro'),
+    branch('center-left-spire', 'trunk-core', [
+      vector(0.05, 6.6, 0), vector(-0.75, 8.0, 0.2), vector(-1.1, 10.0, -0.05),
+      vector(-1.8, 11.5, 0.15),
+    ], 0.42, 0.07, 'macro'),
+    branch('center-right-spire', 'trunk-core', [
+      vector(0.16, 6.9, 0), vector(0.9, 8.2, -0.12), vector(1.3, 10.1, 0.1),
+      vector(2.0, 11.4, -0.15),
+    ], 0.4, 0.07, 'macro'),
+    branch('left-rear', 'trunk-core', [
+      vector(-0.1, 4.7, -0.1), vector(-1.4, 6.0, -1.3), vector(-3.5, 7.2, -2.0),
+      vector(-5.2, 8.1, -2.4),
+    ], 0.46, 0.08, 'macro'),
+    branch('right-rear', 'trunk-core', [
+      vector(0.1, 4.9, -0.15), vector(1.5, 6.2, -1.25), vector(3.6, 7.4, -1.9),
+      vector(5.25, 8.2, -2.2),
+    ], 0.45, 0.08, 'macro'),
+  ];
+}
+
+function rootSpecs() {
+  const vector = (x, y, z) => new THREE.Vector3(x, y, z);
+  return [
+    branch('root-left-front', 'trunk-core', [vector(-0.15, 0.35, 0.2), vector(-1.5, 0.05, 0.95), vector(-3.2, -0.12, 1.45), vector(-4.7, -0.1, 1.3)], 0.68, 0.09, 'root'),
+    branch('root-right-front', 'trunk-core', [vector(0.15, 0.35, 0.2), vector(1.45, 0.04, 0.9), vector(3.0, -0.12, 1.5), vector(4.5, -0.1, 1.25)], 0.66, 0.09, 'root'),
+    branch('root-left-rear', 'trunk-core', [vector(-0.2, 0.28, -0.1), vector(-1.4, 0.02, -1.0), vector(-3.1, -0.15, -1.4), vector(-4.2, -0.1, -1.0)], 0.55, 0.07, 'root'),
+    branch('root-right-rear', 'trunk-core', [vector(0.2, 0.28, -0.1), vector(1.35, 0.02, -0.95), vector(2.9, -0.14, -1.45), vector(4.0, -0.1, -1.05)], 0.54, 0.07, 'root'),
+    branch('root-center-front', 'trunk-core', [vector(0, 0.25, 0.35), vector(0.2, 0.0, 1.25), vector(-0.1, -0.1, 2.5), vector(0.3, -0.08, 3.8)], 0.48, 0.06, 'root'),
+    branch('root-center-rear', 'trunk-core', [vector(0, 0.2, -0.25), vector(-0.2, 0.0, -1.2), vector(0.2, -0.12, -2.4), vector(-0.25, -0.1, -3.5)], 0.44, 0.06, 'root'),
+  ];
+}
+
+function secondaryBranches(parent, seed, density = 1) {
+  const rng = seededRandom(`${seed}/${parent.id}/secondary`);
+  const curve = new THREE.CatmullRomCurve3(parent.points, false, 'centripetal', 0.42);
+  const count = Math.max(3, Math.round((parent.importance === 'trunk' ? 8 : 6) * density));
+  const branches = [];
+  for (let index = 0; index < count; index += 1) {
+    const t = THREE.MathUtils.lerp(0.28, 0.9, (index + 1) / (count + 1));
+    const start = curve.getPointAt(t);
+    const tangent = curve.getTangentAt(t).normalize();
+    const side = new THREE.Vector3(-tangent.y, tangent.x, rng.signed() * 0.42).normalize();
+    const direction = tangent.clone().multiplyScalar(0.18)
+      .addScaledVector(side, index % 2 === 0 ? -rng.range(0.78, 1.08) : rng.range(0.78, 1.08))
+      .add(new THREE.Vector3(0, rng.range(0.38, 0.8), rng.signed() * 0.3))
+      .normalize();
+    const length = rng.range(1.5, parent.importance === 'trunk' ? 2.7 : 2.35);
+    const middle = start.clone().addScaledVector(direction, length * 0.48)
+      .add(new THREE.Vector3(rng.signed() * 0.2, rng.range(0.12, 0.32), rng.signed() * 0.18));
+    const endDirection = direction.clone()
+      .add(new THREE.Vector3(rng.signed() * 0.18, rng.range(0.08, 0.28), rng.signed() * 0.18))
+      .normalize();
+    const end = middle.clone().addScaledVector(endDirection, length * 0.58);
+    const base = THREE.MathUtils.lerp(parent.baseRadius, parent.tipRadius, t) * 0.42;
+    branches.push(branch(
+      `${parent.id}-secondary-${index + 1}`,
+      parent.id,
+      [start, middle, end],
+      Math.max(0.065, base),
+      Math.max(0.022, base * 0.28),
+      'secondary',
+    ));
+  }
+  return branches;
+}
+
+function fineBranches(parent, seed) {
+  const rng = seededRandom(`${seed}/${parent.id}/fine`);
+  const curve = new THREE.CatmullRomCurve3(parent.points, false, 'centripetal', 0.42);
+  const output = [];
+  for (let index = 0; index < 2; index += 1) {
+    const t = 0.48 + index * 0.28;
+    const start = curve.getPointAt(t);
+    const tangent = curve.getTangentAt(t).normalize();
+    const side = new THREE.Vector3(-tangent.y, tangent.x, rng.signed() * 0.55).normalize();
+    const direction = tangent.clone().multiplyScalar(0.22)
+      .addScaledVector(side, index === 0 ? -0.82 : 0.82)
+      .add(new THREE.Vector3(0, rng.range(0.32, 0.58), rng.signed() * 0.3))
+      .normalize();
+    const length = rng.range(0.65, 1.25);
+    const middle = start.clone().addScaledVector(direction, length * 0.55);
+    const end = middle.clone().addScaledVector(
+      direction.clone().add(new THREE.Vector3(rng.signed() * 0.2, 0.2, rng.signed() * 0.2)).normalize(),
+      length * 0.55,
+    );
+    output.push(branch(
+      `${parent.id}-fine-${index + 1}`,
+      parent.id,
+      [start, middle, end],
+      Math.max(0.026, parent.tipRadius * 1.2),
+      0.008,
+      'fine',
+    ));
+  }
+  return output;
+}
+
+function createMaterials(seed, variant, detailed) {
+  const textures = detailed ? createBarkTextures(seed) : null;
+  const bark = new THREE.MeshStandardMaterial({
+    color: detailed ? new THREE.Color(1.02 * variant.branchWarmth, 0.94, 0.82) : 0x76513A,
+    map: textures?.albedo ?? null,
+    roughness: detailed ? 0.86 : 0.72,
+    roughnessMap: textures?.roughness ?? null,
+    metalness: 0,
+    normalMap: textures?.normal ?? null,
+    normalScale: new THREE.Vector2(0.5, 0.34),
+    bumpMap: textures?.height ?? null,
+    bumpScale: detailed ? 0.065 : 0,
+    aoMap: textures?.ao ?? null,
+    aoMapIntensity: 0.42,
+    vertexColors: true,
+  });
+  if (bark.aoMap) bark.aoMap.channel = 0;
+  bark.name = 'repolis-generated-bark-pbr';
+  const cutWood = new THREE.MeshStandardMaterial({
+    color: 0xA97A47,
+    roughness: 0.82,
+    metalness: 0,
+  });
+  const energyColor = new THREE.Color(variant.energy);
+  const energy = new THREE.MeshPhysicalMaterial({
+    color: energyColor,
+    roughness: 0.24,
+    metalness: 0,
+    emissive: energyColor,
+    emissiveIntensity: 2.85,
+    transparent: true,
+    opacity: 0.96,
+    depthWrite: false,
+  });
+  const amberColor = new THREE.Color(variant.amber);
+  const cyanColor = new THREE.Color(variant.cyan);
+  const amberLeaf = new THREE.MeshPhysicalMaterial({
+    color: 0xFFFFFF,
+    roughness: 0.46,
+    metalness: 0,
+    emissive: amberColor,
+    emissiveIntensity: 0.42,
+    vertexColors: true,
+    side: THREE.DoubleSide,
+  });
+  const cyanLeaf = amberLeaf.clone();
+  cyanLeaf.emissive = cyanColor;
+  cyanLeaf.emissiveIntensity = 0.75;
+  const moss = new THREE.MeshStandardMaterial({
+    color: 0x72834E,
+    roughness: 0.97,
+    metalness: 0,
+    vertexColors: true,
+    flatShading: true,
+  });
+  const ground = new THREE.MeshStandardMaterial({
+    color: 0x493F32,
+    roughness: 0.95,
+    metalness: 0,
+    vertexColors: true,
+  });
+  const glyphGold = new THREE.MeshBasicMaterial({
+    color: variant.energy,
+    transparent: true,
+    opacity: 0.82,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const glyphCyan = new THREE.MeshBasicMaterial({
+    color: variant.cyan,
+    transparent: true,
+    opacity: 0.78,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  return {
+    bark,
+    cutWood,
+    energy,
+    amberLeaf,
+    cyanLeaf,
+    moss,
+    ground,
+    glyphGold,
+    glyphCyan,
+    textures,
+    disposable: [
+      bark,
+      cutWood,
+      energy,
+      amberLeaf,
+      cyanLeaf,
+      moss,
+      ground,
+      glyphGold,
+      glyphCyan,
+    ],
+  };
+}
+
+function addBranchNode(spec, parentNode, parentOrigin, material, runtime, seed) {
+  const origin = spec.points[0].clone();
+  const localPoints = spec.points.map((point) => point.clone().sub(origin));
+  const detail = spec.importance === 'trunk'
+    ? { tubularSegments: 36, radialSegments: 24, gnarled: 0.12, rootFlare: 0.62 }
+    : spec.importance === 'macro'
+      ? { tubularSegments: 24, radialSegments: 16, gnarled: 0.1, rootFlare: 0.18 }
+      : { tubularSegments: 12, radialSegments: 9, gnarled: 0.055, rootFlare: 0.08 };
+  const { geometry, curve } = createBranchGeometry(localPoints, {
+    baseRadius: spec.baseRadius,
+    tipRadius: spec.tipRadius,
+    seed: hashString(`${seed}/${spec.id}`),
+    ...detail,
+  });
+  const pivot = new THREE.Group();
+  pivot.name = `${spec.id}__pivot`;
+  pivot.position.copy(origin.clone().sub(parentOrigin));
+  pivot.userData.actionProfile = {
+    animationRole: 'socket-anchor',
+    pivot: { mode: 'branch-root', localPosition: [0, 0, 0] },
+    parentId: spec.parentId,
+    transformChannels: ['visibility', 'material-state'],
+    constraints: ['parent-locked-to-living-system-after-surface-assembly'],
+  };
+  parentNode.add(pivot);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = `${spec.id}__mesh`;
+  mesh.castShadow = spec.importance !== 'fine';
+  mesh.receiveShadow = true;
+  pivot.add(mesh);
+  const tipSocket = new THREE.Object3D();
+  tipSocket.name = `${spec.id}__tip`;
+  tipSocket.position.copy(localPoints.at(-1));
+  pivot.add(tipSocket);
+  runtime.nodes[spec.id] = pivot;
+  runtime.meshes[spec.id] = mesh;
+  runtime.sockets[`${spec.id}:tip`] = tipSocket;
+  runtime.colliders[spec.id] = {
+    type: 'capsule-chain',
+    points: spec.points.map((point) => point.toArray()),
+    startRadius: spec.baseRadius,
+    endRadius: spec.tipRadius,
+  };
+  runtime.destructionGroups[spec.importance] ??= [];
+  runtime.destructionGroups[spec.importance].push(pivot);
+  return { pivot, origin, curve, geometry, localPoints };
+}
+
+function mergedFineGeometry(specs, seed) {
+  const geometries = specs.map((spec) => createBranchGeometry(spec.points, {
+    baseRadius: spec.baseRadius,
+    tipRadius: spec.tipRadius,
+    tubularSegments: 7,
+    radialSegments: 5,
+    seed: hashString(`${seed}/${spec.id}`),
+    gnarled: 0.03,
+  }).geometry);
+  const merged = mergeGeometries(geometries, false);
+  geometries.forEach((geometry) => geometry.dispose());
+  return merged;
+}
+
+function createGround(seed, materials, root) {
+  const rng = seededRandom(`${seed}/ground`);
+  const ground = new THREE.Mesh(
+    new THREE.CylinderGeometry(5.7, 5.9, 0.42, 64, 2),
+    materials.ground,
+  );
+  ground.name = 'repolis-ground-island';
+  ground.position.y = -0.34;
+  ground.scale.z = 0.72;
+  ground.receiveShadow = true;
+  root.add(ground);
+
+  const rockGeometry = new THREE.DodecahedronGeometry(0.18, 0);
+  const rocks = new THREE.InstancedMesh(rockGeometry, materials.ground, 46);
+  const matrix = new THREE.Matrix4();
+  for (let index = 0; index < rocks.count; index += 1) {
+    const angle = rng.range(0, Math.PI * 2);
+    const radius = Math.sqrt(rng.next()) * 4.9;
+    const scale = rng.range(0.35, 1.25);
+    matrix.compose(
+      new THREE.Vector3(Math.cos(angle) * radius, -0.06, Math.sin(angle) * radius * 0.67),
+      new THREE.Quaternion().setFromEuler(new THREE.Euler(rng.next(), rng.next(), rng.next())),
+      new THREE.Vector3(scale, scale * rng.range(0.5, 1.1), scale),
+    );
+    rocks.setMatrixAt(index, matrix);
+    rocks.setColorAt(index, new THREE.Color(rng.pick(['#6E644F', '#8A7B59', '#514A3C'])));
+  }
+  rocks.instanceMatrix.needsUpdate = true;
+  rocks.instanceColor.needsUpdate = true;
+  rocks.castShadow = true;
+  rocks.receiveShadow = true;
+  root.add(rocks);
+  return { ground, rocks };
+}
+
+function createMoss(seed, materials, root, count = 220) {
+  const rng = seededRandom(`${seed}/moss`);
+  const geometry = new THREE.IcosahedronGeometry(0.085, 1);
+  const moss = new THREE.InstancedMesh(geometry, materials.moss, count);
+  const matrix = new THREE.Matrix4();
+  const palette = ['#50633A', '#6E7E47', '#85945A', '#9A9B67'];
+  for (let index = 0; index < count; index += 1) {
+    const trunkPatch = index > count * 0.72;
+    const angle = rng.range(0, Math.PI * 2);
+    const radius = trunkPatch ? rng.range(0.72, 1.0) : rng.range(0.5, 2.2) * Math.sqrt(rng.next());
+    const height = trunkPatch ? rng.range(0.35, 3.15) : rng.range(-0.04, 0.16);
+    const position = new THREE.Vector3(
+      Math.cos(angle) * radius,
+      height,
+      Math.sin(angle) * radius * (trunkPatch ? 0.85 : 0.62),
+    );
+    const scale = trunkPatch
+      ? new THREE.Vector3(rng.range(0.3, 0.75), rng.range(0.06, 0.16), rng.range(0.25, 0.58))
+      : new THREE.Vector3(rng.range(0.6, 1.7), rng.range(0.18, 0.42), rng.range(0.6, 1.65));
+    matrix.compose(
+      position,
+      new THREE.Quaternion().setFromEuler(new THREE.Euler(rng.signed() * 0.5, angle, rng.signed() * 0.5)),
+      scale,
+    );
+    moss.setMatrixAt(index, matrix);
+    moss.setColorAt(index, new THREE.Color(rng.pick(palette)));
+  }
+  moss.instanceMatrix.needsUpdate = true;
+  moss.instanceColor.needsUpdate = true;
+  moss.receiveShadow = true;
+  root.add(moss);
+  return moss;
+}
+
+function createFoliage(seed, variant, materials, anchors, root) {
+  const rng = seededRandom(`${seed}/foliage/${variant.id}`);
+  const targetCount = Math.round(2600 * variant.foliageDensity);
+  const cyanCount = Math.round(targetCount * variant.cyanRatio);
+  const amberCount = targetCount - cyanCount;
+  const geometry = createLeafGeometry();
+  const amberLeaves = new THREE.InstancedMesh(geometry, materials.amberLeaf, amberCount);
+  const cyanLeaves = new THREE.InstancedMesh(geometry, materials.cyanLeaf, cyanCount);
+  amberLeaves.name = 'repolis-amber-leaf-sprays';
+  cyanLeaves.name = 'repolis-cyan-index-leaves';
+  const amberPalette = ['#B9651F', '#D6812A', variant.amber, '#FFD16D', '#FFE9A8'];
+  const cyanPalette = ['#1A9BAE', '#2EC8D8', variant.cyan, '#8BFAFF'];
+  const matrix = new THREE.Matrix4();
+  const up = new THREE.Vector3(0, 1, 0);
+
+  const place = (mesh, index, palette, cyan = false) => {
+    const anchor = rng.pick(anchors);
+    const spread = cyan ? 0.52 : 0.68;
+    const position = anchor.position.clone().add(new THREE.Vector3(
+      rng.signed() * spread,
+      rng.signed() * spread * 0.72,
+      rng.signed() * spread,
+    ));
+    if (position.y < 4.4 && Math.abs(position.x) < 1.35) position.y += 1.2;
+    const direction = anchor.direction.clone()
+      .lerp(position.clone().sub(anchor.position).normalize(), 0.38)
+      .normalize();
+    const quaternion = new THREE.Quaternion().setFromUnitVectors(up, direction);
+    quaternion.multiply(new THREE.Quaternion().setFromAxisAngle(direction, rng.range(0, Math.PI * 2)));
+    const scale = rng.range(0.18, 0.39) * (cyan ? 0.92 : 1);
+    matrix.compose(
+      position,
+      quaternion,
+      new THREE.Vector3(scale * rng.range(0.75, 1.35), scale, scale),
+    );
+    mesh.setMatrixAt(index, matrix);
+    mesh.setColorAt(index, new THREE.Color(rng.pick(palette)));
+  };
+
+  for (let index = 0; index < amberCount; index += 1) {
+    place(amberLeaves, index, amberPalette);
+  }
+  for (let index = 0; index < cyanCount; index += 1) {
+    place(cyanLeaves, index, cyanPalette, true);
+  }
+  for (const leaves of [amberLeaves, cyanLeaves]) {
+    leaves.instanceMatrix.needsUpdate = true;
+    leaves.instanceColor.needsUpdate = true;
+    leaves.receiveShadow = true;
+    root.add(leaves);
+  }
+  return { amberLeaves, cyanLeaves, count: targetCount, geometry };
+}
+
+function createEnergyNetwork(seed, variant, materials, specs, root) {
+  const energyGroup = new THREE.Group();
+  energyGroup.name = 'repolis-gold-energy-network';
+  const selected = specs.filter((spec) => (
+    spec.importance === 'trunk'
+    || spec.id.includes('foundation')
+    || spec.id.includes('crown')
+    || spec.id.includes('spire')
+  ));
+  for (const spec of selected) {
+    const curve = new THREE.CatmullRomCurve3(
+      spec.points.map((point) => point.clone().add(new THREE.Vector3(0, 0, spec.importance === 'trunk' ? 0.92 : 0.05))),
+      false,
+      'centripetal',
+      0.42,
+    );
+    const mesh = new THREE.Mesh(
+      new THREE.TubeGeometry(curve, spec.importance === 'trunk' ? 64 : 32, spec.importance === 'trunk' ? 0.075 : 0.032, 7, false),
+      materials.energy,
+    );
+    mesh.name = `${spec.id}__energy`;
+    energyGroup.add(mesh);
+  }
+  const core = new THREE.Mesh(new THREE.SphereGeometry(0.3, 24, 16), materials.energy);
+  core.position.set(0, 0.55, 0.98);
+  core.name = 'repolis-energy-core';
+  energyGroup.add(core);
+  const rootLight = new THREE.PointLight(new THREE.Color(variant.energy), 18, 7, 2);
+  rootLight.position.set(0, 1.0, 1.4);
+  energyGroup.add(rootLight);
+  root.add(energyGroup);
+  return { group: energyGroup, core, light: rootLight };
+}
+
+function createCodeGlyphs(seed, materials, specs, root) {
+  const rng = seededRandom(`${seed}/code-glyphs`);
+  const selected = specs.filter((spec) => (
+    spec.importance === 'trunk'
+    || spec.id.includes('foundation')
+    || spec.id.includes('crown')
+    || spec.id.includes('spire')
+  ));
+  const glyphs = [];
+  for (const spec of selected) {
+    const curve = new THREE.CatmullRomCurve3(spec.points, false, 'centripetal', 0.42);
+    const count = spec.importance === 'trunk' ? 18 : 9;
+    for (let index = 0; index < count; index += 1) {
+      const t = THREE.MathUtils.lerp(0.12, 0.9, (index + 1) / (count + 1));
+      glyphs.push({
+        position: curve.getPointAt(t).add(new THREE.Vector3(0, 0, spec.importance === 'trunk' ? 1.04 : 0.18)),
+        tangent: curve.getTangentAt(t).normalize(),
+        cyan: rng.next() < 0.22,
+        scale: rng.range(0.72, 1.3),
+      });
+    }
+  }
+  const geometry = new THREE.PlaneGeometry(0.07, 0.2);
+  const goldData = glyphs.filter((glyph) => !glyph.cyan);
+  const cyanData = glyphs.filter((glyph) => glyph.cyan);
+  const up = new THREE.Vector3(0, 1, 0);
+  const matrix = new THREE.Matrix4();
+  const build = (data, material, name) => {
+    const mesh = new THREE.InstancedMesh(geometry, material, data.length);
+    mesh.name = name;
+    data.forEach((glyph, index) => {
+      const quaternion = new THREE.Quaternion().setFromUnitVectors(up, glyph.tangent);
+      matrix.compose(
+        glyph.position,
+        quaternion,
+        new THREE.Vector3(glyph.scale, glyph.scale, glyph.scale),
+      );
+      mesh.setMatrixAt(index, matrix);
+    });
+    mesh.instanceMatrix.needsUpdate = true;
+    root.add(mesh);
+    return mesh;
+  };
+  return {
+    gold: build(goldData, materials.glyphGold, 'repolis-gold-code-glyphs'),
+    cyan: build(cyanData, materials.glyphCyan, 'repolis-cyan-code-glyphs'),
+    count: glyphs.length,
+    geometry,
+  };
+}
+
+function createConstellations(seed, variant, materials, anchors, root) {
+  const rng = seededRandom(`${seed}/constellations/${variant.id}`);
+  const group = new THREE.Group();
+  group.name = 'repolis-constellation-and-hanging-lights';
+  const nodeGeometry = new THREE.SphereGeometry(0.055, 10, 8);
+  const nodes = new THREE.InstancedMesh(nodeGeometry, materials.energy, 46);
+  const points = [];
+  const matrix = new THREE.Matrix4();
+  for (let index = 0; index < nodes.count; index += 1) {
+    const anchor = rng.pick(anchors);
+    const position = anchor.position.clone().add(new THREE.Vector3(
+      rng.signed() * 0.45,
+      rng.range(-0.2, 0.65),
+      rng.range(0.45, 1.25),
+    ));
+    points.push(position);
+    const scale = rng.range(0.55, 1.35);
+    matrix.compose(position, new THREE.Quaternion(), new THREE.Vector3(scale, scale, scale));
+    nodes.setMatrixAt(index, matrix);
+  }
+  nodes.instanceMatrix.needsUpdate = true;
+  group.add(nodes);
+
+  const linePositions = [];
+  for (let index = 0; index < points.length - 1; index += 1) {
+    if (index % 5 === 4) continue;
+    if (points[index].distanceTo(points[index + 1]) > 1.4) continue;
+    linePositions.push(...points[index].toArray(), ...points[index + 1].toArray());
+  }
+  const lineGeometry = new THREE.BufferGeometry();
+  lineGeometry.setAttribute('position', new THREE.Float32BufferAttribute(linePositions, 3));
+  const lines = new THREE.LineSegments(
+    lineGeometry,
+    new THREE.LineBasicMaterial({
+      color: variant.cyan,
+      transparent: true,
+      opacity: 0.55,
+      blending: THREE.AdditiveBlending,
+    }),
+  );
+  group.add(lines);
+
+  const hangingAnchors = anchors
+    .filter((anchor) => anchor.position.y > 5 && Math.abs(anchor.position.x) > 2.4)
+    .slice(0, 18);
+  for (const [index, anchor] of hangingAnchors.entries()) {
+    const length = 0.45 + (index % 5) * 0.17;
+    const curve = new THREE.LineCurve3(
+      anchor.position.clone(),
+      anchor.position.clone().add(new THREE.Vector3(0, -length, 0)),
+    );
+    group.add(new THREE.Mesh(
+      new THREE.TubeGeometry(curve, 4, 0.012, 5, false),
+      materials.energy,
+    ));
+    const bulb = new THREE.Mesh(new THREE.SphereGeometry(0.052, 10, 8), materials.energy);
+    bulb.position.copy(curve.v2);
+    group.add(bulb);
+  }
+  root.add(group);
+  return { group, nodes, lines };
+}
+
+export function createRepolisHero({
+  seed = 20260711,
+  variant = 0,
+  stage = 'full',
+} = {}) {
+  const startedAt = performance.now();
+  const variantConfig = typeof variant === 'number'
+    ? REPOLIS_VARIANTS[variant % REPOLIS_VARIANTS.length]
+    : REPOLIS_VARIANTS.find((item) => item.id === variant) ?? REPOLIS_VARIANTS[0];
+  const stageLevel = STAGE_LEVEL[stage] ?? STAGE_LEVEL.full;
+  const root = new THREE.Group();
+  root.name = 'RepolisHeroTree';
+  const livingSystem = new THREE.Group();
+  livingSystem.name = 'repolis-living-system';
+  root.add(livingSystem);
+  const branchSystem = new THREE.Group();
+  branchSystem.name = 'repolis-action-ready-branch-system';
+  livingSystem.add(branchSystem);
+  const runtime = {
+    nodes: { root, 'living-system': livingSystem, 'branch-system': branchSystem },
+    meshes: {},
+    sockets: {},
+    colliders: {
+      trunk: { type: 'compound-capsule', height: 9.8, radius: 1.15 },
+      crown: { type: 'ellipsoid', center: [0, 8.1, 0], scale: [8.2, 4.6, 3.8] },
+    },
+    destructionGroups: {},
+  };
+  const detailedMaterial = stageLevel >= STAGE_LEVEL['material-pass'];
+  const materials = createMaterials(seed, variantConfig, detailedMaterial);
+  const macroSpecs = macroBranchSpecs();
+  const roots = rootSpecs();
+  const allMacro = stageLevel >= STAGE_LEVEL['structural-pass']
+    ? [...macroSpecs, ...roots]
+    : macroSpecs;
+  const branchRecords = new Map();
+  let vertexCount = 0;
+
+  for (const spec of allMacro) {
+    const parentRecord = branchRecords.get(spec.parentId);
+    const parentNode = parentRecord?.pivot ?? branchSystem;
+    const parentOrigin = parentRecord?.origin ?? new THREE.Vector3();
+    const record = addBranchNode(
+      spec,
+      parentNode,
+      parentOrigin,
+      materials.bark,
+      runtime,
+      seed,
+    );
+    branchRecords.set(spec.id, record);
+    vertexCount += record.geometry.getAttribute('position').count;
+  }
+
+  const secondary = stageLevel >= STAGE_LEVEL['structural-pass']
+    ? macroSpecs.flatMap((spec) => secondaryBranches(spec, seed, stageLevel >= STAGE_LEVEL['form-refinement'] ? 1 : 0.62))
+    : [];
+  for (const spec of secondary) {
+    const parentRecord = branchRecords.get(spec.parentId);
+    const record = addBranchNode(
+      spec,
+      parentRecord?.pivot ?? branchSystem,
+      parentRecord?.origin ?? new THREE.Vector3(),
+      materials.bark,
+      runtime,
+      seed,
+    );
+    branchRecords.set(spec.id, record);
+    vertexCount += record.geometry.getAttribute('position').count;
+  }
+
+  const fine = stageLevel >= STAGE_LEVEL['form-refinement']
+    ? secondary.flatMap((spec) => fineBranches(spec, seed))
+    : [];
+  if (fine.length) {
+    const fineGeometry = mergedFineGeometry(fine, seed);
+    const fineMesh = new THREE.Mesh(fineGeometry, materials.bark);
+    fineMesh.name = 'repolis-fine-branches-merged';
+    fineMesh.receiveShadow = true;
+    branchSystem.add(fineMesh);
+    runtime.meshes['fine-branches'] = fineMesh;
+    vertexCount += fineGeometry.getAttribute('position').count;
+  }
+
+  const anchorSpecs = fine.length ? fine : secondary.length ? secondary : macroSpecs;
+  const anchors = anchorSpecs.map((spec) => {
+    const end = spec.points.at(-1).clone();
+    const before = spec.points.at(-2) ?? spec.points[0];
+    return {
+      position: end,
+      direction: end.clone().sub(before).normalize(),
+      sourceId: spec.id,
+    };
+  });
+  const ground = createGround(seed, materials, root);
+  let moss = null;
+  let foliage = null;
+  let energy = null;
+  let constellations = null;
+  let glyphs = null;
+  if (stageLevel >= STAGE_LEVEL['material-pass']) {
+    energy = createEnergyNetwork(seed, variantConfig, materials, macroSpecs, livingSystem);
+    runtime.nodes['energy-network'] = energy.group;
+    runtime.sockets['energy:root'] = energy.core;
+  }
+  if (stageLevel >= STAGE_LEVEL['material-pass']) {
+    foliage = createFoliage(seed, variantConfig, materials, anchors, livingSystem);
+    runtime.meshes['amber-foliage'] = foliage.amberLeaves;
+    runtime.meshes['cyan-foliage'] = foliage.cyanLeaves;
+  }
+  if (stageLevel >= STAGE_LEVEL['surface-pass']) {
+    moss = createMoss(seed, materials, livingSystem);
+    glyphs = createCodeGlyphs(seed, materials, macroSpecs, livingSystem);
+    constellations = createConstellations(seed, variantConfig, materials, anchors, livingSystem);
+    runtime.meshes.moss = moss;
+    runtime.meshes['gold-code-glyphs'] = glyphs.gold;
+    runtime.meshes['cyan-code-glyphs'] = glyphs.cyan;
+    runtime.nodes.constellations = constellations.group;
+  }
+
+  root.userData.sculptRuntime = {
+    nodeIds: Object.keys(runtime.nodes),
+    meshIds: Object.keys(runtime.meshes),
+    socketIds: Object.keys(runtime.sockets),
+    colliders: runtime.colliders,
+    destructionGroupIds: Object.keys(runtime.destructionGroups),
+    liveRuntime: 'Use the returned hero.runtime object for Object3D references.',
+  };
+  root.userData.sculptDNA = {
+    seed,
+    variantId: variantConfig.id,
+    variantLabel: variantConfig.label,
+    stage,
+    invariantPolicy: [
+      'component-ids',
+      'parent-links',
+      'socket-ids',
+      'attachment-roots',
+      'destruction-groups',
+    ],
+  };
+  const generationMs = performance.now() - startedAt;
+  const stats = {
+    generationMs,
+    macroBranches: allMacro.length,
+    secondaryBranches: secondary.length,
+    fineBranches: fine.length,
+    leafInstances: foliage?.count ?? 0,
+    mossInstances: moss?.count ?? 0,
+    branchVertices: vertexCount,
+    glyphInstances: glyphs?.count ?? 0,
+    importedMeshes: 0,
+    stage,
+  };
+  root.userData.generationStats = stats;
+
+  const update = (elapsedSeconds) => {
+    if (energy) {
+      const pulse = 2.55 + Math.sin(elapsedSeconds * 2.1) * 0.45;
+      materials.energy.emissiveIntensity = pulse;
+      energy.light.intensity = 16 + Math.sin(elapsedSeconds * 1.7) * 3;
+    }
+    if (foliage) {
+      foliage.amberLeaves.rotation.y = Math.sin(elapsedSeconds * 0.17) * 0.006;
+      foliage.cyanLeaves.rotation.y = Math.sin(elapsedSeconds * 0.21 + 1) * 0.008;
+    }
+    livingSystem.rotation.z = Math.sin(elapsedSeconds * 0.22) * 0.0025;
+    livingSystem.rotation.x = Math.sin(elapsedSeconds * 0.17 + 0.8) * 0.0015;
+  };
+
+  const dispose = () => {
+    const geometries = new Set();
+    const disposableMaterials = new Set(materials.disposable);
+    root.traverse((object) => {
+      if (object.geometry) geometries.add(object.geometry);
+      const objectMaterials = Array.isArray(object.material)
+        ? object.material
+        : object.material
+          ? [object.material]
+          : [];
+      objectMaterials.forEach((material) => disposableMaterials.add(material));
+    });
+    geometries.forEach((geometry) => geometry.dispose());
+    disposableMaterials.forEach((material) => material.dispose());
+    Object.values(materials.textures ?? {}).forEach((texture) => texture.dispose());
+  };
+
+  return {
+    root,
+    runtime,
+    stats,
+    variant: variantConfig,
+    update,
+    dispose,
+    materials,
+    ground,
+  };
+}

--- a/index.html
+++ b/index.html
@@ -935,6 +935,10 @@
 <script type="module">
 import * as THREE from 'three';
 import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { createRepolisHero } from './assets/world-tree/createRepolisHero.js';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -1477,6 +1481,41 @@ const detail = n => Math.max(0, Math.round(n*DETAIL));                       // 
 const scene = new THREE.Scene();
 scene.fog = new THREE.Fog(0xd9e4c8, 150, 460);
 const camera = new THREE.PerspectiveCamera(54, innerWidth/innerHeight, 0.1, 760);
+const treeBloomDpr=matchMedia('(pointer:coarse)').matches?1:renderer.getPixelRatio();
+const treeComposer=new EffectComposer(renderer); treeComposer.renderToScreen=false; treeComposer.setPixelRatio(treeBloomDpr); treeComposer.setSize(innerWidth,innerHeight);
+const treeRenderPass=new RenderPass(scene,camera); treeRenderPass.clearColor=new THREE.Color(0x000000); treeRenderPass.clearAlpha=0; treeComposer.addPass(treeRenderPass);
+const worldBloom=new UnrealBloomPass(new THREE.Vector2(innerWidth,innerHeight),0.5,0.36,0.88); treeComposer.addPass(worldBloom);
+const bloomOverlayScene=new THREE.Scene(),bloomOverlayCamera=new THREE.OrthographicCamera(-1,1,1,-1,0,1);
+const bloomOverlay=new THREE.Mesh(new THREE.PlaneGeometry(2,2),new THREE.MeshBasicMaterial({map:treeComposer.renderTarget2.texture,transparent:true,blending:THREE.AdditiveBlending,depthTest:false,depthWrite:false,toneMapped:false})); bloomOverlayScene.add(bloomOverlay);
+const BLOOM_DARK_MATERIAL=new THREE.MeshBasicMaterial({color:0x000000}),BLOOM_DARK_SPRITE=new THREE.SpriteMaterial({color:0x000000,transparent:false,depthTest:false,depthWrite:false}),BLOOM_MATERIALS=new Map();
+function _registerWorldTreeOccluderGroup(group){
+  if(!group||!MEMORIAL_TREE) return; group.traverse(o=>{ if((o.isMesh||o.isSprite)&&!MEMORIAL_TREE.occluders.includes(o)){ o.layers.enable(MEM_TREE_LIGHT_LAYER); MEMORIAL_TREE.occluders.push(o); } });
+}
+function _unregisterWorldTreeOccluderGroup(group){
+  if(!group||!MEMORIAL_TREE) return; const remove=new Set(); group.traverse(o=>{ if(o.isMesh||o.isSprite) remove.add(o); }); MEMORIAL_TREE.occluders=MEMORIAL_TREE.occluders.filter(o=>!remove.has(o));
+}
+function _ensureWorldTreeOccluders(){
+  if(!MEMORIAL_TREE||MEMORIAL_TREE.occludersReady) return; scene.updateMatrixWorld(true);
+  const treeBox=_memHeroBox(MEMORIAL_TREE.group).expandByScalar(3),occluders=[];
+  scene.traverse(o=>{ if(!o.isMesh||(o.userData&&o.userData.worldTreeBloom)) return; if(!o.geometry.boundingBox) o.geometry.computeBoundingBox();
+    const box=o.geometry.boundingBox.clone().applyMatrix4(o.matrixWorld); if(box.intersectsBox(treeBox)){ o.layers.enable(MEM_TREE_LIGHT_LAYER); occluders.push(o); } });
+  MEMORIAL_TREE.occluders=occluders; _registerWorldTreeOccluderGroup(model); RESIDENTS_LIVE.forEach(L=>_registerWorldTreeOccluderGroup(L.group)); MEMORIAL_TREE.occludersReady=true;
+}
+function _prepareWorldTreeBloom(){
+  _ensureWorldTreeOccluders(); for(const o of MEMORIAL_TREE.occluders){ BLOOM_MATERIALS.set(o,o.material); o.material=o.isSprite?BLOOM_DARK_SPRITE:BLOOM_DARK_MATERIAL; }
+}
+function _restoreWorldTreeBloom(){
+  BLOOM_MATERIALS.forEach((material,o)=>{ o.material=material; }); BLOOM_MATERIALS.clear();
+}
+function _renderWorldTreeFrame(refreshTownShadows){
+  if(!MEMORIAL_TREE){ renderer.shadowMap.needsUpdate=refreshTownShadows; renderer.render(scene,camera); return; }
+  const mask=camera.layers.mask; _prepareWorldTreeBloom(); MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=true; }); camera.layers.set(MEM_TREE_LIGHT_LAYER);
+  renderer.shadowMap.needsUpdate=MEMORIAL_TREE.treeShadowDirty; treeComposer.render(); MEMORIAL_TREE.treeShadowDirty=false; _restoreWorldTreeBloom();
+  MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=false; }); camera.layers.set(0);
+  renderer.shadowMap.needsUpdate=refreshTownShadows; renderer.setRenderTarget(null); renderer.render(scene,camera);
+  const autoClear=renderer.autoClear; renderer.autoClear=false; renderer.render(bloomOverlayScene,bloomOverlayCamera); renderer.autoClear=autoClear;
+  camera.layers.mask=mask; MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=true; });
+}
 
 /* toon gradient + material factory */
 function toonGradient(){
@@ -2707,227 +2746,60 @@ function makeRiver(ctrl, opt={}){
     EXTRA_COLLIDERS.push({x:sgx,z:sgz,r:0.4}); }
 }
 /*MEMORIAL_TREE:START*/
-// 🌳 Repolis World Tree Pillar v3 — a colossal, code-native support/roof for the village.
-// Base structure follows Object Sculptor; foliage/materials promote one invariant-safe Sculpt DNA variant.
-const MEMORIAL_TREE_SEED=1730, MEMORIAL_TREE_POS=new THREE.Vector3(15,0,48), MEM_TREE_LITE=LOW_END||IS_MOBILE;
+// 🌳 Solar Archive — unchanged threejs-sculpt-dna production factory, integrated through a thin Repolis adapter.
+const MEMORIAL_TREE_SEED=20260711, MEMORIAL_TREE_POS=new THREE.Vector3(15,0,48), MEM_TREE_LITE=LOW_END||IS_MOBILE;
 let MEMORIAL_TREE=null;
-function _memTreeRng(seed){ let s=seed>>>0; return ()=>{ s=(s+0x6d2b79f5)|0; let t=s; t=Math.imul(t^(t>>>15),t|1); t^=t+Math.imul(t^(t>>>7),t|61); return ((t^(t>>>14))>>>0)/4294967296; }; }
-const MEM_TREE_DNA=Object.freeze({
-  schemaVersion:'1.0',variantId:'repolis-world-tree-pillar-v3-refinement',rootSeed:1760,variantSeed:'1760001',
-  canopy:{desktop:809,medium:413,lowEnd:96,far:58},leafSurface:{normal:0.4354,bump:0.0774,colorBreakup:0.2242,repeat:2.798},
-  palette:{outer:0x4a9a7f,mid:0x4c856b,shadow:0x285953,gold:0xe69a24},
-  invariants:['component-ids','parent-links','material-refs','socket-ids','fracture-groups','attachment-roots','build-pass-order','feature-review-targets']
-});
-function _memLeafStamp(ctx,x,y,s,a,fill,vein,line){
-  ctx.save(); ctx.translate(x,y); ctx.rotate(a); ctx.fillStyle=fill; ctx.strokeStyle=vein; ctx.lineWidth=line;
-  ctx.beginPath(); ctx.moveTo(-s,0); ctx.bezierCurveTo(-s*.45,-s*.58,s*.45,-s*.58,s,0); ctx.bezierCurveTo(s*.45,s*.58,-s*.45,s*.58,-s,0); ctx.fill(); ctx.stroke();
-  ctx.beginPath(); ctx.moveTo(-s*.72,0); ctx.lineTo(s*.72,0);
-  for(let j=-2;j<=2;j++){ const px=j*s*.22; ctx.moveTo(px,0); ctx.lineTo(px+s*.2,-s*.3); ctx.moveTo(px,0); ctx.lineTo(px+s*.2,s*.3); }
-  ctx.stroke(); ctx.restore();
+const MEM_TREE_HERO_SCALE=2, MEM_TREE_HERO_NATIVE_SCALE=0.96, MEM_TREE_LIGHT_LAYER=2, MEM_TREE_HERO_VARIANT='solar-archive', MEM_TREE_FACTORY_SHA='65bd7fc76013ee0f11898174095556d581be64ea8f15e76e090fb8955a17d0e3';
+function _memHeroBox(root){
+  root.updateMatrixWorld(true); const box=new THREE.Box3();
+  root.traverse(o=>{ if(!o.visible||!o.geometry) return; let local;
+    if(o.isInstancedMesh){ o.computeBoundingBox(); local=o.boundingBox; }
+    else { if(!o.geometry.boundingBox) o.geometry.computeBoundingBox(); local=o.geometry.boundingBox; }
+    if(local) box.union(local.clone().applyMatrix4(o.matrixWorld)); });
+  return box;
 }
-function _memFieldCanvas(size,fn){
-  const c=document.createElement('canvas'),ctx=c.getContext('2d'),img=ctx.createImageData(size,size); c.width=c.height=size;
-  for(let y=0;y<size;y++) for(let x=0;x<size;x++){ const v=fn(x/size,y/size,x,y),rgb=Array.isArray(v)?v:[v,v,v],o=(y*size+x)*4;
-    img.data[o]=Math.max(0,Math.min(255,rgb[0]|0)); img.data[o+1]=Math.max(0,Math.min(255,rgb[1]|0)); img.data[o+2]=Math.max(0,Math.min(255,rgb[2]|0)); img.data[o+3]=255; }
-  ctx.putImageData(img,0,0); return c;
+function _memHeroObjectPerf(root){
+  const perf={draws:0,triangles:0}; root.traverse(o=>{ if(!o.visible||!o.isMesh) return; perf.draws++;
+    const g=o.geometry,n=g&&((g.index&&g.index.count)||(g.attributes.position&&g.attributes.position.count))||0; perf.triangles+=Math.round(n/3)*(o.isInstancedMesh?o.count:1); });
+  return perf;
 }
-function _memCanvasTex(canvas,name,srgb,rx,ry){
-  const t=new THREE.CanvasTexture(canvas); t.name=name; t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(rx,ry); t.anisotropy=MEM_TREE_LITE?1:2; if(srgb) t.colorSpace=THREE.SRGBColorSpace; return t;
+function _memHeroEnvironment(root){
+  camera.layers.enable(MEM_TREE_LIGHT_LAYER); return {lights:1};
 }
-function _memBarkTextures(seed,cavity){
-  const size=MEM_TREE_LITE?64:256,aR=_memTreeRng(seed),rR=_memTreeRng(seed^0x51f2),hR=_memTreeRng(seed^0xa711),oR=_memTreeRng(seed^0xc403),base=cavity?[72,43,32]:[142,88,48];
-  const albedo=_memFieldCanvas(size,(u,v)=>{ const ridge=Math.sin((u*7.2+Math.sin(v*9)*0.08)*Math.PI*2),n=(aR()-.5)*22,w=1-v*0.16; return [(base[0]+ridge*14+n)*w,(base[1]+ridge*9+n*.55)*w,(base[2]+ridge*5+n*.3)*w]; });
-  const roughness=_memFieldCanvas(size,(u,v)=>188+Math.sin((u*5.4+v*.4)*Math.PI*2)*18+(rR()-.5)*34);
-  const height=MEM_TREE_LITE?null:_memFieldCanvas(size,(u,v)=>128+Math.sin((u*7.2+Math.sin(v*8)*0.07)*Math.PI*2)*48+(hR()-.5)*22);
-  const ao=_memFieldCanvas(size,(u,v)=>215-Math.pow(Math.abs(Math.sin((u*7.2+v*.08)*Math.PI*2)),5)*82+(oR()-.5)*20);
-  const maps={map:_memCanvasTex(albedo,'WorldTree_BarkAlbedo_'+seed,true,4,2),roughness:_memCanvasTex(roughness,'WorldTree_BarkRoughness_'+seed,false,4,2),
-    bump:height?_memCanvasTex(height,'WorldTree_BarkHeight_'+seed,false,4,2):null,ao:_memCanvasTex(ao,'WorldTree_BarkAO_'+seed,false,4,2),size};
-  maps.ao.channel=0; return maps;
+function _memHeroUpdate(elapsed){
+  if(!MEMORIAL_TREE) return; if(!REDUCED) MEMORIAL_TREE.hero.update(elapsed);
+  const ratio=MEM_TREE_HERO_SCALE/MEM_TREE_HERO_NATIVE_SCALE,m=MEMORIAL_TREE.hero.materials; MEMORIAL_TREE.light.distance=7*ratio;   // preserve factory pulse intensity; only its authored range follows uniform scale
+  if(isNight){ m.amberLeaf.emissiveIntensity=0.42; m.cyanLeaf.emissiveIntensity=0.75; if(REDUCED){ m.energy.emissiveIntensity=2.85; MEMORIAL_TREE.light.intensity=18; } }
+  else { m.energy.emissiveIntensity=0.32; m.amberLeaf.emissiveIntensity=0.12; m.cyanLeaf.emissiveIntensity=0.18; MEMORIAL_TREE.light.intensity=2; }
 }
-function _memLeafTextures(seed,shadow){
-  const size=MEM_TREE_LITE?64:128,albedo=document.createElement('canvas'),height=MEM_TREE_LITE?null:document.createElement('canvas'),ac=albedo.getContext('2d'),hc=height&&height.getContext('2d'),
-    aR=_memTreeRng(seed),hR=_memTreeRng(seed^0x714b),rR=_memTreeRng(seed^0x9c31),oR=_memTreeRng(seed^0xd205);
-  albedo.width=albedo.height=size; if(height) height.width=height.height=size; ac.fillStyle=shadow?'#9ab7a2':'#d7ead7'; ac.fillRect(0,0,size,size); if(hc){ hc.fillStyle='#707070'; hc.fillRect(0,0,size,size); }
-  const count=MEM_TREE_LITE?8:14; for(let i=0;i<count;i++){ let x=aR()*size,y=aR()*size,s=size*(0.12+aR()*0.12),a=aR()*Math.PI;
-    _memLeafStamp(ac,x,y,s,a,shadow?'rgba(197,224,202,.42)':'rgba(241,255,233,.58)',shadow?'rgba(25,75,55,.6)':'rgba(42,103,63,.58)',Math.max(.55,s*.055));
-    if(hc){ x=hR()*size; y=hR()*size; s=size*(0.1+hR()*0.11); a=hR()*Math.PI; _memLeafStamp(hc,x,y,s,a,i%3?'#9b9b9b':'#ababab','#d8d8d8',Math.max(.7,s*.07)); } }
-  const roughness=_memFieldCanvas(size,(u,v)=>178+Math.sin((u*3.1-v*2.4)*Math.PI*2)*15+(rR()-.5)*42);
-  const ao=_memFieldCanvas(size,(u,v)=>224-Math.pow(Math.abs(Math.sin((u*2.7+v*3.3)*Math.PI*2)),6)*54+(oR()-.5)*18),rep=MEM_TREE_DNA.leafSurface.repeat;
-  const maps={map:_memCanvasTex(albedo,'WorldTree_LeafAlbedo_'+seed,true,rep,rep),roughness:_memCanvasTex(roughness,'WorldTree_LeafRoughness_'+seed,false,rep,rep),
-    bump:height?_memCanvasTex(height,'WorldTree_LeafHeight_'+seed,false,rep,rep):null,ao:_memCanvasTex(ao,'WorldTree_LeafAO_'+seed,false,rep,rep),size};
-  maps.ao.channel=0; return maps;
-}
-function _memLeafCardTexture(seed){
-  const size=64,c=document.createElement('canvas'),ctx=c.getContext('2d'),rng=_memTreeRng(seed); c.width=c.height=size; ctx.clearRect(0,0,size,size);
-  [[-10,4,-0.46],[9,5,0.5],[0,-9,0]].forEach((v,i)=>_memLeafStamp(ctx,size/2+v[0],size/2+v[1],size*(i===2?.34:.3),v[2]+(rng()-.5)*.1,
-    i===2?'rgba(245,255,230,.98)':'rgba(219,247,215,.96)','rgba(38,98,58,.92)',1.15));
-  const tex=new THREE.CanvasTexture(c); tex.name='WorldTree_LeafCard'; tex.colorSpace=THREE.SRGBColorSpace; tex.anisotropy=2; return tex;
-}
-const MEM_TREE_LEAF_TEXTURES=[_memLeafTextures(174006,false),_memLeafTextures(174607,true)];
-const MEM_TREE_BARK_TEXTURES=[_memBarkTextures(176001,false),_memBarkTextures(176613,true)];
-const MEM_TREE_LEAF_CARD_TEX=MEM_TREE_LITE?null:_memLeafCardTexture(1740061);
-function _memPbrMaterial(color,tex,roughness,bumpScale,vertexColors=false){
-  const m=applyRim(new THREE.MeshStandardMaterial({color,map:tex&&tex.map||null,roughnessMap:tex&&tex.roughness||null,bumpMap:tex&&tex.bump||null,aoMap:tex&&tex.ao||null,
-    roughness,metalness:0,bumpScale,aoMapIntensity:0.72,vertexColors,flatShading:true})); m.needsUpdate=true; return m;
-}
-const MEM_TREE_MATS={
-  bark:_memPbrMaterial(0xffffff,MEM_TREE_BARK_TEXTURES[0],0.92,0.2), cavity:_memPbrMaterial(0xd8b29a,MEM_TREE_BARK_TEXTURES[1],0.98,0.12), earth:_memPbrMaterial(0x6f5738,null,0.98,0),
-  foliage:_memPbrMaterial(0xffffff,MEM_TREE_LEAF_TEXTURES[0],0.92,MEM_TREE_DNA.leafSurface.bump,true), shadow:_memPbrMaterial(0xe2eee3,MEM_TREE_LEAF_TEXTURES[1],0.98,0.045,true),
-  gold:_memPbrMaterial(MEM_TREE_DNA.palette.gold,null,0.42,0)
-};
-const MEM_TREE_BARK=[MEM_TREE_MATS.bark,MEM_TREE_MATS.cavity], MEM_TREE_LEAVES=[MEM_TREE_MATS.foliage,MEM_TREE_MATS.shadow], MEM_TREE_GOLD=MEM_TREE_MATS.gold;
-MEM_TREE_BARK.forEach(m=>{ m.emissiveIntensity=0.08; });
-MEM_TREE_LEAVES.forEach(m=>{ m.emissiveIntensity=0.12; });
-MEM_TREE_GOLD.emissiveIntensity=0.22;
-const MEM_TREE_LEAF_GEOS=[MEM_TREE_LITE?new THREE.DodecahedronGeometry(0.84,0):new THREE.IcosahedronGeometry(0.78,0),new THREE.DodecahedronGeometry(0.86,0)];
-const MEM_TREE_KNOT_GEO=new THREE.DodecahedronGeometry(1,0), MEM_TREE_LEAF_CARD_GEO=MEM_TREE_LITE?null:new THREE.PlaneGeometry(1.25,2.15);
-const MEM_TREE_LEAF_CARD_MAT=MEM_TREE_LITE?null:applyRim(new THREE.MeshStandardMaterial({map:MEM_TREE_LEAF_CARD_TEX,color:0xffffff,roughness:0.82,metalness:0,vertexColors:true,alphaTest:0.42,side:THREE.DoubleSide}));
-const MEM_TREE_FOLIAGE_COLORS=[
-  [MEM_TREE_DNA.palette.outer,MEM_TREE_DNA.palette.mid,0x67aa78,0x7bbf82],
-  [MEM_TREE_DNA.palette.shadow,0x315b50,0x526b3b,0x244b39]
-].map(a=>a.map(c=>new THREE.Color(c)));
-function _memV(a){ return new THREE.Vector3(a[0],a[1],a[2]); }
-function _memLimb(parent, raw, r0, r1, material, radial, steps, stats, outlined=true){
-  const pts=raw.map(_memV), curve=new THREE.CatmullRomCurve3(pts,false,'centripetal',0.5); radial=radial||(MEM_TREE_LITE?7:10); steps=steps||Math.max(4,(pts.length-1)*(MEM_TREE_LITE?2:3));
-  const frames=curve.computeFrenetFrames(steps,false), pos=[], uv=[], idx=[];
-  for(let i=0;i<=steps;i++){ const u=i/steps, p=curve.getPointAt(u), radius=(r0+(r1-r0)*Math.pow(u,0.82))*(1+(1-u)*(1-u)*(r0>1.5?0.16:0.06));
-    for(let j=0;j<radial;j++){ const a=j/radial*Math.PI*2, rough=1+0.045*Math.sin(j*2.1+i*1.7)+0.022*Math.sin(j*4.3-i*0.8);
-      const off=frames.normals[i].clone().multiplyScalar(Math.cos(a)*radius*rough).add(frames.binormals[i].clone().multiplyScalar(Math.sin(a)*radius*rough));
-      pos.push(p.x+off.x,p.y+off.y,p.z+off.z); uv.push(j/radial,u); } }
-  for(let i=0;i<steps;i++) for(let j=0;j<radial;j++){ const a=i*radial+j,b=i*radial+(j+1)%radial,c=(i+1)*radial+j,d=(i+1)*radial+(j+1)%radial; idx.push(a,c,b,b,c,d); }
-  const geo=new THREE.BufferGeometry(); geo.setAttribute('position',new THREE.Float32BufferAttribute(pos,3)); geo.setAttribute('uv',new THREE.Float32BufferAttribute(uv,2)); geo.setIndex(idx); geo.computeVertexNormals(); geo.computeBoundingSphere();
-  const mat=material&&material.isMaterial?material:MEM_TREE_BARK[(material||0)%MEM_TREE_BARK.length], mesh=new THREE.Mesh(geo,mat); mesh.name=parent.name+'_Sweep'; mesh.castShadow=!MEM_TREE_LITE; mesh.receiveShadow=true; parent.add(mesh);
-  if(outlined&&!MEM_TREE_LITE&&r0>0.72) outline(mesh,Math.min(0.13,r0*0.055)); stats.segments+=steps; stats.sweeps=(stats.sweeps||0)+1; return mesh;
-}
-function _memLeafMass(parent, sectorAngle, total, rng, stats, sectorIndex){
-  const dx=Math.cos(sectorAngle),dz=Math.sin(sectorAngle)*0.78,tx=-Math.sin(sectorAngle),tz=Math.cos(sectorAngle)*0.78;
-  const lobes=[
-    {r:2.5,y:11.6,lr:2.3,sr:2.8,yr:3.8,band:0},
-    {r:5.1,y:13.1,lr:3.2,sr:3.8,yr:5.2,band:0},
-    {r:8.9,y:10.2,lr:4.3,sr:4.8,yr:5.5,band:1},
-    {r:13.1,y:6.5,lr:4.1,sr:4.9,yr:5.2,band:1},
-    {r:16.8,y:2.7,lr:2.8,sr:3.7,yr:4.3,band:2}
-  ], buckets=[[],[]], cards=[], dummy=new THREE.Object3D();
-  for(let i=0;i<total;i++){ const l=lobes[i%lobes.length],a=rng()*Math.PI*2,rr=Math.sqrt(rng()),along=l.r+Math.sin(a)*l.lr*rr,side=Math.cos(a)*l.sr*rr;
-    const py=l.y+(rng()*2-1)*l.yr*(0.38+0.62*rr), underside=6.2-Math.max(0,along-4.5)*0.39;
-    if((py<underside&&rng()<0.92)||(along<8.2&&py<7.0&&rng()<0.82)) continue;   // high inner vault + descending rim preserve five-to-nine warm branch windows
-    const bi=(py<6.4||rr<0.26||l.band===2&&rng()<0.42||rng()<0.17)?1:0, palette=MEM_TREE_FOLIAGE_COLORS[bi], color=palette[(i+sectorIndex+(rng()*palette.length|0))%palette.length], bandScale=l.band===0?0.9:l.band===2?0.82:1;
-    const leaf={p:[dx*along+tx*side,py,dz*along+tz*side],s:[(1.05+rng()*1.18)*bandScale,(0.72+rng()*0.82)*bandScale,(1.0+rng()*1.12)*bandScale],r:[rng()*0.52,rng()*Math.PI,rng()*0.42],color}; buckets[bi].push(leaf);
-    if(!MEM_TREE_LITE&&bi===0&&((i+sectorIndex*2)%3===0)) cards.push(leaf); }
-  buckets.forEach((list,bi)=>{ if(!list.length) return; const mesh=new THREE.InstancedMesh(MEM_TREE_LEAF_GEOS[bi],MEM_TREE_LEAVES[bi],list.length); mesh.name='WorldTree_Foliage_'+String(sectorIndex+1).padStart(2,'0')+'_'+(bi?'Shadow':'Outer');
-    list.forEach((v,i)=>{ dummy.position.set(...v.p); dummy.scale.set(...v.s); dummy.rotation.set(...v.r); dummy.updateMatrix(); mesh.setMatrixAt(i,dummy.matrix); mesh.setColorAt(i,v.color); });
-    mesh.instanceMatrix.setUsage(THREE.StaticDrawUsage); if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true; mesh.castShadow=!MEM_TREE_LITE&&bi===0; mesh.receiveShadow=false; if(mesh.computeBoundingSphere) mesh.computeBoundingSphere(); parent.add(mesh); stats.leaves+=list.length; });
-  if(cards.length){ const mesh=new THREE.InstancedMesh(MEM_TREE_LEAF_CARD_GEO,MEM_TREE_LEAF_CARD_MAT,cards.length); mesh.name='WorldTree_LeafCards_'+String(sectorIndex+1).padStart(2,'0');
-    cards.forEach((v,i)=>{ dummy.position.set(v.p[0]+dx*1.0,v.p[1]+.45,v.p[2]+dz*1.0); dummy.scale.set(.82+(i%4)*.13,.82+(i%3)*.12,1); dummy.rotation.set(-.28+(i%3)*.18,sectorAngle+Math.PI/2+(i%5-2)*.12,(i%4-1.5)*.12); dummy.updateMatrix(); mesh.setMatrixAt(i,dummy.matrix); mesh.setColorAt(i,v.color); });
-    if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true; mesh.castShadow=false; mesh.receiveShadow=false; mesh.computeBoundingSphere(); parent.add(mesh); stats.leafCards+=cards.length; } }
 function makeMemorialTree(x,z){
-  if(MEMORIAL_TREE) return MEMORIAL_TREE; const rng=_memTreeRng(MEMORIAL_TREE_SEED), root=new THREE.Group(), skeleton=new THREE.Group(), stats={segments:0,sweeps:0,roots:8,leaders:4,barkRidges:MEM_TREE_LITE?6:12,barkPlates:MEM_TREE_LITE?6:18,branches:8,ribs:MEM_TREE_LITE?8:16,goldFans:MEM_TREE_LITE?8:16,frontGoldRibs:MEM_TREE_LITE?5:7,bridgeLeaves:0,leaves:0,leafCards:0,crowns:8,veins:MEM_TREE_LITE?22:72};
-  root.name='RepolisWorldTreePillarV3'; skeleton.name='WorldTree_StaticSkeleton'; root.add(skeleton); root.position.set(x,0,z); root.rotation.y=-0.1; scene.add(root);
-  const rootGroups=[], limbGroups=[], crownGroups=[], sockets={};
-  // Blockout: a 34-unit rooted pillar carrying a 44-unit circular umbrella crown above the village roofs.
-  const moundLow=new THREE.Mesh(new THREE.CylinderGeometry(5.15,5.45,0.9,MEM_TREE_LITE?18:28),MEM_TREE_MATS.earth); moundLow.position.y=0.45; moundLow.receiveShadow=true; skeleton.add(moundLow);
-  const moundHigh=new THREE.Mesh(new THREE.CylinderGeometry(4.35,4.85,1.3,MEM_TREE_LITE?16:24),MEM_TREE_MATS.earth); moundHigh.position.y=1.15; moundHigh.receiveShadow=true; skeleton.add(moundHigh);
-  const flare=new THREE.Mesh(new THREE.CylinderGeometry(3.85,5.05,4.4,MEM_TREE_LITE?10:16),MEM_TREE_BARK[0]); flare.name='WorldTree_ButtressFoundation'; flare.position.y=2.75; flare.castShadow=true; skeleton.add(flare); if(!MEM_TREE_LITE) outline(flare,0.18);
-  for(let i=0;i<stats.roots;i++){ const a=i/stats.roots*Math.PI*2+(rng()-0.5)*0.14, len=5.3+rng()*0.3, rg=new THREE.Group(); rg.name='WorldTree_Root_'+String(i+1).padStart(2,'0'); skeleton.add(rg); rootGroups.push(rg);
-    _memLimb(rg,[[0,6.15,0],[Math.cos(a+0.08)*3.0,2.15,Math.sin(a+0.08)*3.0],[Math.cos(a)*len,0.68,Math.sin(a)*len]],2.18+rng()*0.16,0.2,i%2,MEM_TREE_LITE?7:10,MEM_TREE_LITE?5:8,stats); }
-  const trunk=new THREE.Group(); trunk.name='WorldTree_TrunkPillar'; skeleton.add(trunk); limbGroups.push(trunk);
-  _memLimb(trunk,[[0,1.0,0],[-0.5,5.8,0.32],[0.35,11.2,-0.25],[0,17.8,0]],4.35,2.28,MEM_TREE_BARK[0],MEM_TREE_LITE?9:14,MEM_TREE_LITE?9:14,stats);
-  const ridgeGeo=new THREE.CylinderGeometry(0.1,0.3,10.5,5,2,true),ridgeMesh=new THREE.InstancedMesh(ridgeGeo,MEM_TREE_BARK[0],stats.barkRidges),ridgeDummy=new THREE.Object3D();
-  ridgeMesh.name='WorldTree_BarkRidges';
-  for(let i=0;i<stats.barkRidges;i++){ const a=i/stats.barkRidges*Math.PI*2+(rng()-0.5)*0.18,r=3.18+(i%3)*0.13; ridgeDummy.position.set(Math.cos(a)*r,6.7+(rng()-0.5)*1.5,Math.sin(a)*r);
-    ridgeDummy.rotation.set(Math.sin(a)*0.055,a,(rng()-0.5)*0.13); ridgeDummy.scale.set(0.72+(i%4)*0.11,0.68+rng()*0.32,0.66+(i%2)*0.15); ridgeDummy.updateMatrix(); ridgeMesh.setMatrixAt(i,ridgeDummy.matrix); }
-  ridgeMesh.castShadow=!MEM_TREE_LITE; ridgeMesh.receiveShadow=true; skeleton.add(ridgeMesh);
-  const plateGeo=new THREE.DodecahedronGeometry(0.34,0),plateMesh=new THREE.InstancedMesh(plateGeo,MEM_TREE_BARK[1],stats.barkPlates),plateDummy=new THREE.Object3D();
-  plateMesh.name='WorldTree_BarkPlates';
-  for(let i=0;i<stats.barkPlates;i++){ const a=i/stats.barkPlates*Math.PI*2+(rng()-0.5)*0.42,y=2.6+rng()*11.4,r=Math.max(2.65,4.25-y*0.11); plateDummy.position.set(Math.cos(a)*r,y,Math.sin(a)*r);
-    plateDummy.rotation.set((rng()-0.5)*0.35,a,(rng()-0.5)*0.32); plateDummy.scale.set(0.65+rng()*0.8,1.0+rng()*1.4,0.45+rng()*0.45); plateDummy.updateMatrix(); plateMesh.setMatrixAt(i,plateDummy.matrix); }
-  plateMesh.castShadow=!MEM_TREE_LITE; plateMesh.receiveShadow=true; skeleton.add(plateMesh);
-  const crotch=new THREE.Group(); crotch.name='WorldTree_CrotchMass'; skeleton.add(crotch);
-  const leaderDefs=[
-    [[-0.8,11.6,0.3],[-1.3,15.9,0.5],[-4.6,19.6,1.1],[-7.4,21.2,0.4]],
-    [[0.7,12.1,0.2],[1.4,16.2,0.4],[4.8,19.9,0.7],[7.2,21.8,-0.1]],
-    [[-0.2,12.8,-0.8],[-0.6,16.5,-1.6],[-1.8,20.2,-5.0],[-2.6,21.5,-7.2]],
-    [[0.3,13.0,0.9],[0.7,16.7,1.8],[2.2,20.0,5.0],[3.0,21.0,7.0]]
-  ];
-  leaderDefs.forEach((path,i)=>{ const g=new THREE.Group(); g.name='WorldTree_CrotchLeader_'+String(i+1).padStart(2,'0'); crotch.add(g); limbGroups.push(g);
-    _memLimb(g,path,2.45-i*0.08,0.68,MEM_TREE_BARK[i&1],MEM_TREE_LITE?8:12,MEM_TREE_LITE?7:10,stats,false); });
-  const goldCrotch=new THREE.Mesh(MEM_TREE_KNOT_GEO,MEM_TREE_GOLD); goldCrotch.name='WorldTree_InnerGoldCrotch'; goldCrotch.position.set(0,17.3,-0.6); goldCrotch.scale.set(1.65,2.2,1.55); skeleton.add(goldCrotch);
-  const innerSpine=new THREE.Group(); innerSpine.name='WorldTree_InnerGoldSpine'; skeleton.add(innerSpine);
-  _memLimb(innerSpine,[[0,7.8,-0.25],[-0.2,12.8,-0.45],[0,17.6,-0.9]],0.82,0.34,MEM_TREE_GOLD,MEM_TREE_LITE?6:8,MEM_TREE_LITE?6:9,stats,false);
-  // Structure: eight endpoint-authored radial boughs create the shallow vault and scalloped crown perimeter.
-  const boughSockets=[],boughPaths=[],knotDummy=new THREE.Object3D(),boughKnots=new THREE.InstancedMesh(MEM_TREE_KNOT_GEO,MEM_TREE_BARK[0],stats.branches);
-  for(let i=0;i<stats.branches;i++){ const a=i/stats.branches*Math.PI*2+(rng()-0.5)*0.075, dx=Math.cos(a),dz=Math.sin(a)*0.78,tx=-Math.sin(a),tz=Math.cos(a)*0.78, side=(rng()-0.5)*1.4;
-    const bg=new THREE.Group(); bg.name='WorldTree_PrimaryBough_'+String(i+1).padStart(2,'0'); crotch.add(bg); limbGroups.push(bg);
-    const rootY=14.5+(i%3)*0.72,reach=16.8+rng()*1.2,path=[[dx*0.72,rootY,dz*0.72],[dx*3.7+tx*side,18.1+(i%2)*0.65,dz*3.7+tz*side],
-      [dx*7.8-tx*side*0.25,21.4+(i%3)*0.62,dz*7.8-tz*side*0.25],[dx*12.6+tx*side*0.32,23.0+(i%2)*0.55,dz*12.6+tz*side*0.32],[dx*reach,21.1+rng()*0.9,dz*reach]];
-    _memLimb(bg,path,2.15-rng()*0.14,0.24,MEM_TREE_BARK[0],MEM_TREE_LITE?8:12,MEM_TREE_LITE?9:13,stats,false); boughSockets.push(path[0]); boughPaths.push(path);
-    knotDummy.position.set(dx*0.88,rootY+0.35,dz*0.88); knotDummy.rotation.set(0,-a,0); knotDummy.scale.set(2.15,1.5,1.72); knotDummy.updateMatrix(); boughKnots.setMatrixAt(i,knotDummy.matrix); }
-  boughKnots.name='WorldTree_BoughJointCollars'; boughKnots.castShadow=!MEM_TREE_LITE; crotch.add(boughKnots);
-  const ribGroup=new THREE.Group(); ribGroup.name='WorldTree_SecondaryRibs'; skeleton.add(ribGroup);
-  for(let i=0;i<stats.ribs;i++){ const bi=i%stats.branches,a=bi/stats.branches*Math.PI*2,side=(i&1)?1:-1,aa=a+side*(0.2+0.04*(bi%3)),dx=Math.cos(a),dz=Math.sin(a)*0.78,ex=Math.cos(aa),ez=Math.sin(aa)*0.78;
-    const rg=new THREE.Group(); rg.name='WorldTree_Rib_'+String(i+1).padStart(2,'0'); ribGroup.add(rg);
-    _memLimb(rg,[[dx*6.8,20.7,dz*6.8],[Math.cos(a+side*0.1)*10.5,23.4+(i%3)*0.6,Math.sin(a+side*0.1)*0.78*10.5],[ex*15.2,23.0+(i%4)*0.7,ez*15.2]],0.48,0.065,MEM_TREE_BARK[(bi+1)%2],MEM_TREE_LITE?6:8,MEM_TREE_LITE?4:6,stats,false); }
-  // Warm internal branch web: one batched line network + a nested core; the bounded guide light is added separately below.
-  const veinPos=[]; for(let i=0;i<stats.veins;i++){ const bi=i%stats.branches,path=boughPaths[bi],level=((i/stats.branches)|0)%3,t=(level+1)/4,jitter=(rng()-0.5)*0.7;
-    const a=path[1+level],b=path[2+level],p0=[a[0]+jitter,a[1]+0.46,a[2]-0.42],p1=[a[0]+(b[0]-a[0])*(0.62+t*0.16)-jitter,a[1]+(b[1]-a[1])*(0.62+t*0.16)+0.34,a[2]+(b[2]-a[2])*(0.62+t*0.16)-0.42];
-    veinPos.push(...p0,...p1); if(i%4===0){ const p2=[p1[0]+(bi&1?0.75:-0.75),p1[1]+0.7,p1[2]-0.18]; veinPos.push(...p1,...p2); } }
-  const veinGeo=new THREE.BufferGeometry(); veinGeo.setAttribute('position',new THREE.Float32BufferAttribute(veinPos,3)); const veinMat=new THREE.LineBasicMaterial({color:0x9a7026,transparent:true,opacity:0.34});
-  const goldVeins=new THREE.LineSegments(veinGeo,veinMat); goldVeins.name='WorldTree_GoldenVeinNetwork'; skeleton.add(goldVeins);
-  const goldFans=new THREE.Group(); goldFans.name='WorldTree_PrimaryGoldFans'; skeleton.add(goldFans);
-  for(let i=0;i<stats.goldFans;i++){ const bi=i%stats.branches,path=boughPaths[bi],secondary=i>=stats.branches,side=secondary?(bi&1?0.38:-0.38):0,gg=new THREE.Group(); gg.name='WorldTree_GoldFan_'+String(i+1).padStart(2,'0'); goldFans.add(gg);
-    const goldPath=path.slice(1,secondary?4:5).map((p,j)=>[p[0]+side*((j+1)/3),p[1]+0.18+0.1*j,p[2]+0.34-Math.abs(side)*0.12]);
-    _memLimb(gg,goldPath,secondary?0.22:0.32,secondary?0.042:0.055,MEM_TREE_GOLD,MEM_TREE_LITE?5:7,MEM_TREE_LITE?6:9,stats,false); }
-  const frontGold=new THREE.Group(); frontGold.name='WorldTree_FrontGoldenVault'; skeleton.add(frontGold);
-  const frontBoughIds=[5,6,7,5,6,7,6];
-  for(let i=0;i<stats.frontGoldRibs;i++){ const bi=frontBoughIds[i],path=boughPaths[bi],side=((i%3)-1)*0.42,fg=new THREE.Group(); fg.name='WorldTree_FrontGoldRib_'+String(i+1).padStart(2,'0'); frontGold.add(fg);
-    const goldPath=path.slice(1,5).map((p,j)=>[p[0]+side*(j+1),p[1]+0.22+j*0.11,p[2]+0.18]);
-    _memLimb(fg,goldPath,0.18,0.038,MEM_TREE_GOLD,MEM_TREE_LITE?5:7,MEM_TREE_LITE?6:8,stats,false); }
-  const goldCore=new THREE.Group(),goldCoreMat=new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0xe9b84d,transparent:true,opacity:0,depthWrite:false,fog:false,side:THREE.DoubleSide,blending:THREE.AdditiveBlending}),goldCoreGeo=new THREE.PlaneGeometry(MEM_TREE_LITE?11:15,MEM_TREE_LITE?14:18),corePlanes=MEM_TREE_LITE?2:3;
-  goldCore.name='WorldTree_InnerGoldCore'; goldCore.position.set(0,19.5,0); for(let i=0;i<corePlanes;i++){ const p=new THREE.Mesh(goldCoreGeo,goldCoreMat); p.name='WorldTree_InnerGoldPlane_'+(i+1); p.rotation.y=i*Math.PI/corePlanes; goldCore.add(p); } skeleton.add(goldCore);
-  // Form/detail: eight crown sectors pivot at their supported inner edges; large/medium/small lobes preserve a circular rim and warm apertures.
-  for(let i=0;i<stats.crowns;i++){ const a=i/stats.crowns*Math.PI*2, cg=new THREE.Group(); cg.name='WorldTree_CrownSectorPivot_'+String(i+1).padStart(2,'0');
-    cg.position.set(Math.cos(a)*3.5,16.4,Math.sin(a)*3.5*0.78); root.add(cg); crownGroups.push(cg);
-    const twigA=a+(rng()-0.5)*0.16,tdx=Math.cos(twigA),tdz=Math.sin(twigA)*0.78;
-    if(!MEM_TREE_LITE||!(i&1)) _memLimb(cg,[[0,0,0],[tdx*5.5,3.0,tdz*5.5],[tdx*11.5,5.7,tdz*11.5]],0.32,0.055,MEM_TREE_BARK[1],MEM_TREE_LITE?6:8,MEM_TREE_LITE?4:6,stats,false);
-    _memLeafMass(cg,a,MEM_TREE_LITE?12:100,rng,stats,i);
-    if(!REDUCED){ cg.userData.sway={sp:0.22+i*0.018,ph:(i*2.13)%6.2832,amp:MEM_TREE_LITE?0.0024:0.0054}; SWAY.push(cg); } }
-  const bridgeN=MEM_TREE_LITE?14:72,bridge=new THREE.InstancedMesh(MEM_TREE_LEAF_GEOS[0],MEM_TREE_LEAVES[0],bridgeN),bridgeDummy=new THREE.Object3D(),bridgePalette=MEM_TREE_FOLIAGE_COLORS[0];
-  bridge.name='WorldTree_CanopyBridge';
-  for(let i=0;i<bridgeN;i++){ const a=rng()*Math.PI*2,rr=Math.sqrt(rng())*10.5; bridgeDummy.position.set(Math.cos(a)*rr,24.5+rng()*7.5,Math.sin(a)*rr*0.78);
-    bridgeDummy.rotation.set(rng()*0.45,rng()*Math.PI,rng()*0.36); bridgeDummy.scale.set(1.05+rng()*1.15,0.68+rng()*0.82,0.98+rng()*1.02); bridgeDummy.updateMatrix(); bridge.setMatrixAt(i,bridgeDummy.matrix); bridge.setColorAt(i,bridgePalette[i%bridgePalette.length]); }
-  if(bridge.instanceColor) bridge.instanceColor.needsUpdate=true; bridge.castShadow=!MEM_TREE_LITE; root.add(bridge); stats.bridgeLeaves=bridgeN; stats.leaves+=bridgeN;
-  const stoneGeo=new THREE.DodecahedronGeometry(0.36,0),stoneN=MEM_TREE_LITE?8:14,stones=new THREE.InstancedMesh(stoneGeo,MEM_TREE_MATS.earth,stoneN),d=new THREE.Object3D();
-  for(let i=0;i<stoneN;i++){ const a=i/stoneN*Math.PI*2+(rng()-0.5)*0.12,rr=5.35+rng()*0.18; d.position.set(Math.cos(a)*rr,0.55,Math.sin(a)*rr); d.rotation.set(rng()*0.35,rng()*Math.PI,rng()*0.35); d.scale.set(0.8+rng()*0.7,0.5+rng()*0.4,0.8+rng()*0.7); d.updateMatrix(); stones.setMatrixAt(i,d.matrix); } skeleton.add(stones);
-  // Static night guidance: emissive gold + one bounded shadowless light; no particles or per-frame geometry.
-  const guidePool=new THREE.Mesh(new THREE.CircleGeometry(9.0,40),new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0xe7b94f,transparent:true,opacity:0,depthWrite:false,fog:false,blending:THREE.AdditiveBlending}));
-  guidePool.rotation.x=-Math.PI/2; guidePool.position.y=0.035; root.add(guidePool);
-  const crownAura=new THREE.Group(), crownAuraMat=new THREE.MeshBasicMaterial({map:GLOW_TEX,color:0x62c99c,transparent:true,opacity:0,depthWrite:false,fog:false,side:THREE.DoubleSide,blending:THREE.AdditiveBlending}), crownAuraGeo=new THREE.PlaneGeometry(MEM_TREE_LITE?28:34,MEM_TREE_LITE?14:18),auraPlanes=MEM_TREE_LITE?2:3;
-  crownAura.name='WorldTree_IridescentCanopyAura'; crownAura.position.set(0,25,0); for(let i=0;i<auraPlanes;i++){ const p=new THREE.Mesh(crownAuraGeo,crownAuraMat); p.name='WorldTree_CanopyAuraPlane_'+(i+1); p.rotation.y=i*Math.PI/auraPlanes; crownAura.add(p); } root.add(crownAura);
-  const guideLight=new THREE.PointLight(0xffc27a,0,MEM_TREE_LITE?56:78,1.9); guideLight.name='WorldTree_GuideLight'; guideLight.position.set(0,17,0); guideLight.castShadow=false; root.add(guideLight);
-  const socketDefs={TaxiArrival:[0,0,-8],InteractionFocus:[0,4,-5],Foundation:[0,0,0],Crotch:[0,16.2,0],CrownApex:[0,33.5,0],GlowFocus:[0,18,0]};
-  boughSockets.forEach((p,i)=>{ socketDefs['Bough'+String(i+1).padStart(2,'0')]=p; });
-  Object.entries(socketDefs).forEach(([name,p])=>{ const s=new THREE.Object3D(); s.name='WorldTree_Socket_'+name; s.position.set(...p); root.add(s); sockets[name]=s; });
-  const collider={x,z,r:5.8,_memorialTree:true}; EXTRA_COLLIDERS.push(collider);
-  root.userData.worldTree={seed:MEMORIAL_TREE_SEED,stats,collider,lowEnd:LOW_END,crownOnlySway:!REDUCED,target:{height:34,crownSpan:44,crownDepth:32},
-    lightPolicy:'one-shadowless-night-guide',materialPolicy:'independent-seeded-pbr',sockets:Object.keys(socketDefs),
-    protectedGroups:['WorldTree_ButtressFoundation','WorldTree_TrunkPillar','WorldTree_CrotchMass',...rootGroups.map(g=>g.name),...limbGroups.map(g=>g.name),...crownGroups.map(g=>g.name)]};
-  root.userData.sculptDNA={schemaVersion:MEM_TREE_DNA.schemaVersion,enabled:true,strategy:'rooted load path, inset gold, layered crown, independent PBR, and bounded radiance refinement',selected:MEM_TREE_DNA};
-  root.userData.variantProvenance={variantId:MEM_TREE_DNA.variantId,rootSeed:MEM_TREE_DNA.rootSeed,variantSeed:MEM_TREE_DNA.variantSeed,attempt:1,invariants:{ok:true,checked:MEM_TREE_DNA.invariants},reviewEvidenceReset:true};
-  root.userData.sculptRuntime={qualityMode:MEM_TREE_LITE?'lite':'full',
-    nodes:{root:root.name,skeleton:skeleton.name,trunk:trunk.name,crotch:crotch.name,boughs:limbGroups.filter(g=>g.name.startsWith('WorldTree_PrimaryBough_')).map(g=>g.name),crowns:crownGroups.map(g=>g.name)},
-    meshes:{barkRidges:ridgeMesh.name,barkPlates:plateMesh.name,foliage:'WorldTree_Foliage_*',gold:[goldFans.name,frontGold.name,goldVeins.name]},
-    sockets:Object.fromEntries(Object.entries(socketDefs).map(([name,p])=>[name,{position:p}])),
-    colliders:{root:{type:'cylinder',radius:collider.r,center:[collider.x,0,collider.z]},canopy:{type:'none'}},
-    destructionGroups:{protectedSupport:['WorldTree_ButtressFoundation',trunk.name,crotch.name],protectedCrown:crownGroups.map(g=>g.name)},
-    materialState:{controller:'setNightState',pbr:'MeshStandardMaterial',guideLight:'one-static-shadowless'}};
-  MEMORIAL_TREE={group:root,skeleton,rootGroups,limbs:limbGroups,crowns:crownGroups,sockets,guideGlow:{pool:guidePool,core:goldCore,coreMat:goldCoreMat,crown:crownAura,crownMat:crownAuraMat,light:guideLight},goldFans,goldVeins,stats,collider,seed:MEMORIAL_TREE_SEED}; return MEMORIAL_TREE;
+  if(MEMORIAL_TREE) return MEMORIAL_TREE;
+  const stage='full', hero=createRepolisHero({seed:MEMORIAL_TREE_SEED,variant:MEM_TREE_HERO_VARIANT,stage}), root=hero.root;
+  root.traverse(o=>{ if(o.isMesh) o.castShadow=false; });   // plugin motion stays live without stale moving shadows under Repolis's frozen-shadow policy
+  const nativeBox=_memHeroBox(root); root.name='RepolisWorldTreeSolarArchive'; root.scale.setScalar(MEM_TREE_HERO_SCALE);
+  root.position.set(x,-nativeBox.min.y*MEM_TREE_HERO_SCALE,z); scene.add(root); const environment=_memHeroEnvironment(root); renderer.shadowMap.needsUpdate=true;
+  let light=null; root.traverse(o=>{ if(o.isPointLight){ light=o; o.name='WorldTree_GuideLight'; o.castShadow=false; } });
+  const crowns=[hero.runtime.meshes['amber-foliage'],hero.runtime.meshes['cyan-foliage']].filter(Boolean);
+  const sockets={}, customSockets={TaxiArrival:[0,nativeBox.min.y,-5.4],InteractionFocus:[0,2.4,-3],Foundation:[0,nativeBox.min.y,0],Crotch:[0,4.8,0],CrownApex:[0,nativeBox.max.y,0],GlowFocus:[0,1,1.4]};
+  Object.entries(customSockets).forEach(([name,p])=>{ const s=new THREE.Object3D(); s.name='WorldTree_Socket_'+name; s.position.set(...p); root.add(s); sockets[name]=s; });
+  ['left-foundation:tip','right-foundation:tip','left-crown:tip','right-crown:tip','center-left-spire:tip','center-right-spire:tip','left-rear:tip','right-rear:tip'].forEach((id,i)=>{ const s=hero.runtime.sockets[id]; if(s) sockets['Bough'+String(i+1).padStart(2,'0')]=s; });
+  const collider={x,z,r:11.6,_memorialTree:true}; EXTRA_COLLIDERS.push(collider);
+  const size=nativeBox.getSize(new THREE.Vector3()).multiplyScalar(MEM_TREE_HERO_SCALE);
+  root.userData.worldTree={seed:MEMORIAL_TREE_SEED,variant:MEM_TREE_HERO_VARIANT,stage,factorySha256:MEM_TREE_FACTORY_SHA,collider,crownOnlySway:false,
+    target:{height:+size.y.toFixed(1),crownSpan:+size.x.toFixed(1),crownDepth:+size.z.toFixed(1)},lightPolicy:'factory-emissive-selective-bloom',sockets:Object.keys(sockets)};
+  root.userData.repolisAdapter={factoryUnmodified:true,groundVisible:true,pulseDisabled:false,bloom:{night:[0.5,0.36,0.88],day:[0.04,0.18,0.96]},selectiveBloom:true,depthAware:true,scale:MEM_TREE_HERO_SCALE,qualityMode:'full'};
+  const bloomRoots=[light,...crowns,hero.runtime.nodes['energy-network'],hero.runtime.nodes.constellations,hero.runtime.meshes['gold-code-glyphs'],hero.runtime.meshes['cyan-code-glyphs']].filter(Boolean);
+  bloomRoots.forEach(o=>o.traverse(n=>{ n.userData.worldTreeBloom=true; n.layers.enable(MEM_TREE_LIGHT_LAYER); })); light.layers.set(MEM_TREE_LIGHT_LAYER);
+  const bloomLights=[light];
+  MEMORIAL_TREE={hero,group:root,runtime:hero.runtime,crowns,sockets,light,environment,bloomLights,occluders:[],occludersReady:false,treeShadowDirty:false,stats:hero.stats,collider,seed:MEMORIAL_TREE_SEED,nativeBox};
+  return MEMORIAL_TREE;
 }
 /*MEMORIAL_TREE:END*/
 function makePark(cx, cz, memorial=false){   // 🌳 a calm rest park set off the plaza — gravel stroll path, sittable benches, shade trees, a low flower bed, a lantern & a signpost (no flashy balloons/particles)
   const toPlaza=Math.atan2(-cz,-cx);
   const g=new THREE.Group(); g.position.set(cx,0,cz); scene.add(g);
   // circular gravel stroll path laid on the lawn
-  const path=new THREE.Mesh(new THREE.RingGeometry(memorial?6.6:2.9,memorial?7.9:3.8,MEM_TREE_LITE?36:52), texMat(SAND_TEX,3,3)); path.rotation.x=-Math.PI/2; path.position.y=0.03; path.receiveShadow=true; g.add(path);
+  const path=new THREE.Mesh(new THREE.RingGeometry(memorial?12.2:2.9,memorial?13.6:3.8,MEM_TREE_LITE?36:52), texMat(SAND_TEX,3,3)); path.rotation.x=-Math.PI/2; path.position.y=0.03; path.receiveShadow=true; g.add(path);
   // low central flower bed: soil disc + stone rim + Provençal lavender (calm, low — not a balloon mound)
   if(memorial) makeMemorialTree(cx,cz);
   else { const soil=new THREE.Mesh(new THREE.CylinderGeometry(1.4,1.5,0.18,20), toon(0x6e513a)); soil.position.y=0.09; g.add(soil);
@@ -2935,7 +2807,7 @@ function makePark(cx, cz, memorial=false){   // 🌳 a calm rest park set off th
     for(let i=0;i<5;i++){ const a=i/5*Math.PI*2; lavenderClump(g, Math.cos(a)*0.78, Math.sin(a)*0.78, 0.9); }
     EXTRA_COLLIDERS.push({x:cx,z:cz,r:1.7}); }
   // sittable benches on the far side, facing the flower bed
-  for(let i=0;i<3;i++){ const a=toPlaza+Math.PI+(i-1)*1.15, br=memorial?9.1:4.25, bx=cx+Math.cos(a)*br, bz=cz+Math.sin(a)*br;
+  for(let i=0;i<3;i++){ const a=toPlaza+Math.PI+(i-1)*1.15, br=memorial?14.8:4.25, bx=cx+Math.cos(a)*br, bz=cz+Math.sin(a)*br;
     makeBench(bx, bz, Math.atan2(-Math.cos(a),-Math.sin(a))); }
   // shade trees framing the outer edge (mixed Provençal: leafy · cypress · olive)
   if(!memorial) [[0.5,'t'],[1.55,'c'],[2.6,'o'],[4.1,'t'],[5.2,'c']].forEach(([off,kind])=>{ const a=toPlaza+off, tx=cx+Math.cos(a)*5.2, tz=cz+Math.sin(a)*5.2;
@@ -2946,9 +2818,9 @@ function makePark(cx, cz, memorial=false){   // 🌳 a calm rest park set off th
     flowerPatch(cx+Math.cos(toPlaza-1.6)*4.6, cz+Math.sin(toPlaza-1.6)*4.6);
     makeRock(cx+Math.cos(toPlaza+2.6)*4.4, cz+Math.sin(toPlaza+2.6)*4.4, 0.9); }   // world-tree path stays fully open; its own root-ring stones provide the quiet detail
   // evening lighting (night-aware guild lantern)
-  makeGuildLantern(cx+Math.cos(toPlaza-0.7)*(memorial?9.7:4.6), cz+Math.sin(toPlaza-0.7)*(memorial?9.7:4.6));
+  makeGuildLantern(cx+Math.cos(toPlaza-0.7)*(memorial?15.2:4.6), cz+Math.sin(toPlaza-0.7)*(memorial?15.2:4.6));
   // wooden signpost at the plaza-facing entrance
-  const signG=new THREE.Group(); signG.position.set(cx+Math.cos(toPlaza)*(memorial?9.9:4.7), 0, cz+Math.sin(toPlaza)*(memorial?9.9:4.7)); signG.rotation.y=Math.PI/2-toPlaza; scene.add(signG);
+  const signG=new THREE.Group(); signG.position.set(cx+Math.cos(toPlaza)*(memorial?15.4:4.7), 0, cz+Math.sin(toPlaza)*(memorial?15.4:4.7)); signG.rotation.y=Math.PI/2-toPlaza; scene.add(signG);
   const post=rbox(0.16,2.1,0.16,0x7a5230,0.03); post.position.y=1.05; outline(post,0.03); signG.add(post);
   const arm=rbox(0.16,0.16,0.5,0x7a5230,0.03); arm.position.set(0,1.9,0.18); signG.add(arm);
   const board=new THREE.Mesh(new THREE.PlaneGeometry(1.8,0.62), new THREE.MeshBasicMaterial({map:signTexture('Park · 공원',0x6fbf73),transparent:true})); board.position.set(0,1.78,0.1); signG.add(board);
@@ -4463,6 +4335,8 @@ function setNightState(night){
   isNight=night;
   if(night===_nightState) return;
   _nightState=night;
+  if(MEMORIAL_TREE) MEMORIAL_TREE.treeShadowDirty=true;
+  worldBloom.strength=night?0.5:0.04; worldBloom.radius=night?0.36:0.18; worldBloom.threshold=night?0.88:0.96;
   renderer.shadowMap.needsUpdate=true; lastAct=performance.now();   // perf: 밤낮 전환 → 그림자 1회 강제 갱신 + 60fps 깨우기
   moon.visible=night; starsGroup.visible=night; fireflyGroup.visible=night;
   birdFlock.visible=!night; butterflyGroup.visible=!night;
@@ -4470,13 +4344,6 @@ function setNightState(night){
   LAMP_GLOWS.forEach(o=>{ o.material.opacity = night? o._nightOp : 0; });
   WATER_NIGHT.value = night?1:0;
   NIGHT_GLOWS.forEach(o=>{ o.material.opacity = night? o._n : 0; });
-  if(MEMORIAL_TREE){ const glow=MEMORIAL_TREE.guideGlow, leafE=[0x3d8b6e,0x665229], leafDay=[0x356d58,0x3f4d2c], barkE=[0x7a3915,0x40200f];
-    MEM_TREE_LEAVES.forEach((m,i)=>{ m.emissive.setHex(night?leafE[i]:leafDay[i]); m.emissiveIntensity=night?(i?0.34:0.56):(i?0.14:0.3); });
-    MEM_TREE_BARK.forEach((m,i)=>{ m.emissive.setHex(barkE[i]); m.emissiveIntensity=night?0.28:0.03; });
-    MEM_TREE_GOLD.emissive.setHex(0xc87418); MEM_TREE_GOLD.emissiveIntensity=night?0.92:0.08;
-    glow.pool.material.opacity=night?0.17:0.02; glow.coreMat.opacity=night?0.16:0.02; glow.crownMat.opacity=night?0.012:0.002;
-    glow.light.intensity=night?(MEM_TREE_LITE?54:88):0;
-    MEMORIAL_TREE.goldVeins.material.color.setHex(night?0xf0a63c:0x9b6a22); MEMORIAL_TREE.goldVeins.material.opacity=night?0.78:0.32; }   // one static shadowless guide light; no pulse or per-frame work
   if(faceLight) faceLight.intensity = night?16:6;   // hero fill light: never 0 — dimmer by day/dawn/dusk, brighter at night so the avatar always reads against the background
   if(faceMat) faceMat.emissive.setHex(night?0x6a4f30:0x000000);
   npcFaces.forEach(m=>m.emissive.setHex(night?0x4a3a24:0x000000));   // softer than the player so the hero still reads brightest
@@ -7059,6 +6926,7 @@ function animate(){
   updateSmoke(clock.elapsedTime);
   updateGarlands(clock.elapsedTime);
   updateSway(clock.elapsedTime);
+  _memHeroUpdate(clock.elapsedTime);   // exact plugin pulse/motion plus uniform-scale light compensation
   updateChows(clock.elapsedTime,dt);
   updateChrono(dt);
   if(obsScope) obsScope.rotation.y+=dt*0.05;   // the great telescope slowly sweeps the sky
@@ -7085,11 +6953,10 @@ function animate(){
   updateHearth(clock.elapsedTime);
   rtTick(dt);
   if(userInput||moving||ride||dragging||navTarget) lastAct=_now;   // perf: dynamic state → stay 60fps + refresh shadows next frames
-  if(!_idle) renderer.shadowMap.needsUpdate=true;                  // perf: refresh shadow map only while active; frozen when idle
-  renderer.render(scene,camera);
+  _renderWorldTreeFrame(!_idle);                                  // selective tree bloom + independent main-scene shadow refresh
 }
 requestAnimationFrame(animate);
-addEventListener('resize',()=>{ camera.aspect=innerWidth/innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth,innerHeight); });
+addEventListener('resize',()=>{ camera.aspect=innerWidth/innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth,innerHeight); treeComposer.setSize(innerWidth,innerHeight); });
 
 /* ---- Phase 4D: optional realtime multiplayer + live counter (backend-agnostic) ----
    Static GitHub Pages can't host a socket server, so Repolis connects to an
@@ -7170,15 +7037,16 @@ updateLiveTitle();
 function addPeer(p){ if(!p||p.id===guestId()||peers.has(p.id)) return;
   const color=p.color!=null?p.color:PEER_COLORS[hashStr(p.id)%PEER_COLORS.length];
   const g=makePeerAvatar(p.name,color); g.position.set(p.x||0,0,p.z||0); g.rotation.y=p.yaw||0; scene.add(g);
+  _registerWorldTreeOccluderGroup(g);
   if(isNight&&g._faceMat) g._faceMat.emissive.setHex(0x4a3a24);
   peers.set(p.id,{group:g,name:p.name||'Guest',tx:p.x||0,tz:p.z||0,tyaw:p.yaw||0,emoteT:0,emoteKind:'wave'}); }
-function removePeer(id){ const p=peers.get(id); if(p){ if(p.group._faceMat) npcFaces.delete(p.group._faceMat); scene.remove(p.group); peers.delete(id); } }
+function removePeer(id){ const p=peers.get(id); if(p){ _unregisterWorldTreeOccluderGroup(p.group); if(p.group._faceMat) npcFaces.delete(p.group._faceMat); scene.remove(p.group); peers.delete(id); } }
 function clearPeers(){ for(const id of [...peers.keys()]) removePeer(id); }
 /* ---- click-to-greet: tap a nearby visitor → wave; relayed so they (and everyone) see it ---- */
 /* ---- emotes & click-to-greet: tap a nearby visitor → wave; emote bar → broadcast emote; relayed so everyone sees it ---- */
 const EMOJI_TEX={};
 function emojiTex(emoji){ if(EMOJI_TEX[emoji]) return EMOJI_TEX[emoji]; const cv=document.createElement('canvas'); cv.width=cv.height=128; const x=cv.getContext('2d'); x.font='100px serif'; x.textAlign='center'; x.textBaseline='middle'; x.fillText(emoji,64,76); return EMOJI_TEX[emoji]=new THREE.CanvasTexture(cv); }
-function emoteBubble(group,kind){ if(!group) return; const E=EMOTES[kind]||EMOTES.wave; const sp=new THREE.Sprite(new THREE.SpriteMaterial({map:emojiTex(E.emoji),transparent:true,depthTest:false})); sp.scale.set(1.2,1.2,1); sp.position.y=3.9; group.add(sp); let t=0; (function fade(){ t+=0.016; sp.position.y=3.9+t*0.7; sp.material.opacity=Math.max(0,1-t/1.4); if(t<1.4) requestAnimationFrame(fade); else { group.remove(sp); sp.material.dispose(); } })(); }
+function emoteBubble(group,kind){ if(!group) return; const E=EMOTES[kind]||EMOTES.wave; const sp=new THREE.Sprite(new THREE.SpriteMaterial({map:emojiTex(E.emoji),transparent:true,depthTest:false})); sp.scale.set(1.2,1.2,1); sp.position.y=3.9; group.add(sp); _registerWorldTreeOccluderGroup(sp); let t=0; (function fade(){ t+=0.016; sp.position.y=3.9+t*0.7; sp.material.opacity=Math.max(0,1-t/1.4); if(t<1.4) requestAnimationFrame(fade); else { _unregisterWorldTreeOccluderGroup(sp); group.remove(sp); sp.material.dispose(); } })(); }
 function playEmote(kind){ const E=EMOTES[kind]; if(!E||emoteT>0.3) return; emoteT=E.dur; emoteKind=kind; emoteBubble(model,kind); rtSend({t:'emote',id:guestId(),kind}); }
 const _ray=new THREE.Raycaster(), _ndc=new THREE.Vector2();
 function peerAtScreen(cx,cy){ if(!peers.size) return null; const r=dom.getBoundingClientRect(); _ndc.x=((cx-r.left)/r.width)*2-1; _ndc.y=-((cy-r.top)/r.height)*2+1; _ray.setFromCamera(_ndc,camera); let best=null,bd=Infinity; for(const [id,p] of peers){ const hit=_ray.intersectObject(p.group,true); if(hit.length&&hit[0].distance<bd){ bd=hit[0].distance; best={id,p}; } } return best; }
@@ -7417,24 +7285,20 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
     dpr:+renderer.getPixelRatio().toFixed(2), size:[innerWidth,innerHeight],
     tier:{ mobile:IS_MOBILE, lowEnd:LOW_END, reduced:REDUCED, detail:DETAIL },
     idleCap:(performance.now()-lastAct)>1200, shadowAuto:renderer.shadowMap.autoUpdate }; };
-  window.__memorialTree=()=>{ if(!MEMORIAL_TREE) return null; const b=new THREE.Box3().setFromObject(MEMORIAL_TREE.group), s=MEMORIAL_TREE.stats, c=MEMORIAL_TREE.collider, objectPerf={draws:0,triangles:0};
-    MEMORIAL_TREE.group.traverse(o=>{ if(!o.isMesh) return; objectPerf.draws++; const g=o.geometry,n=g&&((g.index&&g.index.count)||g.attributes.position&&g.attributes.position.count)||0; objectPerf.triangles+=Math.round(n/3)*(o.isInstancedMesh?o.count:1); });
-    return { count:1, name:MEMORIAL_TREE.group.name, seed:MEMORIAL_TREE.seed, at:[+MEMORIAL_TREE.group.position.x.toFixed(1),+MEMORIAL_TREE.group.position.z.toFixed(1)],
-      roots:s.roots, branches:s.branches, barkRidges:s.barkRidges, barkPlates:s.barkPlates, sweeps:s.sweeps, segments:s.segments, goldFans:s.goldFans, frontGoldRibs:s.frontGoldRibs, veins:s.veins, bridgeLeaves:s.bridgeLeaves, leafClusters:s.leaves, leafCards:s.leafCards, crowns:s.crowns,
-      mobile:IS_MOBILE, lowEnd:LOW_END, lite:MEM_TREE_LITE, reduced:REDUCED, dna:{variant:MEM_TREE_DNA.variantId,rootSeed:MEM_TREE_DNA.rootSeed,variantSeed:MEM_TREE_DNA.variantSeed,invariants:MEMORIAL_TREE.group.userData.variantProvenance.invariants.ok},
-      leafTexture:{size:MEM_TREE_LEAF_TEXTURES[0].size,maps:MEM_TREE_LEAF_TEXTURES.reduce((n,t)=>n+['map','roughness','bump','ao'].filter(k=>!!t[k]).length,0),bump:!!MEM_TREE_LEAF_TEXTURES[0].bump,repeat:MEM_TREE_DNA.leafSurface.repeat},
-      pbr:{material:'MeshStandardMaterial',barkSize:MEM_TREE_BARK_TEXTURES[0].size,barkMaps:MEM_TREE_BARK_TEXTURES.reduce((n,t)=>n+['map','roughness','bump','ao'].filter(k=>!!t[k]).length,0),referenceConfidence:{bark:0.794,foliage:0.814}},
-      runtime:{qualityMode:MEMORIAL_TREE.group.userData.sculptRuntime.qualityMode,nodeGroups:Object.keys(MEMORIAL_TREE.group.userData.sculptRuntime.nodes).length,sockets:Object.keys(MEMORIAL_TREE.group.userData.sculptRuntime.sockets).length,objectPerf},
-      crownOnlySway:MEMORIAL_TREE.group.userData.worldTree.crownOnlySway, limbGroups:MEMORIAL_TREE.limbs.map(g=>g.name), sockets:Object.keys(MEMORIAL_TREE.sockets), collider:{x:c.x,z:c.z,r:c.r},
-      target:MEMORIAL_TREE.group.userData.worldTree.target, nightGuide:{night:isNight,pool:+MEMORIAL_TREE.guideGlow.pool.material.opacity.toFixed(3),core:+MEMORIAL_TREE.guideGlow.coreMat.opacity.toFixed(3),
-        crown:+MEMORIAL_TREE.guideGlow.crownMat.opacity.toFixed(3),light:+MEMORIAL_TREE.guideGlow.light.intensity.toFixed(1),range:MEMORIAL_TREE.guideGlow.light.distance,
-        veins:+MEMORIAL_TREE.goldVeins.material.opacity.toFixed(3),goldEmissive:'#'+MEM_TREE_GOLD.emissive.getHexString()},
-      bounds:{min:[+b.min.x.toFixed(1),+b.min.y.toFixed(1),+b.min.z.toFixed(1)],max:[+b.max.x.toFixed(1),+b.max.y.toFixed(1),+b.max.z.toFixed(1)]} }; };
+  window.__memorialTree=()=>{ if(!MEMORIAL_TREE) return null; const b=_memHeroBox(MEMORIAL_TREE.group),s=MEMORIAL_TREE.stats,c=MEMORIAL_TREE.collider,wt=MEMORIAL_TREE.group.userData.worldTree,adapter=MEMORIAL_TREE.group.userData.repolisAdapter;
+    return {count:1,name:MEMORIAL_TREE.group.name,seed:MEMORIAL_TREE.seed,at:[+MEMORIAL_TREE.group.position.x.toFixed(1),+MEMORIAL_TREE.group.position.z.toFixed(1)],
+      variant:wt.variant,stage:wt.stage,factory:{sha256:wt.factorySha256,unmodified:adapter.factoryUnmodified,scale:adapter.scale,groundVisible:adapter.groundVisible,pulseDisabled:adapter.pulseDisabled,bloom:adapter.bloom},
+      macroBranches:s.macroBranches,secondaryBranches:s.secondaryBranches,fineBranches:s.fineBranches,leafInstances:s.leafInstances,mossInstances:s.mossInstances,glyphInstances:s.glyphInstances,branchVertices:s.branchVertices,generationMs:+s.generationMs.toFixed(1),
+      mobile:IS_MOBILE,lowEnd:LOW_END,lite:MEM_TREE_LITE,reduced:REDUCED,runtime:{qualityMode:adapter.qualityMode,nodes:Object.keys(MEMORIAL_TREE.runtime.nodes).length,meshes:Object.keys(MEMORIAL_TREE.runtime.meshes).length,sockets:Object.keys(MEMORIAL_TREE.sockets).length,objectPerf:_memHeroObjectPerf(MEMORIAL_TREE.group)},
+      crownOnlySway:wt.crownOnlySway,sockets:Object.keys(MEMORIAL_TREE.sockets),collider:{x:c.x,z:c.z,r:c.r},target:wt.target,
+      nightGuide:{night:isNight,light:+MEMORIAL_TREE.light.intensity.toFixed(1),range:+MEMORIAL_TREE.light.distance.toFixed(1),energy:+MEMORIAL_TREE.hero.materials.energy.emissiveIntensity.toFixed(2),amber:+MEMORIAL_TREE.hero.materials.amberLeaf.emissiveIntensity.toFixed(2),cyan:+MEMORIAL_TREE.hero.materials.cyanLeaf.emissiveIntensity.toFixed(2),environmentLights:1},
+      bounds:{min:[+b.min.x.toFixed(1),+b.min.y.toFixed(1),+b.min.z.toFixed(1)],max:[+b.max.x.toFixed(1),+b.max.y.toFixed(1),+b.max.z.toFixed(1)]}}; };
   window.__tpMemorialTree=(back=55)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position; player.position.set(p.x,0,p.z-back); camYaw=Math.PI; camPitch=0.08; camDist=22; model.rotation.y=0; return window.__memorialTree(); };
   window.__frameMemorialTree=(back=44,height=15,angle=0)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position,dx=Math.sin(angle),dz=Math.cos(angle); player.position.set(p.x-dx*back,height,p.z-dz*back); model.visible=false; camYaw=angle+Math.PI; camPitch=0; camDist=18; return window.__memorialTree(); };
   window.__unframeMemorialTree=()=>{ model.visible=true; player.position.y=0; return true; };
+  window.__memorialTreeVisible=(visible=true)=>{ if(!MEMORIAL_TREE) return false; MEMORIAL_TREE.group.visible=visible!==false; return MEMORIAL_TREE.group.visible; };
   window.__memorialTreeCollision=()=>{ if(!MEMORIAL_TREE) return null; const c=MEMORIAL_TREE.collider, p=new THREE.Vector3(c.x+0.05,0,c.z); resolveColliders(p);
-    return { radius:c.r, resolved:[+p.x.toFixed(2),+p.z.toFixed(2)], distance:+Math.hypot(p.x-c.x,p.z-c.z).toFixed(2), clearOfPath:6.6-c.r }; };
+    return { radius:c.r, resolved:[+p.x.toFixed(2),+p.z.toFixed(2)], distance:+Math.hypot(p.x-c.x,p.z-c.z).toFixed(2), clearOfPath:12.2-c.r }; };
   window.__act=()=>({prompt:document.getElementById('prompt').classList.contains('show'), btn:document.getElementById('actBtn').classList.contains('avail')});
   window.__cw=(name)=>{ const b=buildings.find(x=>x.repo===name); return b?+(b._cw||3).toFixed(2):null; };
   window.__farZRepo=()=>{ let best=null,bz=-1e9; for(const b of buildings){ if(b._isLibrary) continue; if(b._z>bz){ bz=b._z; best=b; } } return best?{repo:best.repo,x:+best._x.toFixed(1),z:+best._z.toFixed(1)}:null; };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -13,10 +13,12 @@ import { tmpdir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { createHash } from 'crypto';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const HTML = readFileSync(join(ROOT, 'index.html'), 'utf8');
+const WORLD_TREE_FACTORY = readFileSync(join(ROOT, 'assets/world-tree/createRepolisHero.js'), 'utf8');
 
 let pass = 0, fail = 0; const fails = [];
 function ok(cond, msg) { if (cond) { pass++; } else { fail++; fails.push(msg); console.log('  ✗ ' + msg); } }
@@ -650,63 +652,69 @@ ok(/updateStarTrail\(clock\.elapsedTime\)/.test(HTML), 'the main world loop upda
 group('one colossal deterministic World Tree Pillar supports the village');
 const memorialTreeBlock = (HTML.match(/\/\*MEMORIAL_TREE:START\*\/([\s\S]*?)\/\*MEMORIAL_TREE:END\*\//) || [, ''])[1];
 ok(memorialTreeBlock.length > 0, 'world-tree procedural block is extractable from index.html');
-ok(/const MEMORIAL_TREE_SEED=1730, MEMORIAL_TREE_POS=new THREE\.Vector3\(15,0,48\)/.test(memorialTreeBlock)
-  && /function _memTreeRng\(seed\)/.test(memorialTreeBlock), 'skill-authored World Tree uses fixed seed 1730 + isolated deterministic PRNG');
-ok(!/Math\.random\(/.test(memorialTreeBlock), 'world-tree shape contains no Math.random (reload-stable silhouette)');
-ok(/variantId:'repolis-world-tree-pillar-v3-refinement'/.test(memorialTreeBlock)
-  && /rootSeed:1760,variantSeed:'1760001'/.test(memorialTreeBlock)
-  && /root\.userData\.sculptDNA=/.test(memorialTreeBlock) && /root\.userData\.variantProvenance=/.test(memorialTreeBlock), 'refined Sculpt DNA v3 provenance and invariant review travel with the runtime object');
+ok(createHash('sha256').update(WORLD_TREE_FACTORY).digest('hex') === '65bd7fc76013ee0f11898174095556d581be64ea8f15e76e090fb8955a17d0e3',
+  'Repolis production factory is byte-identical to threejs-sculpt-dna v0.4.0');
+ok(/import \{ createRepolisHero \} from '\.\/assets\/world-tree\/createRepolisHero\.js'/.test(HTML)
+  && /import \{ mergeGeometries \} from 'three\/addons\/utils\/BufferGeometryUtils\.js'/.test(WORLD_TREE_FACTORY), 'native Solar Archive factory resolves through the existing Three.js import map');
+ok(/import \{ EffectComposer \}/.test(HTML) && /import \{ UnrealBloomPass \}/.test(HTML)
+  && /new UnrealBloomPass\(new THREE\.Vector2\(innerWidth,innerHeight\),0\.5,0\.36,0\.88\)/.test(HTML)
+  && /treeBloomDpr=matchMedia\('\(pointer:coarse\)'\)\.matches\?1:renderer\.getPixelRatio\(\)/.test(HTML)
+  && /new THREE\.MeshBasicMaterial\(\{map:treeComposer\.renderTarget2\.texture,transparent:true,blending:THREE\.AdditiveBlending/.test(HTML)
+  && /_prepareWorldTreeBloom\(\)/.test(HTML)
+  && /_restoreWorldTreeBloom\(\)/.test(HTML)
+  && /renderer\.render\(scene,camera\)[\s\S]*?renderer\.render\(bloomOverlayScene,bloomOverlayCamera\)/.test(HTML), 'direct town render plus one additive bloom quad preserves original exposure without a full-screen base copy');
+ok(/const MEMORIAL_TREE_SEED=20260711, MEMORIAL_TREE_POS=new THREE\.Vector3\(15,0,48\)/.test(memorialTreeBlock)
+  && /MEM_TREE_HERO_VARIANT='solar-archive'/.test(memorialTreeBlock), 'exactly seeded Solar Archive is selected at the existing north park position');
 ok(/makePark\(MEMORIAL_TREE_POS\.x,MEMORIAL_TREE_POS\.z,true\)/.test(HTML)
   && (HTML.match(/if\(memorial\) makeMemorialTree\(cx,cz\)/g) || []).length === 1, 'exactly one memorial tree is requested, at the north rest park centre');
-ok(/MEM_TREE_LITE=LOW_END\|\|IS_MOBILE/.test(memorialTreeBlock)
-  && /stats=\{segments:0,sweeps:0,roots:8,leaders:4,barkRidges:MEM_TREE_LITE\?6:12,barkPlates:MEM_TREE_LITE\?6:18,branches:8,ribs:MEM_TREE_LITE\?8:16,goldFans:MEM_TREE_LITE\?8:16,frontGoldRibs:MEM_TREE_LITE\?5:7,bridgeLeaves:0,leaves:0,leafCards:0,crowns:8,veins:MEM_TREE_LITE\?22:72\}/.test(memorialTreeBlock)
-  && /target:\{height:34,crownSpan:44,crownDepth:32\}/.test(memorialTreeBlock), '8 roots + 8 boughs + 8 crown sectors map the skill spec to a 34×44×32 village pillar');
-ok(/new THREE\.CatmullRomCurve3\(pts,false,'centripetal',0\.5\)/.test(memorialTreeBlock)
-  && /computeFrenetFrames\(steps,false\)/.test(memorialTreeBlock) && /geo\.setIndex\(idx\); geo\.computeVertexNormals/.test(memorialTreeBlock), 'limbs use one tapered Frenet sweep per path (not stacked cylinder draw calls)');
-ok(/new THREE\.InstancedMesh\(MEM_TREE_LEAF_GEOS\[bi\],MEM_TREE_LEAVES\[bi\],list\.length\)/.test(memorialTreeBlock)
-  && /_memLeafMass\(cg,a,MEM_TREE_LITE\?12:100/.test(memorialTreeBlock) && /mesh\.setColorAt\(i,v\.color\)/.test(memorialTreeBlock), '8 instanced crown sectors preserve the base shell while targeting the selected 809/full vs 96/mobile Sculpt DNA budget');
-ok(/new THREE\.IcosahedronGeometry\(0\.78,0\)/.test(memorialTreeBlock)
-  && /WorldTree_BarkRidges/.test(memorialTreeBlock), 'form pass uses smaller faceted outer foliage plus tapered instanced bark-ridge relief');
-ok(/WorldTree_BarkPlates/.test(memorialTreeBlock)
-  && /\[\[-10,4,-0\.46\],\[9,5,0\.5\],\[0,-9,0\]\]/.test(memorialTreeBlock), 'surface pass adds seeded bark plates and three-leaf alpha clusters without new material systems');
-ok(/function _memPbrMaterial\(color,tex,roughness,bumpScale,vertexColors=false\)/.test(memorialTreeBlock)
-  && /new THREE\.MeshStandardMaterial/.test(memorialTreeBlock)
-  && /const MEM_TREE_MATS=\{[\s\S]*?bark:_memPbrMaterial[\s\S]*?cavity:_memPbrMaterial[\s\S]*?earth:_memPbrMaterial[\s\S]*?foliage:_memPbrMaterial[\s\S]*?shadow:_memPbrMaterial[\s\S]*?gold:_memPbrMaterial/.test(memorialTreeBlock), 'six pooled MeshStandard PBR material systems match the strict ObjectSculptSpec');
-ok(/function _memLeafTextures\(seed,shadow\)/.test(memorialTreeBlock)
-  && /function _memBarkTextures\(seed,cavity\)/.test(memorialTreeBlock)
-  && /roughness:_memCanvasTex\(roughness/.test(memorialTreeBlock) && /bump:height\?_memCanvasTex\(height/.test(memorialTreeBlock)
-  && /ao:_memCanvasTex\(ao/.test(memorialTreeBlock) && /maps\.ao\.channel=0/.test(memorialTreeBlock)
-  && !/(fetch|TextureLoader|GLTFLoader)\s*\(/.test(memorialTreeBlock), 'bark + leaf use independent seeded albedo/roughness/height/AO; mobile drops height maps and fetches no asset');
-ok(/MEM_TREE_LEAF_CARD_TEX=MEM_TREE_LITE\?null:/.test(memorialTreeBlock)
-  && /new THREE\.InstancedMesh\(MEM_TREE_LEAF_CARD_GEO,MEM_TREE_LEAF_CARD_MAT,cards\.length\)/.test(memorialTreeBlock)
-  && /stats\.leafCards\+=cards\.length/.test(memorialTreeBlock), 'desktop adds sparse alpha-tested leaf silhouettes from existing clump positions; mobile omits the layer');
-ok(/preserve five-to-nine warm branch windows/.test(memorialTreeBlock) && /WorldTree_GoldenVeinNetwork/.test(memorialTreeBlock)
-  && /WorldTree_PrimaryGoldFans/.test(memorialTreeBlock) && /WorldTree_SecondaryRibs/.test(memorialTreeBlock)
-  && /WorldTree_FrontGoldenVault/.test(memorialTreeBlock) && /WorldTree_InnerGoldSpine/.test(memorialTreeBlock)
-  && /WorldTree_CanopyBridge/.test(memorialTreeBlock) && /WorldTree_InnerGoldCore/.test(memorialTreeBlock)
-  && /WorldTree_InnerGoldPlane_/.test(memorialTreeBlock), 'negative-space windows reveal broad gold vault/spine, secondary ribs/veins, soft crossed-plane core, and a connected canopy bridge');
-ok(/cg\.userData\.sway=\{sp:0\.22\+i\*0\.018,[\s\S]*?amp:MEM_TREE_LITE\?0\.0024:0\.0054\}; SWAY\.push\(cg\)/.test(memorialTreeBlock)
-  && !/regSway\(root/.test(memorialTreeBlock), 'only 8 crown pivots sway within the skill spec amplitude; roots/trunk/boughs stay rigid');
-ok(/skeleton\.name='WorldTree_StaticSkeleton'/.test(memorialTreeBlock)
-  && /WorldTree_TrunkPillar/.test(memorialTreeBlock) && /WorldTree_PrimaryBough_/.test(memorialTreeBlock)
-  && /WorldTree_CrotchLeader_/.test(memorialTreeBlock) && /WorldTree_CrownSectorPivot_/.test(memorialTreeBlock)
-  && /socketDefs\['Bough'\+String/.test(memorialTreeBlock), 'named skeleton, roots, four embedded crotch leaders, boughs, crown pivots, and sockets are action-ready');
-ok(/root\.userData\.sculptRuntime=\{qualityMode:/.test(memorialTreeBlock)
-  && /nodes:\{root:root\.name,skeleton:skeleton\.name,trunk:trunk\.name,crotch:crotch\.name/.test(memorialTreeBlock)
-  && /sockets:Object\.fromEntries/.test(memorialTreeBlock) && /destructionGroups:\{protectedSupport:/.test(memorialTreeBlock), 'runtime metadata exposes action-ready nodes, sockets, colliders, destruction groups, quality tier, and material state');
-ok(/const collider=\{x,z,r:5\.8,_memorialTree:true\}; EXTRA_COLLIDERS\.push\(collider\)/.test(memorialTreeBlock)
-  && /new THREE\.RingGeometry\(memorial\?6\.6:2\.9,memorial\?7\.9:3\.8/.test(HTML), '5.8 root collider stays inside the widened 6.6-radius park path');
+ok(/const stage='full'/.test(memorialTreeBlock)
+  && /createRepolisHero\(\{seed:MEMORIAL_TREE_SEED,variant:MEM_TREE_HERO_VARIANT,stage\}\)/.test(memorialTreeBlock), 'desktop and touch tiers both use the exact full Solar Archive hero');
+ok(/macroBranchSpecs\(\)/.test(WORLD_TREE_FACTORY) && /secondaryBranches\(spec, seed/.test(WORLD_TREE_FACTORY)
+  && /fineBranches\(spec, seed\)/.test(WORLD_TREE_FACTORY) && /mergedFineGeometry/.test(WORLD_TREE_FACTORY), 'factory preserves macro → secondary → merged fine branch hierarchy');
+ok(/Math\.round\(2600 \* variant\.foliageDensity\)/.test(WORLD_TREE_FACTORY)
+  && /id: 'solar-archive'[\s\S]*?foliageDensity: 1\.16[\s\S]*?cyanRatio: 0\.1/.test(WORLD_TREE_FACTORY), 'Solar Archive supplies 3,016 small instanced leaves with restrained cyan distribution');
+ok(/createBarkTextures\(seed\)/.test(WORLD_TREE_FACTORY)
+  && /roughnessMap: textures\?\.roughness/.test(WORLD_TREE_FACTORY) && /normalMap: textures\?\.normal/.test(WORLD_TREE_FACTORY)
+  && /aoMap: textures\?\.ao/.test(WORLD_TREE_FACTORY) && !/(fetch|TextureLoader|GLTFLoader)\s*\(/.test(WORLD_TREE_FACTORY), 'factory generates independent bark PBR channels with no mesh/texture fetch');
+ok(!/hero\.ground\.(ground|rocks)\.visible=false/.test(memorialTreeBlock)
+  && /root\.scale\.setScalar\(MEM_TREE_HERO_SCALE\)/.test(memorialTreeBlock)
+  && /scene\.add\(root\)/.test(memorialTreeBlock), 'thin adapter keeps the full factory in the main depth scene for correct occlusion');
+ok(/if\(o\.isInstancedMesh\)\{ o\.computeBoundingBox\(\); local=o\.boundingBox; \}/.test(memorialTreeBlock), 'tree bounds include every instanced leaf, moss, glyph, and ornament transform');
+ok(/root\.traverse\(o=>\{ if\(o\.isMesh\) o\.castShadow=false; \}/.test(memorialTreeBlock), 'live factory motion cannot leave stale tree shadows under the town frozen-shadow policy');
+ok(/const collider=\{x,z,r:11\.6,_memorialTree:true\}; EXTRA_COLLIDERS\.push\(collider\)/.test(memorialTreeBlock)
+  && /new THREE\.RingGeometry\(memorial\?12\.2:2\.9,memorial\?13\.6:3\.8/.test(HTML), '11.6 Solar root-island collider stays inside the widened 12.2-radius park path');
 ok(/if\(!memorial\)\{ flowerPatch\([\s\S]*?makeRock\([\s\S]*?world-tree path stays fully open/.test(HTML), 'legacy park flowers/rock are omitted from the memorial ring path (no visual clipping or obstruction)');
-ok((memorialTreeBlock.match(/new THREE\.PointLight/g)||[]).length===1
-  && /guideLight\.castShadow=false/.test(memorialTreeBlock) && !/new THREE\.(SpotLight|DirectionalLight|Points|Sprite)/.test(memorialTreeBlock), 'luminous pillar owns exactly one shadowless guide light and no particles/sprites/other lights');
-ok(/WorldTree_IridescentCanopyAura/.test(memorialTreeBlock)
-  && /WorldTree_CanopyAuraPlane_/.test(memorialTreeBlock)
-  && /MEM_TREE_GOLD\.emissiveIntensity=night\?0\.92:0\.08/.test(HTML)
-  && /glow\.light\.intensity=night\?\(MEM_TREE_LITE\?54:88\):0/.test(HTML)
-  && /MEMORIAL_TREE\.goldVeins\.material\.opacity=night\?0\.78:0\.32/.test(HTML), 'night gate preserves amber detail with bounded foliage/gold/core/aura + one static light without per-frame pulse');
+ok((WORLD_TREE_FACTORY.match(/new THREE\.PointLight/g)||[]).length===1
+  && /o\.name='WorldTree_GuideLight'; o\.castShadow=false/.test(memorialTreeBlock)
+  && /MEMORIAL_TREE\.hero\.update\(elapsed\)/.test(memorialTreeBlock)
+  && /_memHeroUpdate\(clock\.elapsedTime\)/.test(HTML), 'factory owns one shadowless guide light and runs its original pulse + living-tree update');
+ok(/const pulse = 2\.55 \+ Math\.sin\(elapsedSeconds \* 2\.1\) \* 0\.45/.test(WORLD_TREE_FACTORY)
+  && /energy\.light\.intensity = 16 \+ Math\.sin\(elapsedSeconds \* 1\.7\) \* 3/.test(WORLD_TREE_FACTORY)
+  && /livingSystem\.rotation\.z = Math\.sin/.test(WORLD_TREE_FACTORY), 'web keeps the plugin energy, light, foliage, and living-system effects unchanged');
+ok(/customSockets=\{TaxiArrival:/.test(memorialTreeBlock)
+  && /\['left-foundation:tip','right-foundation:tip','left-crown:tip','right-crown:tip'/.test(memorialTreeBlock), 'adapter preserves six Repolis sockets plus eight action-ready factory bough sockets');
+ok(/root\.userData\.repolisAdapter=\{factoryUnmodified:true,groundVisible:true,pulseDisabled:false[\s\S]*?selectiveBloom:true,depthAware:true/.test(memorialTreeBlock), 'runtime metadata records unchanged full factory effects and depth-aware selective bloom');
+ok(/treeBox=_memHeroBox\(MEMORIAL_TREE\.group\)\.expandByScalar\(3\)/.test(HTML)
+  && /o\.layers\.enable\(MEM_TREE_LIGHT_LAYER\); occluders\.push\(o\)/.test(HTML)
+  && /RESIDENTS_LIVE\.forEach\(L=>_registerWorldTreeOccluderGroup\(L\.group\)\)/.test(HTML), 'bloom pre-pass includes only the tree and nearby/static or moving occluders');
+ok(/_registerWorldTreeOccluderGroup\(g\)/.test(HTML)
+  && /_unregisterWorldTreeOccluderGroup\(p\.group\)/.test(HTML)
+  && /_registerWorldTreeOccluderGroup\(sp\)/.test(HTML), 'remote peer meshes, labels, and temporary emotes enter and leave the bloom depth cache without leaks');
+ok(/const bloomRoots=\[light,\.\.\.crowns,hero\.runtime\.nodes\['energy-network'\],hero\.runtime\.nodes\.constellations/.test(memorialTreeBlock)
+  && /n\.userData\.worldTreeBloom=true; n\.layers\.enable\(MEM_TREE_LIGHT_LAYER\)/.test(memorialTreeBlock)
+  && !/WorldTree_(Key|CoolRim|WarmFill|FrontFill)/.test(memorialTreeBlock), 'only energy, ornaments, leaves, and the factory PointLight enter exact bloom; bark/root stay town-lit');
+ok(/ratio=MEM_TREE_HERO_SCALE\/MEM_TREE_HERO_NATIVE_SCALE/.test(memorialTreeBlock)
+  && !/MEMORIAL_TREE\.light\.intensity\*=/.test(memorialTreeBlock)
+  && /MEMORIAL_TREE\.light\.distance=7\*ratio/.test(memorialTreeBlock), 'factory PointLight keeps its exact pulse intensity while its authored range follows uniform scale');
+ok(/if\(isNight\)\{ m\.amberLeaf\.emissiveIntensity=0\.42; m\.cyanLeaf\.emissiveIntensity=0\.75/.test(memorialTreeBlock)
+  && /if\(REDUCED\)\{ m\.energy\.emissiveIntensity=2\.85; MEMORIAL_TREE\.light\.intensity=18/.test(memorialTreeBlock)
+  && /else \{ m\.energy\.emissiveIntensity=0\.32/.test(memorialTreeBlock)
+  && /worldBloom\.strength=night\?0\.5:0\.04/.test(HTML), 'day calms ornaments while night/reduced-motion restore exact live-demo material and light values');
+ok(/renderer\.shadowMap\.needsUpdate=MEMORIAL_TREE\.treeShadowDirty; treeComposer\.render\(\)/.test(HTML)
+  && /renderer\.shadowMap\.needsUpdate=refreshTownShadows; renderer\.setRenderTarget\(null\); renderer\.render\(scene,camera\)/.test(HTML), 'bloom pre-pass cannot consume the main town shadow refresh');
 ok(/window\.__memorialTree=/.test(HTML) && /window\.__tpMemorialTree=/.test(HTML)
-  && /objectPerf=\{draws:0,triangles:0\}/.test(HTML) && /window\.__frameMemorialTree=/.test(HTML)
-  && /window\.__memorialTreeCollision=/.test(HTML), '?dbg exposes tree spec/bounds/per-object budget, town/focus viewpoints, and collider probes');
+  && /_memHeroObjectPerf\(MEMORIAL_TREE\.group\)/.test(HTML) && /window\.__frameMemorialTree=/.test(HTML)
+  && /window\.__memorialTreeVisible=/.test(HTML) && /window\.__memorialTreeCollision=/.test(HTML), '?dbg exposes factory hash/stats/bounds/budget, viewpoints, visibility A/B, and collider probes');
 
 console.log('\n──────────────────────────────');
 console.log(fail === 0 ? '✅ ALL GREEN — ' + pass + ' checks passed' : '❌ ' + fail + ' FAILED / ' + pass + ' passed');


### PR DESCRIPTION
## Summary
- replace the hand-authored v3 tree with the unchanged threejs-sculpt-dna v0.4.0 Solar Archive production factory
- preserve full desktop/mobile effects: 3,016 leaves, 15→56→112 branch hierarchy, moss, glyphs, constellations, pulse, motion, PBR, and ground
- isolate emissive-only selective bloom from normal town exposure with cached static/dynamic depth occluders
- widen the memorial park collider/path and preserve 14 Repolis/factory sockets

## Validation
- `node scripts/smoke.mjs` — 399 green
- `node council/test.mjs` — 130 green
- `node council/test-live.mjs` — 56 green
- all JavaScript syntax checks pass
- native plugin — 34 tests pass; canonical spec and Sculpt DNA validate without warnings
- 390×844 full-effect mobile: 58 FPS, nonblank canvas, console errors 0
- final code review: no significant issues