### PR TITLE
fix: restore living World Tree at night [1.77.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **Repolis** are documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/); dates are UTC.
 
+## [1.77.2] — 2026-07-11
+
+### 🌳 World Tree night legibility — restore the living Solar Archive
+- **Sharp tree surfaces restored.** Energy paths, glyphs, and all 3,016 leaf cards remain in the normal depth-tested base render while also feeding the isolated bloom source. The final composite is now the standard `base + blur bloom`; it no longer replaces the visible tree with a sparse effect-only copy.
+- **Warm bark from every approach.** A restrained tree-local emissive floor restores the generated brown bark and PBR relief at night without adding town-facing lights or changing global exposure. The factory PointLight remains effect-layer-only, so nearby buildings do not brighten.
+- **No factory downgrade.** The Solar Archive production factory file, geometry, 3,016-leaf count, animation, sockets, and SHA remain unchanged; only the Repolis adapter corrects layer routing and the night bark floor.
+
 ## [1.77.1] — 2026-07-11
 
 ### 💡 World Tree HDR isolation — live neon, invariant town exposure

--- a/index.html
+++ b/index.html
@@ -1537,13 +1537,13 @@ function _renderWorldTreeFrame(refreshTownShadows){
     needBloom=treeVisible&&effectPhase&&(WORLD_TREE_RENDER_MODE==='final-composite'||WORLD_TREE_RENDER_MODE==='bloom-only'),needSource=needEmissive||needBloom,
     forceProofLayer=!isNight&&(WORLD_TREE_RENDER_MODE==='emissive-only'||WORLD_TREE_RENDER_MODE==='bloom-only');
   if(needSource&&MEMORIAL_TREE){ _prepareWorldTreeBloom(); camera.layers.set(MEM_TREE_LIGHT_LAYER); MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=false; });
-    if(forceProofLayer) MEMORIAL_TREE.bloomRoots.forEach(root=>root.traverse(o=>{ o.layers.set(MEM_TREE_LIGHT_LAYER); }));
+    if(forceProofLayer) _setWorldTreeGlowLayers(true);
     MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=true; }); renderer.setRenderTarget(emissiveTarget); renderer.setClearColor(0x000000,0); renderer.clear(); renderer.render(scene,camera);
     if(needBloom) treeComposer.render(); MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=false; }); }
   renderer.toneMapping=savedTone; renderer.outputColorSpace=savedSpace; renderer.setClearColor(savedClear,savedAlpha); camera.layers.mask=mask; renderer.setRenderTarget(null);
   finalMix.uniforms.baseWeight.value=(WORLD_TREE_RENDER_MODE==='emissive-only'||WORLD_TREE_RENDER_MODE==='bloom-only')?0:1;
-  finalMix.uniforms.bloomWeight.value=needBloom?1:0; finalMix.uniforms.emissiveWeight.value=needEmissive?1:0; finalComposer.render();
-  if(MEMORIAL_TREE){ if(forceProofLayer) MEMORIAL_TREE.bloomRoots.forEach(root=>root.traverse(o=>{ o.layers.set(0); }));
+  finalMix.uniforms.bloomWeight.value=needBloom?1:0; finalMix.uniforms.emissiveWeight.value=WORLD_TREE_RENDER_MODE==='emissive-only'?1:0; finalComposer.render();
+  if(MEMORIAL_TREE){ if(forceProofLayer) _setWorldTreeGlowLayers(false);
     MEMORIAL_TREE.group.visible=requestedTreeVisible; MEMORIAL_TREE.bloomLights.forEach(light=>{ light.visible=true; }); }
 }
 
@@ -2796,10 +2796,15 @@ function _memHeroObjectPerf(root){
 function _memHeroEnvironment(root){
   camera.layers.enable(MEM_TREE_LIGHT_LAYER); return {lights:1};
 }
+function _setWorldTreeGlowLayers(night){
+  if(!MEMORIAL_TREE) return;
+  MEMORIAL_TREE.bloomRoots.forEach(root=>root.traverse(o=>{ o.layers.set(0); if(night) o.layers.enable(MEM_TREE_LIGHT_LAYER); }));
+  MEMORIAL_TREE.bloomLights.forEach(light=>light.layers.set(MEM_TREE_LIGHT_LAYER));
+}
 function _memHeroUpdate(elapsed){
   if(!MEMORIAL_TREE) return; if(!REDUCED) MEMORIAL_TREE.hero.update(elapsed);
   const ratio=MEM_TREE_HERO_SCALE/MEM_TREE_HERO_NATIVE_SCALE,m=MEMORIAL_TREE.hero.materials; MEMORIAL_TREE.light.distance=7*ratio;   // preserve factory pulse intensity; only its authored range follows uniform scale
-  if(isNight){ m.bark.emissive.setHex(0x160b06); m.bark.emissiveIntensity=0.03; m.amberLeaf.emissiveIntensity=0.42; m.cyanLeaf.emissiveIntensity=0.75; if(REDUCED){ m.energy.emissiveIntensity=2.85; MEMORIAL_TREE.light.intensity=18; } }
+  if(isNight){ m.bark.emissive.setHex(0x7a3f20); m.bark.emissiveIntensity=0.28; m.amberLeaf.emissiveIntensity=0.42; m.cyanLeaf.emissiveIntensity=0.75; if(REDUCED){ m.energy.emissiveIntensity=2.85; MEMORIAL_TREE.light.intensity=18; } }
   else { m.bark.emissive.setHex(0x6a3518); m.bark.emissiveIntensity=0.24; m.energy.emissiveIntensity=0.32; m.amberLeaf.emissiveIntensity=0.32; m.cyanLeaf.emissiveIntensity=0.38; MEMORIAL_TREE.light.intensity=2; }
 }
 function makeMemorialTree(x,z){
@@ -2818,11 +2823,12 @@ function makeMemorialTree(x,z){
   const size=nativeBox.getSize(new THREE.Vector3()).multiplyScalar(MEM_TREE_HERO_SCALE);
   root.userData.worldTree={seed:MEMORIAL_TREE_SEED,variant:MEM_TREE_HERO_VARIANT,stage,factorySha256:MEM_TREE_FACTORY_SHA,collider,crownOnlySway:false,
     target:{height:+size.y.toFixed(1),crownSpan:+size.x.toFixed(1),crownDepth:+size.z.toFixed(1)},lightPolicy:'factory-emissive-selective-bloom',sockets:Object.keys(sockets)};
-  root.userData.repolisAdapter={factoryUnmodified:true,groundVisible:true,pulseDisabled:false,leafScale:1.22,bloom:{night:[0.5,0.36,0.88],day:[0.04,0.18,0.96]},selectiveBloom:true,depthAware:true,scale:MEM_TREE_HERO_SCALE,qualityMode:'full'};
-  const bloomRoots=[light,...crowns,hero.runtime.nodes['energy-network'],hero.runtime.meshes['gold-code-glyphs'],hero.runtime.meshes['cyan-code-glyphs']].filter(Boolean);
-  bloomRoots.forEach(o=>o.traverse(n=>{ n.userData.worldTreeBloom=true; n.layers.set(MEM_TREE_LIGHT_LAYER); })); light.layers.set(MEM_TREE_LIGHT_LAYER);
-  const bloomLights=[light];
+  root.userData.repolisAdapter={factoryUnmodified:true,groundVisible:true,pulseDisabled:false,leafScale:1.22,bloom:{night:[0.5,0.36,0.88],day:[0.04,0.18,0.96]},selectiveBloom:true,sharpGlowInBase:true,depthAware:true,scale:MEM_TREE_HERO_SCALE,qualityMode:'full'};
+  const bloomRoots=[...crowns,hero.runtime.nodes['energy-network'],hero.runtime.meshes['gold-code-glyphs'],hero.runtime.meshes['cyan-code-glyphs']].filter(Boolean);
+  bloomRoots.forEach(o=>o.traverse(n=>{ n.userData.worldTreeBloom=true; }));
+  const bloomLights=[light].filter(Boolean);
   MEMORIAL_TREE={hero,group:root,runtime:hero.runtime,crowns,sockets,light,environment,bloomRoots,bloomLights,dynamicOccluderGroups:new Set(),occludersReady:false,requestedVisible:true,treeShadowDirty:false,stats:hero.stats,collider,seed:MEMORIAL_TREE_SEED,nativeBox};
+  _setWorldTreeGlowLayers(false);
   return MEMORIAL_TREE;
 }
 /*MEMORIAL_TREE:END*/
@@ -4367,7 +4373,7 @@ function setNightState(night){
   if(night===_nightState) return;
   _nightState=night;
   if(MEMORIAL_TREE) MEMORIAL_TREE.treeShadowDirty=true;
-  if(MEMORIAL_TREE) MEMORIAL_TREE.bloomRoots.forEach(root=>root.traverse(o=>{ o.layers.set(night?MEM_TREE_LIGHT_LAYER:0); }));
+  _setWorldTreeGlowLayers(night);
   worldBloom.strength=night?0.5:0.04; worldBloom.radius=night?0.36:0.18; worldBloom.threshold=night?0.88:0.96;
   renderer.shadowMap.needsUpdate=true; lastAct=performance.now();   // perf: 밤낮 전환 → 그림자 1회 강제 갱신 + 60fps 깨우기
   moon.visible=night; starsGroup.visible=night; fireflyGroup.visible=night;
@@ -7325,7 +7331,7 @@ if(location.search.includes('dbg')){ window.__cam=()=>({camYaw,camPitch,charYaw:
       macroBranches:s.macroBranches,secondaryBranches:s.secondaryBranches,fineBranches:s.fineBranches,leafInstances:s.leafInstances,mossInstances:s.mossInstances,glyphInstances:s.glyphInstances,branchVertices:s.branchVertices,generationMs:+s.generationMs.toFixed(1),
       mobile:IS_MOBILE,lowEnd:LOW_END,lite:MEM_TREE_LITE,reduced:REDUCED,runtime:{qualityMode:adapter.qualityMode,nodes:Object.keys(MEMORIAL_TREE.runtime.nodes).length,meshes:Object.keys(MEMORIAL_TREE.runtime.meshes).length,sockets:Object.keys(MEMORIAL_TREE.sockets).length,dynamicOccluders:MEMORIAL_TREE.dynamicOccluderGroups.size,staticProxies:MEMORIAL_TREE.staticProxyCount||0,objectPerf:_memHeroObjectPerf(MEMORIAL_TREE.group)},
       crownOnlySway:wt.crownOnlySway,sockets:Object.keys(MEMORIAL_TREE.sockets),collider:{x:c.x,z:c.z,r:c.r},target:wt.target,
-      nightGuide:{night:isNight,light:+MEMORIAL_TREE.light.intensity.toFixed(1),range:+MEMORIAL_TREE.light.distance.toFixed(1),energy:+MEMORIAL_TREE.hero.materials.energy.emissiveIntensity.toFixed(2),amber:+MEMORIAL_TREE.hero.materials.amberLeaf.emissiveIntensity.toFixed(2),cyan:+MEMORIAL_TREE.hero.materials.cyanLeaf.emissiveIntensity.toFixed(2),environmentLights:1},
+      nightGuide:{night:isNight,light:+MEMORIAL_TREE.light.intensity.toFixed(1),range:+MEMORIAL_TREE.light.distance.toFixed(1),energy:+MEMORIAL_TREE.hero.materials.energy.emissiveIntensity.toFixed(2),amber:+MEMORIAL_TREE.hero.materials.amberLeaf.emissiveIntensity.toFixed(2),cyan:+MEMORIAL_TREE.hero.materials.cyanLeaf.emissiveIntensity.toFixed(2),environmentLights:1,layers:{energy:MEMORIAL_TREE.hero.runtime.nodes['energy-network'].layers.mask,amber:MEMORIAL_TREE.crowns[0].layers.mask,light:MEMORIAL_TREE.light.layers.mask}},
       bounds:{min:[+b.min.x.toFixed(1),+b.min.y.toFixed(1),+b.min.z.toFixed(1)],max:[+b.max.x.toFixed(1),+b.max.y.toFixed(1),+b.max.z.toFixed(1)]}}; };
   window.__tpMemorialTree=(back=55)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position; player.position.set(p.x,0,p.z-back); camYaw=Math.PI; camPitch=0.08; camDist=22; model.rotation.y=0; return window.__memorialTree(); };
   window.__frameMemorialTree=(back=44,height=15,angle=0)=>{ if(!MEMORIAL_TREE) return null; const p=MEMORIAL_TREE.group.position,dx=Math.sin(angle),dz=Math.cos(angle); player.position.set(p.x-dx*back,height,p.z-dz*back); model.visible=false; camYaw=angle+Math.PI; camPitch=0; camDist=18; return window.__memorialTree(); };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -697,7 +697,7 @@ ok(/const pulse = 2\.55 \+ Math\.sin\(elapsedSeconds \* 2\.1\) \* 0\.45/.test(WO
   && /livingSystem\.rotation\.z = Math\.sin/.test(WORLD_TREE_FACTORY), 'web keeps the plugin energy, light, foliage, and living-system effects unchanged');
 ok(/customSockets=\{TaxiArrival:/.test(memorialTreeBlock)
   && /\['left-foundation:tip','right-foundation:tip','left-crown:tip','right-crown:tip'/.test(memorialTreeBlock), 'adapter preserves six Repolis sockets plus eight action-ready factory bough sockets');
-ok(/root\.userData\.repolisAdapter=\{factoryUnmodified:true,groundVisible:true,pulseDisabled:false[\s\S]*?selectiveBloom:true,depthAware:true/.test(memorialTreeBlock), 'runtime metadata records unchanged full factory effects and depth-aware selective bloom');
+ok(/root\.userData\.repolisAdapter=\{factoryUnmodified:true,groundVisible:true,pulseDisabled:false[\s\S]*?selectiveBloom:true,sharpGlowInBase:true,depthAware:true/.test(memorialTreeBlock), 'runtime metadata records unchanged full factory effects and sharp-base depth-aware selective bloom');
 ok(/treeBox=_memHeroBox\(MEMORIAL_TREE\.group\)\.expandByScalar\(3\)/.test(HTML)
   && /WorldTree_BuildingDepthProxies/.test(HTML) && /WorldTree_PropDepthProxies/.test(HTML)
   && (HTML.match(/frustumCulled=false/g)||[]).length>=3
@@ -706,25 +706,28 @@ ok(/treeBox=_memHeroBox\(MEMORIAL_TREE\.group\)\.expandByScalar\(3\)/.test(HTML)
 ok(/_registerWorldTreeOccluderGroup\(g\)/.test(HTML)
   && /_unregisterWorldTreeOccluderGroup\(p\.group\)/.test(HTML)
   && /dynamicOccluderGroups\.delete/.test(HTML), 'remote peer avatar proxies enter and leave the bloom depth cache without leaks');
-ok(/const bloomRoots=\[light,\.\.\.crowns,hero\.runtime\.nodes\['energy-network'\],hero\.runtime\.meshes\['gold-code-glyphs'\]/.test(memorialTreeBlock)
-  && /n\.userData\.worldTreeBloom=true; n\.layers\.set\(MEM_TREE_LIGHT_LAYER\)/.test(memorialTreeBlock)
+ok(/const bloomRoots=\[\.\.\.crowns,hero\.runtime\.nodes\['energy-network'\],hero\.runtime\.meshes\['gold-code-glyphs'\]/.test(memorialTreeBlock)
+  && /o\.layers\.set\(0\); if\(night\) o\.layers\.enable\(MEM_TREE_LIGHT_LAYER\)/.test(memorialTreeBlock)
+  && /bloomLights\.forEach\(light=>light\.layers\.set\(MEM_TREE_LIGHT_LAYER\)\)/.test(memorialTreeBlock)
   && !/hero\.runtime\.nodes\.constellations/.test(memorialTreeBlock)
-  && !/WorldTree_(Key|CoolRim|WarmFill|FrontFill)/.test(memorialTreeBlock), 'only energy, glyphs, leaves, and PointLight enter bloom; full constellations remain visible in the base pass');
+  && !/WorldTree_(Key|CoolRim|WarmFill|FrontFill)/.test(memorialTreeBlock), 'energy, glyphs, and leaves stay sharp in base and also feed bloom; PointLight remains effect-only');
 ok(/requestedTreeVisible=MEMORIAL_TREE\?MEMORIAL_TREE\.requestedVisible!==false:false/.test(HTML)
   && /MEMORIAL_TREE\.group\.visible=requestedTreeVisible/.test(HTML)
-  && /finalMix\.uniforms\.bloomWeight\.value=needBloom\?1:0/.test(HTML), 'tree-off or hidden state restores visibility and cannot composite stale bloom targets');
+  && /finalMix\.uniforms\.bloomWeight\.value=needBloom\?1:0/.test(HTML)
+  && /emissiveWeight\.value=WORLD_TREE_RENDER_MODE==='emissive-only'\?1:0/.test(HTML), 'final uses base plus blur once; tree-off and debug modes cannot composite a duplicate sharp emissive source');
 ok(/ratio=MEM_TREE_HERO_SCALE\/MEM_TREE_HERO_NATIVE_SCALE/.test(memorialTreeBlock)
   && !/MEMORIAL_TREE\.light\.intensity\*=/.test(memorialTreeBlock)
   && /MEMORIAL_TREE\.light\.distance=7\*ratio/.test(memorialTreeBlock), 'factory PointLight keeps its exact pulse intensity while its authored range follows uniform scale');
-ok(/if\(isNight\)\{ m\.bark\.emissive\.setHex\(0x160b06\); m\.bark\.emissiveIntensity=0\.03; m\.amberLeaf\.emissiveIntensity=0\.42/.test(memorialTreeBlock)
+ok(/if\(isNight\)\{ m\.bark\.emissive\.setHex\(0x7a3f20\); m\.bark\.emissiveIntensity=0\.28; m\.amberLeaf\.emissiveIntensity=0\.42/.test(memorialTreeBlock)
   && /if\(REDUCED\)\{ m\.energy\.emissiveIntensity=2\.85; MEMORIAL_TREE\.light\.intensity=18/.test(memorialTreeBlock)
   && /else \{ m\.bark\.emissive\.setHex\(0x6a3518\)/.test(memorialTreeBlock)
   && /m\.amberLeaf\.emissiveIntensity=0\.32; m\.cyanLeaf\.emissiveIntensity=0\.38/.test(memorialTreeBlock)
-  && /MEMORIAL_TREE\.bloomRoots\.forEach\(root=>root\.traverse\(o=>\{ o\.layers\.set\(night\?MEM_TREE_LIGHT_LAYER:0\)/.test(HTML)
+  && /_setWorldTreeGlowLayers\(night\)/.test(HTML)
   && /worldBloom\.strength=night\?0\.5:0\.04/.test(HTML), 'day calms ornaments while night/reduced-motion restore exact live-demo material and light values');
 ok(/effectPhase=isNight\|\|WORLD_TREE_RENDER_MODE==='emissive-only'\|\|WORLD_TREE_RENDER_MODE==='bloom-only'/.test(HTML), 'day/dawn/dusk final mode skips emissive and bloom HDR passes entirely');
 ok(/forceProofLayer=!isNight&&\(WORLD_TREE_RENDER_MODE==='emissive-only'\|\|WORLD_TREE_RENDER_MODE==='bloom-only'\)/.test(HTML)
-  && /if\(forceProofLayer\) MEMORIAL_TREE\.bloomRoots\.forEach/.test(HTML), 'daytime emissive/bloom proof modes temporarily route glow roots to the effect layer');
+  && /if\(forceProofLayer\) _setWorldTreeGlowLayers\(true\)/.test(HTML)
+  && /if\(forceProofLayer\) _setWorldTreeGlowLayers\(false\)/.test(HTML), 'daytime emissive/bloom proof modes restore visual dual-layers and keep PointLight effect-only');
 ok(/MEMORIAL_TREE\.bloomLights\.forEach\(light=>\{ light\.visible=true; \}\); renderer\.setRenderTarget\(emissiveTarget\)/.test(HTML), 'factory PointLight contributes only to the isolated emissive source, never the town base');
 ok(/geometry\.scale\(1\.22,1\.22,1\.22\)/.test(memorialTreeBlock)
   && /leafScale:1\.22/.test(memorialTreeBlock), 'adapter enlarges factory leaf cards without changing their count, anchors, or hierarchy');


### PR DESCRIPTION
## Root cause
The 1.77.1 selective-bloom adapter removed the visible energy, glyph, and leaf surfaces from the depth-tested base render. It then made the final image depend on a sparse effect-only copy while forcing night bark to a near-black emissive floor. Normal and rear approaches therefore read as a black, leafless silhouette.

## Fix
- keep energy, glyphs, and all 3,016 leaf cards sharp in base layer 0 and additionally route them to the isolated bloom layer at night
- composite `base + true blur bloom`; reserve the sharp emissive target for the debug proof mode only
- keep the factory PointLight effect-only so the town never receives physical spill
- restore a restrained warm bark floor from every viewing direction
- preserve the byte-identical production factory, geometry, animation, sockets, and leaf count

## Verification
- same-camera mobile front/back and desktop five-pass captures
- Town Exposure Invariance: 0.26% mean / 0.00% P95 delta
- layer masks: night visuals 0+2 / light 2; day visuals 0 / light 2; proof-mode restore verified
- same-browser A/B shows no measurable performance regression
- smoke 404, council 130, council live 56, plugin 34
- console errors/warnings 0
- factory SHA-256: 65bd7fc76013ee0f11898174095556d581be64ea8f15e76e090fb8955a17d0e3