### PR TITLE
fix: keep MIRA grounded when Context7 quota is exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [1.80.1] — 2026-07-16
+
+### 📚 Fix: MIRA survives Context7's shared anonymous MCP quota
+
+- Context7 remains MIRA's primary oracle, but a production Cloudflare egress can share an exhausted anonymous
+  monthly quota. Known library identities now retain their canonical Context7 IDs.
+- If resolve or query returns a quota/rate-limit response, the Worker reads the same library's bounded public
+  Context7 `llms.txt` document, preserves source links, and applies the same grounded synthesis rules.
+- Unsupported libraries still fail explicitly; the fallback never substitutes general model knowledge for
+  missing documentation.
+
 ## [1.80.0] — 2026-07-16
 
 ### 🧭 Residents introduce roaming MCP scholars — find expertise by walking the town

--- a/SCHOLARS.md
+++ b/SCHOLARS.md
@@ -144,3 +144,5 @@ git‑ignored `cloudflare-taxi/SECRETS.local.md`; the full secret list + the one
 
 MIRA and LYRA work anonymously. Optional `CONTEXT7_API_KEY` and `HF_TOKEN` Worker
 secrets only raise third-party quotas; they are never sent to the browser.
+When Context7's shared anonymous MCP quota is exhausted, MIRA uses the resolved library's
+public Context7 `llms.txt` document as a bounded fallback and keeps the same source trace.

--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -47,6 +47,8 @@ service principal only has the `Cognitive Services OpenAI User` role on your AOA
 
 MIRA and LYRA work anonymously. For higher third-party quotas you may additionally set
 `CONTEXT7_API_KEY` and `HF_TOKEN` as Worker secrets. They remain server-side and are optional.
+If Context7's anonymous MCP quota is exhausted, MIRA falls back to that library's public
+Context7 `llms.txt` page rather than returning an ungrounded answer.
 
 Deterministic navigation ("take me to the most popular repo") is handled in the client
 and never reaches here. If the KB is unreachable / slow / unconfigured, the Worker returns

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -192,24 +192,27 @@ function refsFromMarkdown(text, fallbackUrl, fallbackName) {
 }
 
 const CONTEXT7_NAMES = [
-  ["next.js", /(?:next\.?js|nextjs)/i], ["react", /\breact(?:\.?js)?\b/i], ["vue", /\bvue(?:\.?js)?\b/i],
-  ["svelte", /\bsvelte(?:kit)?\b/i], ["angular", /\bangular\b/i], ["three.js", /(?:three\.?js|threejs)/i],
-  ["express", /\bexpress(?:\.?js)?\b/i], ["fastapi", /\bfastapi\b/i], ["django", /\bdjango\b/i],
-  ["flask", /\bflask\b/i], ["spring boot", /\bspring\s*boot\b/i], ["tailwind css", /\btailwind(?:\s*css)?\b/i],
-  ["supabase", /\bsupabase\b/i], ["langchain", /\blangchain\b/i], ["transformers", /\btransformers\b/i],
-  ["pytorch", /\b(?:pytorch|torch)\b/i], ["tensorflow", /\btensorflow\b/i], ["node.js", /(?:node\.?js|nodejs)/i],
-  ["cloudflare workers", /\bcloudflare\s+workers?\b/i], ["redis", /\bredis\b/i], ["postgresql", /\b(?:postgres|postgresql)\b/i],
+  ["next.js", "/vercel/next.js", /(?:next\.?js|nextjs)/i], ["react", "/reactjs/react.dev", /\breact(?:\.?js)?\b/i],
+  ["supabase", "/supabase/supabase", /\bsupabase\b/i], ["mongodb", "/mongodb/docs", /\bmongo(?:db)?\b/i],
+  ["vue", "", /\bvue(?:\.?js)?\b/i], ["svelte", "", /\bsvelte(?:kit)?\b/i], ["angular", "", /\bangular\b/i],
+  ["three.js", "", /(?:three\.?js|threejs)/i], ["express", "", /\bexpress(?:\.?js)?\b/i],
+  ["fastapi", "", /\bfastapi\b/i], ["django", "", /\bdjango\b/i], ["flask", "", /\bflask\b/i],
+  ["spring boot", "", /\bspring\s*boot\b/i], ["tailwind css", "", /\btailwind(?:\s*css)?\b/i],
+  ["langchain", "", /\blangchain\b/i], ["transformers", "", /\btransformers\b/i],
+  ["pytorch", "", /\b(?:pytorch|torch)\b/i], ["tensorflow", "", /\btensorflow\b/i],
+  ["node.js", "", /(?:node\.?js|nodejs)/i], ["cloudflare workers", "", /\bcloudflare\s+workers?\b/i],
+  ["redis", "", /\bredis\b/i], ["postgresql", "", /\b(?:postgres|postgresql)\b/i],
 ];
 
 function context7Target(question) {
   const q = String(question || "").slice(0, 500);
   const direct = q.match(/(?:^|\s)(\/[\w.-]+\/[\w.-]+(?:\/[\w.-]+)?)(?=\s|$)/);
-  if (direct) return { libraryId: direct[1], libraryName: direct[1].split("/").filter(Boolean).slice(-1)[0] };
-  for (const [name, re] of CONTEXT7_NAMES) if (re.test(q)) return { libraryId: "", libraryName: name };
+  if (direct) return { libraryId: direct[1], fallbackId: direct[1], libraryName: direct[1].split("/").filter(Boolean).slice(-1)[0] };
+  for (const [name, id, re] of CONTEXT7_NAMES) if (re.test(q)) return { libraryId: "", fallbackId: id, libraryName: name };
   const candidates = q.match(/@?[\w.-]+(?:\/[\w.-]+)?/g) || [];
   const stop = new Set(["how", "what", "which", "with", "from", "using", "use", "version", "latest", "docs", "api"]);
   const picked = candidates.find((x) => x.length >= 3 && !stop.has(x.toLowerCase()) && /[A-Za-z]/.test(x));
-  return { libraryId: "", libraryName: picked || q.slice(0, 80) };
+  return { libraryId: "", fallbackId: "", libraryName: picked || q.slice(0, 80) };
 }
 
 function hfSearchType(question) {
@@ -271,27 +274,38 @@ async function context7Ask(question, env, extra) {
       null, false, ctrl.signal, headers);
     const sid = init.sid;
     if (sid) await mcpRpc(cfg.url, "notifications/initialized", null, sid, true, ctrl.signal, headers);
-    const target = context7Target(question);
+    const target = context7Target(question), tools = [];
     let libraryId = target.libraryId, resolveText = "";
     if (!libraryId) {
+      tools.push("resolve-library-id");
       const resolved = await mcpRpc(cfg.url, "tools/call", {
         name: "resolve-library-id", arguments: { libraryName: target.libraryName, query: String(question).slice(0, 500) },
       }, sid, false, ctrl.signal, headers);
       resolveText = mcpText(resolved);
       libraryId = (resolveText.match(/Context7-compatible library ID:\s*(\/[^\s]+)/i) || [])[1] || "";
+      if (!libraryId && /quota exceeded|rate limit|too many requests/i.test(resolveText)) libraryId = target.fallbackId;
     }
     if (!libraryId) {
       clearTimeout(timer);
       return json({ kind: "docs", notFound: true, items: [], trace: { ks: cfg.source, tools: ["resolve-library-id"] } }, 200, env);
     }
+    tools.push("query-docs");
     const docs = await mcpRpc(cfg.url, "tools/call", {
       name: "query-docs", arguments: { libraryId, query: String(question).slice(0, 500) },
     }, sid, false, ctrl.signal, headers);
+    let text = mcpText(docs);
+    if (!text || /quota exceeded|rate limit|too many requests/i.test(text)) {
+      const publicUrl = `https://context7.com${libraryId}/llms.txt?topic=${encodeURIComponent(String(question).slice(0, 180))}&tokens=3500`;
+      const publicDocs = await fetch(publicUrl, { signal: ctrl.signal });
+      if (publicDocs.ok) { text = await publicDocs.text(); tools.push("context7-llms"); }
+    }
     clearTimeout(timer);
-    const text = mcpText(docs);
     if (!text) return json({ fallback: true, reason: "empty Context7 docs" }, 200, env);
+    if (/quota exceeded|rate limit|too many requests/i.test(text)) {
+      return json({ fallback: true, reason: "Context7 quota exceeded" }, 200, env);
+    }
     const refs = refsFromMarkdown(text, `https://context7.com/${libraryId.replace(/^\//, "")}`, libraryId);
-    return directMcpResponse("context7", question, text, refs, ["resolve-library-id", "query-docs"], env, extra, started);
+    return directMcpResponse("context7", question, text, refs, tools, env, extra, started);
   } catch (e) {
     clearTimeout(timer);
     return json({ fallback: true, reason: e?.name === "AbortError" ? `timeout ${timeoutMs}ms` : String(e).slice(0, 160) }, 200, env);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -411,6 +411,7 @@ ok(/LYRA · 창조의 대장장이/.test(SCHOLARS_SRC) && /LYRA · the Forgemast
 ok(/url: "https:\/\/mcp\.context7\.com\/mcp"[\s\S]*?adapter: "context7"/.test(WORKER), 'Context7 official remote MCP endpoint is registered');
 ok(/url: "https:\/\/huggingface\.co\/mcp"[\s\S]*?adapter: "huggingface"/.test(WORKER), 'Hugging Face official remote MCP endpoint is registered');
 ok(/async function context7Ask\([\s\S]*?"resolve-library-id"[\s\S]*?"query-docs"/.test(WORKER), 'MIRA performs Context7 resolve → versioned docs retrieval');
+ok(/context7\.com\$\{libraryId\}\/llms\.txt\?topic=/.test(WORKER) && /tools\.push\("context7-llms"\)/.test(WORKER), 'Context7 anonymous quota exhaustion falls back to the same library public llms docs');
 ok(/async function huggingFaceAsk\([\s\S]*?type === "paper" \? "hf_fs" : "hub_repo_search"/.test(WORKER), 'LYRA uses Hub repo search for models/datasets and hf_fs for papers');
 ok(/No \(\?:repositories\|papers\) found/.test(WORKER) && /notFound: true/.test(WORKER), 'empty Hugging Face searches surface as not-found instead of a fake generic result');
 ok(/env\.CONTEXT7_API_KEY \? \{ CONTEXT7_API_KEY: env\.CONTEXT7_API_KEY \} : \{\}/.test(WORKER), 'Context7 is anonymous by default with an optional quota key');


### PR DESCRIPTION
## Summary
- retain canonical Context7 IDs for common libraries
- keep MCP as the primary path
- fall back to bounded public Context7 llms.txt docs when shared anonymous MCP quota is exhausted
- preserve source traces and reject unsupported libraries explicitly

## Checks
- 520 smoke guards
- Worker syntax
- live Context7 public documentation fallback probe