### PR TITLE
docs: connect demo to first town visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [1.83.3] — 2026-07-22
+
+### 🎬 README demo continuity — from Hada curiosity to a first town visit
+
+- The existing current EN/KO GIFs now have visible 15-second captions that explain the full
+  traffic→building→Gitber→taxi→repo-card story instead of relying on image alt text.
+- Generic control copy becomes the exact first interaction path: `WASD`/touch to walk, ask Gitber, and
+  `Enter`/tap to open, with no-sign-up/no-build and local-run proof kept in the same compact line.
+- A single calm `Star Repolis` link follows the action path below the demo. The GIF, hero hierarchy, data
+  mapping section, and Council assets remain unchanged.
+
 ## [1.83.2] — 2026-07-21
 
 ### 🏡 Resident cottage variety — richer homes, bounded batches

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,8 @@
 
 <a href="https://hyeonsangjeon.github.io/Repolis/"><img src="assets/demo.ko.gif" alt="Repolis 데모: 트래픽으로 지은 살아 있는 GitHub 마을, 깃버 검색과 택시 이동, 실제 레포 카드" width="92%"></a>
 
-<sub>가입 없음 · 빌드 없음 · 키보드, 터치, 모바일 조작 지원 · <strong><a href="#60초-로컬-실행">로컬 실행</a></strong></sub>
+<sub>🎬 <strong>15초 데모:</strong> 트래픽 → 건물 · 깃버에게 질문 → 택시 이동 → 실제 레포 카드</sub><br>
+<sub><code>WASD</code> / 터치로 걷기 · 깃버에게 묻기 · <code>Enter</code> / 탭으로 열기 · 가입이나 빌드 없음 · <strong><a href="#60초-로컬-실행">로컬 실행</a></strong> · ⭐ <strong><a href="https://github.com/hyeonsangjeon/Repolis">Star 남기기</a></strong></sub>
 
 [![매일 갱신](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=flat-square&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=flat-square&logo=three.js&logoColor=white)](https://threejs.org)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 <a href="https://hyeonsangjeon.github.io/Repolis/"><img src="assets/demo.gif" alt="Repolis demo: a living traffic-shaped GitHub town, Gitber search, taxi ride, and real repository card" width="92%"></a>
 
-<sub>No sign-up · no build step · keyboard, touch, and mobile controls · <strong><a href="#run-in-60-seconds">Run locally</a></strong></sub>
+<sub>🎬 <strong>15-second demo:</strong> traffic → buildings · ask Gitber → taxi ride → real repo card</sub><br>
+<sub><code>WASD</code> / touch to walk · ask Gitber · <code>Enter</code> / tap to open · no sign-up or build · <strong><a href="#run-in-60-seconds">Run locally</a></strong> · ⭐ <strong><a href="https://github.com/hyeonsangjeon/Repolis">Star Repolis</a></strong></sub>
 
 [![Daily refresh](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=flat-square&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=flat-square&logo=three.js&logoColor=white)](https://threejs.org)

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -46,11 +46,19 @@ const heroCopy = 'Public GitHub repos become a walkable 3D town. Traffic shapes 
 const heroCopyKo = 'Repolis는 공개 GitHub 레포를 직접 걸어 다니는 3D 마을로 바꿉니다. 트래픽이 건물을 만들고, 주민이 살아가며, 깃버가 원하는 프로젝트까지 데려갑니다.';
 ok(README_EN.includes(`**${heroCopy}**`) && README_KO.includes(`**${heroCopyKo}**`), 'EN/KO heroes carry one copyable product sentence');
 const heroOrderEn = [README_EN.indexOf(`**${heroCopy}**`), README_EN.indexOf('Open-Live%20Town'),
-  README_EN.indexOf('assets/demo.gif'), README_EN.indexOf('daily%20refresh')];
+  README_EN.indexOf('assets/demo.gif'), README_EN.indexOf('🎬 <strong>15-second demo:</strong>'),
+  README_EN.indexOf('<code>WASD</code> / touch to walk'), README_EN.indexOf('>Star Repolis</a>'), README_EN.indexOf('daily%20refresh')];
 const heroOrderKo = [README_KO.indexOf(`**${heroCopyKo}**`), README_KO.indexOf('%EB%9D%BC%EC%9D%B4%EB%B8%8C-'),
-  README_KO.indexOf('assets/demo.ko.gif'), README_KO.indexOf('daily%20refresh')];
-ok(heroOrderEn.every(i => i >= 0) && heroOrderEn.every((i, n) => n === 0 || heroOrderEn[n - 1] < i), 'English hero orders story → live CTA → demo → utility proof');
-ok(heroOrderKo.every(i => i >= 0) && heroOrderKo.every((i, n) => n === 0 || heroOrderKo[n - 1] < i), 'Korean hero orders story → live CTA → demo → utility proof');
+  README_KO.indexOf('assets/demo.ko.gif'), README_KO.indexOf('🎬 <strong>15초 데모:</strong>'),
+  README_KO.indexOf('<code>WASD</code> / 터치로 걷기'), README_KO.indexOf('>Star 남기기</a>'), README_KO.indexOf('daily%20refresh')];
+ok(heroOrderEn.every(i => i >= 0) && heroOrderEn.every((i, n) => n === 0 || heroOrderEn[n - 1] < i), 'English hero orders story → live CTA → demo → caption → controls → Star → utility proof');
+ok(heroOrderKo.every(i => i >= 0) && heroOrderKo.every((i, n) => n === 0 || heroOrderKo[n - 1] < i), 'Korean hero orders story → live CTA → demo → caption → controls → Star → utility proof');
+ok(/traffic → buildings · ask Gitber → taxi ride → real repo card/.test(README_EN)
+  &&/트래픽 → 건물 · 깃버에게 질문 → 택시 이동 → 실제 레포 카드/.test(README_KO), 'visible EN/KO captions describe what the existing demo proves');
+ok(/<code>Enter<\/code> \/ tap to open · no sign-up or build/.test(README_EN)
+  &&/<code>Enter<\/code> \/ 탭으로 열기 · 가입이나 빌드 없음/.test(README_KO), 'visible controls state the exact first interaction and friction-free setup');
+ok((README_EN.match(/href="https:\/\/github\.com\/hyeonsangjeon\/Repolis">Star Repolis<\/a>/g)||[]).length===1
+  &&(README_KO.match(/href="https:\/\/github\.com\/hyeonsangjeon\/Repolis">Star 남기기<\/a>/g)||[]).length===1, 'each hero contains exactly one calm repository Star CTA');
 ok((HTML.split(heroCopy).length - 1) === 3 && !HTML.includes('6-pin grid'), 'description, Open Graph, and Twitter share the current positioning');
 ok(DEMO_EN.subarray(0, 6).toString() === 'GIF89a' && DEMO_EN.readUInt16LE(6) === 520 && DEMO_EN.readUInt16LE(8) === 293
   && DEMO_KO.subarray(0, 6).toString() === 'GIF89a' && DEMO_KO.readUInt16LE(6) === 520 && DEMO_KO.readUInt16LE(8) === 293, 'EN/KO hero demos remain 520×293 GIF89a assets');


### PR DESCRIPTION
## Summary
- add visible EN/KO captions explaining the existing 15-second traffic-to-repo demo
- replace generic control copy with WASD/touch, Gitber, and Enter/tap actions
- keep no-sign-up/build and local-run proof, then add one calm Star CTA below the demo

## Validation
- `node council/test.mjs`
- `node council/test-live.mjs`
- `node scripts/smoke.mjs`
- `node --check scholars.js`
- `node --check cloudflare-taxi/src/grounded.js`
- YAML and local Markdown link checks
- GitHub GFM desktop and 390×844 EN/KO first-fold rendering
