### PR TITLE
feat: enforce durable NPC budget cap

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -238,17 +238,58 @@ tool list intentionally contains no account, position, order, conversion, deposi
 or transfer capability. Returned MCP documents include a Coinbase source URL and a retrieval
 timestamp so the KB can cite the data it used.
 
-## 🧑‍🌾 Resident NPC social layer (optional, budget-capped)
+## 🧑‍🌾 Resident NPC social layer (optional, hard-capped)
 
 The city's **townspeople** (9 residents — distinct from the specialist scholars and Gitber the taxi) trade
-short turn-by-turn ambient lines and chat with the visitor. **This is off by default and costs nothing:**
-`index.html` ships them as deterministic **scripted** residents (zero network). The Worker only produces
-real model turns when you opt in *and* the daily budget allows — otherwise every action returns
-`{ fallback: true }` and the client uses its own free scripted bank.
+short ambient lines and chat with the visitor. They remain deterministic **scripted** residents by default:
+zero network, zero backend, and zero model cost. The Worker produces a real model turn only when every env/KV
+kill switch is on **and** the Durable NPC Budget Governor accepts a worst-case reservation.
 
-The client learns the runtime toggles + budget from a best-effort `npcConfig` call on boot; it can never
-exceed the Worker's env ceiling. All model turns are **budget-capped** (UTC-day tally) and **redacted** in
-metrics. The `NPC_*` namespace is fully separate from `COUNCIL_*`.
+### Durable hard-cap design
+
+`NPC_BUDGET_GOVERNOR` is a SQLite-backed Durable Object binding. Every Worker isolate addresses the same
+`npc-budget-canonical-v1` instance, which serializes and persists the UTC-day budget:
+
+- aggregate only: `spent`, `reserved`, completed/in-flight turns, and bounded daily attempts;
+- idempotency records: reservation day, amount, and pending/settled/released status;
+- **never** prompts, conversation text, visitor identifiers, or personal data.
+
+Before Azure OpenAI is called, the Worker validates the selected deployment's price table and official model
+input/output limits, then calculates a conservative maximum cost from the exact bounded message bytes plus 512
+chat-framing tokens and the request's `max_completion_tokens`. One UTF-8 byte per input token is the conservative
+tokenizer bound; the reservation uses the more expensive of normal/cached input prices and the full output
+allowance. The committed `gpt-5.4-mini` entry uses Azure's documented 272,000-token maximum input and
+128,000-token maximum output limits; the request itself is capped at 120 output tokens. The Governor atomically
+accepts only when:
+
+```text
+spent + reserved + maximumTurnCost <= NPC_DAY_CAP_USD
+completedTurns + reservedTurns < NPC_DAILY_TURN_MAX  (when non-zero)
+acceptedAttempts < NPC_DAILY_ATTEMPT_MAX
+```
+
+Concurrent requests therefore cannot pass the same remaining dollars or turn slot. Success settles normalized
+provider usage and returns the unused reservation. A failure proven to occur before Azure model dispatch releases
+the reservation at zero cost. Once dispatch begins, HTTP/network error, timeout, abort, unusable/empty content, or
+missing/partial/malformed/out-of-bounds usage conservatively settles the full reservation before scripted fallback;
+that removes the reservation without pretending an ambiguous provider attempt was free. Unknown deployment pricing,
+malformed caps, a missing/unresponsive binding, or failed settlement all **fail closed before another model
+call**; the client uses its free scripted bank. A failed settlement leaves the conservative reservation held,
+so loss of availability cannot become cap overshoot.
+
+UTC rollover starts a clean active-day aggregate on the first Governor operation of the new day. Prior-day
+in-flight reservations and their aggregate remain only as needed to settle/release cross-midnight calls safely.
+Lowering the cap or imposing a tighter turn limit during a day is sticky until the next UTC day, so an older
+Worker isolate cannot reopen it with stale higher settings. In-day increases deliberately wait until rollover.
+If current spend/reservations already exceed a new lower cap, no new reservation is accepted.
+`NPC_DAY_CAP_USD=0` disables model turns immediately at the Governor.
+Accepted reservations also increment a durable attempt counter. `NPC_DAILY_ATTEMPT_MAX` provides a bounded
+abuse/storage ceiling even when providers repeatedly fail and release their dollar/turn reservations; released
+idempotency tombstones are deleted, the immediately prior UTC day's settled records remain available for response
+retries, and later rollovers remove older finalized records once no pending call needs them.
+Every pending reservation has a durable lease longer than the provider timeout plus Governor retries. A Durable
+Object alarm full-settles an orphaned lease, so a terminated Worker cannot leave permanent pending state or reopen
+possibly billable dollars.
 
 ### Actions
 
@@ -256,74 +297,95 @@ metrics. The `NPC_*` namespace is fully separate from `COUNCIL_*`.
 
 ```jsonc
 { "npc_action": "npcConfig", "lang": "ko" }
-// → { ok, config:{ aiEnabled, ambientEnabled, playerChatEnabled, maxTurns, hardMaxTurns, source, liveToggle }, budget:{…} }
+// → { ok, config:{ aiEnabled, ambientEnabled, playerChatEnabled, maxTurns, hardMaxTurns,
+//                  source:"durable-object", flagSource, liveToggle },
+//      budget:{ source:"durable-object", available, ... } }
 { "npc_action": "npcBudget" }
-// → { ok, budget:{ enabled, dayCapUsd, spentUsd, remainingUsd, turnsToday, dailyTurnMax, blocked } }
+// → { ok, budget:{ enabled, available, source:"durable-object", day, dayCapUsd,
+//                  spentUsd, reservedUsd, remainingUsd, turnsToday, reservedTurns,
+//                  dailyTurnMax, attemptsToday, dailyAttemptMax, blocked } }
 { "npc_action": "npcAmbientTurn", "speaker":"sol", "listener":"jun", "topic":"model", "lang":"ko",
   "last":[{ "who":"jun", "text":"…" }] }
-// → { ok, line:"one ≤180-char line", budget:{…} }   |   { ok, fallback:true, reason, budget }
+// → { ok, line:"one short line", budget:{…} } | { ok, fallback:true, reason, budget }
 { "npc_action": "npcPlayerChat", "speaker":"nari", "zone":"web", "question":"…", "lang":"ko" }
-// → { ok, line:"…", budget }   |   { ok:false, fallback:true, reason:"npc_budget_exhausted", budget }
+// → { ok, line:"…", budget } | { ok:false, fallback:true, reason:"npc_budget_exhausted", budget }
 ```
 
-### Env (all optional — defaults keep AI **off** so a fresh clone costs nothing)
+`npcConfig` and `npcBudget` only read flags/Governor state; they never invoke a model. When the binding is
+unavailable, they return `available:false`, `blocked:true`, and `source:"durable-object"` rather than an
+isolate-local estimate.
+
+### Env (all optional — defaults keep AI **off**)
 
 | Var | Default | Meaning |
 |---|---|---|
-| `NPC_AI_ENABLED` | `false` | Master switch. `!== "true"` → **never** a model call (hard ceiling). |
-| `NPC_AMBIENT_ENABLED` | `false` | Allow model-powered ambient turns (requires `NPC_AI_ENABLED`). |
-| `NPC_PLAYER_CHAT_ENABLED` | `false` | Allow model-powered player chat (requires `NPC_AI_ENABLED`). |
-| `NPC_LIVE_TOGGLE` | `false` | Master kill-switch for the live KV path. `!== "true"` → the `NPC_FLAGS` KV is **ignored** and residents stay strictly env-gated (deploy-only, the safe default). `"true"` → the dashboard can flip on/off in real time (see below). |
-| `NPC_MODEL_DEFAULT` | `gpt-5.4-mini` | Deployment name for NPC turns. |
-| `NPC_MODEL_AMBIENT` / `NPC_MODEL_PLAYER` | — | Optional per-role deployment overrides. |
-| `NPC_DAY_CAP_USD` | `10` | Hard daily spend cap; over it → `npc_budget_exhausted`. |
-| `NPC_DAILY_TURN_MAX` | `0` (off) | Optional hard daily turn cap. |
-| `NPC_PRICE_IN_PER_1K` / `NPC_PRICE_OUT_PER_1K` | `0.00015` / `0.0006` | Price per 1K tokens for the day tally. |
-| `NPC_TURN_COST_USD` | `0.0003` | Flat per-turn estimate when the model returns no usage. |
-| `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient turn caps. |
-| `NPC_TIMEOUT_MS` | `12000` | Per-turn model timeout. |
-| `METRICS_URL` | — | Optional private collector; redacted fire-and-forget events (lengths only, no text). |
+| `NPC_AI_ENABLED` | `false` | Top-level env ceiling. Anything except `"true"` means **never** a resident model call. KV cannot override it on. |
+| `NPC_AMBIENT_ENABLED` | `false` | Env ceiling for model-powered ambient turns (also requires `NPC_AI_ENABLED`). |
+| `NPC_PLAYER_CHAT_ENABLED` | `false` | Env ceiling for model-powered player chat (also requires `NPC_AI_ENABLED`). |
+| `NPC_LIVE_TOGGLE` | `false` | Enables per-request `NPC_FLAGS` kill switches. When off, KV is ignored. |
+| `NPC_MODEL_DEFAULT` | `gpt-5.4-mini` | Azure OpenAI deployment name for resident turns. |
+| `NPC_MODEL_AMBIENT` / `NPC_MODEL_PLAYER` | — | Optional per-role deployment overrides; each deployed name needs a pricing entry. |
+| `NPC_MODEL_PRICING_JSON` | built-in `gpt-5.4-mini` table | JSON map of deployment alias to `inputPer1MUsd`, `cachedInputPer1MUsd`, `outputPer1MUsd`, `maxInputTokens`, and `maxOutputTokens`. Invalid/unknown/incomplete means no call. |
+| `NPC_MAX_COMPLETION_TOKENS` | `120` | Provider output cap and reservation output bound (1–4096). |
+| `NPC_DAY_CAP_USD` | `10` | Durable UTC-day hard cap. `0` disables calls. Invalid values fail closed. |
+| `NPC_DAILY_TURN_MAX` | `0` (off) | Optional durable daily turn cap; in-flight reservations consume slots. |
+| `NPC_DAILY_ATTEMPT_MAX` | `5000` | Hard abuse/storage ceiling for accepted reservations, including provider failures. Must be positive. |
+| `NPC_BUDGET_TIMEOUT_MS` | `1500` | Internal Governor response deadline (100–10000 ms); timeout fails closed. |
+| `NPC_RESERVATION_LEASE_MS` | `60000` | Orphan lease; must exceed `NPC_TIMEOUT_MS + 2×NPC_BUDGET_TIMEOUT_MS + 10000` and be ≤300000. Expiry full-settles. |
+| `NPC_TIMEOUT_MS` | `12000` | Entra token + model request deadline; timeout aborts the request and releases its reservation. |
+| `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient conversation caps. |
+| `METRICS_URL` | — | Optional private collector. Resident budget telemetry is anonymous aggregate operations only. |
 
-Model turns reuse the **same** Entra ID service principal as the scholar chat (`AAD_*` + `AOAI_ENDPOINT`);
-no new secret is needed.
+Model turns reuse the **same** Entra ID service principal as scholar chat (`AAD_*` + `AOAI_ENDPOINT`); no
+new secret is needed. Keep the committed `NPC_MODEL_PRICING_JSON` synchronized with the actual deployment
+meter before enabling the pilot. A custom deployment alias without a matching entry is deliberately rejected.
 
-### Live on/off from the owner dashboard (no redeploy)
+Allowed resident-budget telemetry is limited to `npc_budget_reserve` (accepted/rejected),
+`npc_budget_settle` (settled/released), `npc_provider_error`, and `npc_budget_utc_reset`. Events may include
+role, reason, aggregate dollars/turns, and whether provider usage was authoritative. They never include prompt
+text, conversation text, speaker/visitor identity, instance ID, or reservation ID. Scholar/KB/MCP telemetry
+remains on its existing independent path.
 
-By default the flags above are **deploy-time** — flipping them means `wrangler secret put` + a Worker
-deploy (seconds, but still a deploy). For a real-time button, bind a shared KV namespace and turn on the
-master kill-switch:
+### Live kill switches
 
+By default the three feature flags are deploy-time env ceilings. For an owner dashboard, bind the shared KV
+namespace and enable live reads:
+
+```bash
+# create once; bind the SAME id in the private dashboard Worker
+npx wrangler kv namespace create NPC_FLAGS
+# [[kv_namespaces]] binding="NPC_FLAGS" id="…" is already wired here
+npx wrangler secret put NPC_LIVE_TOGGLE   # enter: true
 ```
-# create once, bind the SAME id in repolis-metrics/wrangler.toml
-wrangler kv namespace create NPC_FLAGS
-# [[kv_namespaces]] binding="NPC_FLAGS" id="…" in wrangler.toml (already wired here)
-wrangler secret put NPC_LIVE_TOGGLE   # set to: true
-```
 
-With `NPC_LIVE_TOGGLE="true"`, this Worker reads `NPC_FLAGS` keys `ai_enabled` / `ambient_enabled` /
-`player_chat_enabled` (`"true"`/`"false"`) **per request**, each falling back to its env var when the key is
-absent. The private **repolis-metrics** dashboard writes those keys from an owner-only button. Propagation
-across Cloudflare's edge takes **up to ~60s**. This can never bypass the ceiling: `aiEnabled` is still ANDed
-into every model call, so `NPC_AI_ENABLED=false` + no KV key = strictly scripted. Leave `NPC_LIVE_TOGGLE`
-unset and the KV is ignored entirely — forks stay safe with zero config.
+With `NPC_LIVE_TOGGLE="true"`, the Worker reads `ai_enabled`, `ambient_enabled`, and
+`player_chat_enabled` (`"true"`/`"false"`) on every resident request. KV may turn an env-enabled feature off,
+but can never turn an env-disabled feature on. A missing binding or KV read failure disables all resident AI
+for that request.
+Cloudflare KV propagation can take up to about 60 seconds; use `NPC_AI_ENABLED=false` plus a Worker deploy for
+the account-level hard stop.
 
-### Deferred (documented, not shipped in v1)
+### Disable and rollback safely
 
-- **Durable budget store.** The day tally lives in Worker **module scope**, so it resets when the isolate
-  recycles — fine as a soft cost brake, but for strict multi-isolate enforcement bind a **D1 table** or a
-  **Durable Object** and swap `npcBudgetState` / `npcChargeTurn` to read/write it.
-- **Private `repolis-metrics` dashboard.** The Worker *emits* redacted metrics to `METRICS_URL` and, when
-  `NPC_LIVE_TOGGLE` is on, *reads* the on/off flags the dashboard writes to `NPC_FLAGS`. The dashboard itself
-  is a separate **private** repo (never part of this public town).
-- **Real Azure Foundry deployment names.** `NPC_MODEL_*` are config-only; with none set the adapter falls
-  back to `gpt-5.4-mini`.
+1. Set all three dashboard KV flags to `"false"` (if live toggles are enabled).
+2. Set `NPC_AI_ENABLED=false` in the Worker environment and deploy. Confirm `npcConfig.config.aiEnabled=false`
+   and read `npcBudget`; neither action calls a model.
+3. Roll back application code only while the env ceiling remains false. Do **not** remove the binding or add a
+   destructive Durable Object deletion migration during an incident; the persisted ledger can remain unused.
+4. Re-enable only after the pricing table, cap, migration, and read-only `npcBudget` response are verified.
 
-Local `.dev.vars` to try a real turn:
+The binding and `new_sqlite_classes = ["NpcBudgetGovernor"]` migration in `wrangler.toml` create the namespace
+on first deploy. Validate packaging without publishing by running `npx wrangler deploy --dry-run --outdir
+/tmp/repolis-taxi-dry-run`. Template forks and the public site still require no backend: without a configured
+grounded service, the browser never contacts this Worker and residents remain scripted.
 
-```
+Local `.dev.vars` for a bounded real-turn test:
+
+```text
 NPC_AI_ENABLED=true
 NPC_AMBIENT_ENABLED=true
 NPC_PLAYER_CHAT_ENABLED=true
 NPC_DAY_CAP_USD=1
-# reuses AOAI_ENDPOINT + AAD_* from the scholar-chat block above
+# Reuses AOAI_ENDPOINT + AAD_* from the scholar-chat block above.
+# Keep NPC_MODEL_PRICING_JSON aligned if NPC_MODEL_DEFAULT is a custom deployment alias.
 ```

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -45,6 +45,13 @@ import CouncilGuards from "../../council/guards.js";
 import CouncilLive from "../../council/live.js";
 import CouncilFixtures from "../../council/fixtures.js";
 import COUNCIL_CFG from "../../council/council.config.json";
+import {
+  NpcBudgetGovernor,
+  npcBudgetStatus,
+  runBudgetedNpcCall,
+} from "./npc-budget-governor.js";
+
+export { NpcBudgetGovernor };
 
 // --- Direct-MCP fallback for scholar NPCs. Used ONLY when the scholar's Azure Knowledge
 // Base is unreachable/unconfigured (clone-friendly, keyless). Normally scholars go through
@@ -871,7 +878,7 @@ function isNotFound(a) {
 
 // Entra ID service-principal token (client-credentials), cached until ~1 min before expiry.
 let _aad = { token: "", exp: 0 };
-async function aadToken(env) {
+async function aadToken(env, signal) {
   const now = Date.now();
   if (_aad.token && now < _aad.exp - 60000) return _aad.token;
   const body = new URLSearchParams({
@@ -882,6 +889,7 @@ async function aadToken(env) {
   });
   const r = await fetch(`https://login.microsoftonline.com/${env.AAD_TENANT}/oauth2/v2.0/token`, {
     method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body,
+    signal,
   });
   if (!r.ok) throw new Error("aad token " + r.status);
   const j = await r.json();
@@ -1203,9 +1211,9 @@ async function councilStreamHandler(body, request, env) {
 /* ============================ 🧑‍🌾 Resident NPC social layer (additive; existing behavior untouched) ============================
    Townspeople actions dispatched via body.npc_action: npcConfig | npcBudget | npcAmbientTurn | npcPlayerChat.
    Namespace is NPC_* (fully separate from COUNCIL_*). Hard ceiling: NPC_AI_ENABLED !== "true" → never a model call,
-   always { fallback:true } so the client uses its own free scripted bank. Over the daily cap → { ok:false,
-   reason:"npc_budget_exhausted" }. The budget ledger below is a module-scope best-effort tally (resets when the
-   Worker isolate recycles) — a durable D1/Durable-Object store is the documented deferred upgrade for real enforcement. */
+   always { fallback:true } so the client uses its own free scripted bank. A single canonical Durable Object atomically
+   reserves the maximum possible turn cost before a provider call and settles actual usage afterward. Any governor,
+   pricing, provider, timeout, or settlement failure stays fail-closed on the scripted path. */
 
 // Short server-side persona summaries for the 9 residents (canonical source is the RESIDENTS registry in index.html).
 const NPC_PERSONAS = {
@@ -1270,31 +1278,6 @@ function npcPlayerUser(body, lang) {
 }
 function capLine(s, max = 180) { return String(s || "").replace(/\s+/g, " ").trim().slice(0, max); }
 
-// --- NPC budget: UTC-day module-scope ledger (best-effort; deferred: D1/DO for durable multi-isolate enforcement) ---
-let _npcLedger = { day: "", spentUsd: 0, turns: 0 };
-function _utcDay() { return new Date().toISOString().slice(0, 10); }
-function npcBudgetState(env) {
-  const day = _utcDay();
-  if (_npcLedger.day !== day) _npcLedger = { day, spentUsd: 0, turns: 0 };
-  const dayCapUsd = Number(env.NPC_DAY_CAP_USD || 10);
-  const dailyTurnMax = Number(env.NPC_DAILY_TURN_MAX || 0);
-  const remainingUsd = Math.max(0, dayCapUsd - _npcLedger.spentUsd);
-  const blocked = remainingUsd <= 0 || (dailyTurnMax > 0 && _npcLedger.turns >= dailyTurnMax);
-  return {
-    enabled: env.NPC_AI_ENABLED === "true", source: "module", day, dayCapUsd,
-    spentUsd: +_npcLedger.spentUsd.toFixed(4), remainingUsd: +remainingUsd.toFixed(4),
-    turnsToday: _npcLedger.turns, dailyTurnMax, blocked,
-  };
-}
-function npcChargeTurn(env, usd) {
-  const day = _utcDay();
-  if (_npcLedger.day !== day) _npcLedger = { day, spentUsd: 0, turns: 0 };
-  _npcLedger.spentUsd += (Number(usd) || 0); _npcLedger.turns += 1;
-}
-function npcDeployment(env, role) {
-  return (role === "ambient" && env.NPC_MODEL_AMBIENT) || (role === "player" && env.NPC_MODEL_PLAYER)
-    || env.NPC_MODEL_DEFAULT || "gpt-5.4-mini";
-}
 function normalizeModelUsage(usage) {
   const u = usage && typeof usage === "object" ? usage : {};
   const details = u.prompt_tokens_details || u.input_tokens_details || {};
@@ -1305,16 +1288,13 @@ function normalizeModelUsage(usage) {
   };
 }
 function modelCostUsd(env, usage) {
-  if (!usage) return Number(env.NPC_TURN_COST_USD || 0.0003);
+  if (!usage) return 0;
   const u = normalizeModelUsage(usage);
   const input = Math.max(0, u.prompt_tokens - u.cached_tokens);
   const priceIn = Number(env.MODEL_PRICE_IN_PER_1M_USD || 0.75);
   const priceCached = Number(env.MODEL_PRICE_CACHED_IN_PER_1M_USD || 0.075);
   const priceOut = Number(env.MODEL_PRICE_OUT_PER_1M_USD || 4.5);
   return input / 1000000 * priceIn + u.cached_tokens / 1000000 * priceCached + u.completion_tokens / 1000000 * priceOut;
-}
-function npcCostUsd(env, usage) {
-  return modelCostUsd(env, usage);
 }
 // Fire-and-forget metrics to a private collector; text is redacted to lengths only (public-safe).
 function npcRedact(m) {
@@ -1385,9 +1365,6 @@ function marketNotice(answer, lang) {
     : "Public market information only, not investment advice. Recheck the live price with your exchange or broker before trading.";
   return text.includes(notice) ? text : `${text}\n\n${notice}`;
 }
-function personaRoute(role) {
-  return role === "ambient" ? "persona_ambient" : "persona_visitor";
-}
 function emitProviderUsage(env, ctx, route, ks, npc, activity, base) {
   if (!activity || !activity.usage) return;
   const u = normalizeModelUsage(activity.usage);
@@ -1424,30 +1401,44 @@ function emitKbQuery(env, ctx, route, cfg, npc, out, base) {
     ...base,
   }, ctx);
 }
-// Provider adapter. Hard ceiling: with the effective aiEnabled false this returns null WITHOUT calling any model.
-async function npcModelCall(env, role, sys, userMsg, aiEnabled) {
-  if (!aiEnabled) return null;
-  if (!env.AAD_CLIENT_ID || !env.AAD_CLIENT_SECRET || !env.AAD_TENANT || !env.AOAI_ENDPOINT) return null;
+// Provider adapter. A caller must hold a Durable Object reservation; aiEnabled is a second hard ceiling.
+async function npcModelCall(env, role, plan, aiEnabled) {
+  if (!aiEnabled) return { ok: false, reason: "npc_ai_disabled" };
+  if (!env.AAD_CLIENT_ID || !env.AAD_CLIENT_SECRET || !env.AAD_TENANT || !env.AOAI_ENDPOINT) {
+    return { ok: false, reason: "provider_unconfigured" };
+  }
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), Number(env.NPC_TIMEOUT_MS || 12000));
   const started = Date.now();
+  let modelDispatched = false;
   try {
-    const token = await aadToken(env);
-    const dep = npcDeployment(env, role);
+    const token = await aadToken(env, ctrl.signal);
     const ver = env.AOAI_API_VERSION || "2025-04-01-preview";
-    const url = `${env.AOAI_ENDPOINT.replace(/\/$/, "")}/openai/deployments/${dep}/chat/completions?api-version=${ver}`;
-    const r = await fetch(url, {
+    const url = `${env.AOAI_ENDPOINT.replace(/\/$/, "")}/openai/deployments/${plan.deployment}/chat/completions?api-version=${ver}`;
+    const modelRequest = fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: "Bearer " + token },
-      body: JSON.stringify({ messages: [{ role: "system", content: sys }, { role: "user", content: String(userMsg).slice(0, role === "player" ? 1500 : 600) }], max_completion_tokens: 120 }),
+      body: JSON.stringify({ messages: plan.messages, max_completion_tokens: plan.maxOutputTokens }),
       signal: ctrl.signal,
     });
-    clearTimeout(timer);
-    if (!r.ok) return null;
+    modelDispatched = true;
+    const r = await modelRequest;
+    if (!r.ok) return { ok: false, billable: true, reason: "provider_http_error", ms: Date.now() - started };
     const j = await r.json();
     const txt = j.choices?.[0]?.message?.content;
-    return txt && txt.trim() ? { text: txt.trim(), usage: j.usage || null, ms: Date.now() - started } : null;
-  } catch { clearTimeout(timer); return null; }
+    return txt && txt.trim()
+      ? { ok: true, text: txt.trim(), usage: j.usage || null, ms: Date.now() - started }
+      : { ok: false, billable: true, reason: "provider_empty_response", usage: j.usage || null, ms: Date.now() - started };
+  } catch (error) {
+    return {
+      ok: false,
+      billable: modelDispatched,
+      reason: error?.name === "AbortError" ? "provider_timeout" : "provider_error",
+      ms: Date.now() - started,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 // --- Live flag resolver. NPC_LIVE_TOGGLE is the master kill-switch. When it is NOT "true",
 //     behaviour is exactly the env-gated default (KV ignored) — the safe, deploy-only posture.
@@ -1458,9 +1449,12 @@ async function npcResolveFlags(env) {
   const envAi = env.NPC_AI_ENABLED === "true";
   const envAmb = env.NPC_AMBIENT_ENABLED === "true";
   const envPc = env.NPC_PLAYER_CHAT_ENABLED === "true";
-  const liveReady = env.NPC_LIVE_TOGGLE === "true" && env.NPC_FLAGS && typeof env.NPC_FLAGS.get === "function";
-  if (!liveReady) {
+  const liveToggle = env.NPC_LIVE_TOGGLE === "true";
+  if (!liveToggle) {
     return { aiEnabled: envAi, ambientEnabled: envAi && envAmb, playerChatEnabled: envAi && envPc, source: "env", liveToggle: false };
+  }
+  if (!env.NPC_FLAGS || typeof env.NPC_FLAGS.get !== "function") {
+    return { aiEnabled: false, ambientEnabled: false, playerChatEnabled: false, source: "kv-unavailable", liveToggle: true };
   }
   let kAi = null, kAmb = null, kPc = null;
   try {
@@ -1469,13 +1463,15 @@ async function npcResolveFlags(env) {
       env.NPC_FLAGS.get("ambient_enabled"),
       env.NPC_FLAGS.get("player_chat_enabled"),
     ]);
-  } catch { /* KV read failure → fall back to env per key below */ }
-  const pick = (kv, envVal) => (kv === "true" ? true : kv === "false" ? false : envVal);
-  const ai = pick(kAi, envAi);
+  } catch {
+    return { aiEnabled: false, ambientEnabled: false, playerChatEnabled: false, source: "kv-unavailable", liveToggle: true };
+  }
+  const allows = (kv) => kv !== "false";
+  const ai = envAi && allows(kAi);
   return {
     aiEnabled: ai,
-    ambientEnabled: ai && pick(kAmb, envAmb),
-    playerChatEnabled: ai && pick(kPc, envPc),
+    ambientEnabled: ai && envAmb && allows(kAmb),
+    playerChatEnabled: ai && envPc && allows(kPc),
     source: "kv", liveToggle: true,
   };
 }
@@ -1486,55 +1482,64 @@ async function npcHandler(body, request, env, ctx) {
   const aiEnabled = flags.aiEnabled;
   const ambientOn = flags.ambientEnabled;
   const playerOn = flags.playerChatEnabled;
+  const emitBudgetMetric = (name, meta) => npcMetric(env, name, meta, ctx);
 
   if (action === "npcConfig") {
+    const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
+    const budgetReady = budget.available === true;
     return json({ ok: true, config: {
-      aiEnabled, ambientEnabled: ambientOn, playerChatEnabled: playerOn,
+      aiEnabled: aiEnabled && budgetReady,
+      ambientEnabled: ambientOn && budgetReady,
+      playerChatEnabled: playerOn && budgetReady,
       maxTurns: Number(env.NPC_MAX_TURNS || 6), hardMaxTurns: Number(env.NPC_HARD_MAX_TURNS || 10),
-      source: flags.source, liveToggle: flags.liveToggle,
-    }, budget: npcBudgetState(env) }, 200, env);
+      source: "durable-object", flagSource: flags.source, liveToggle: flags.liveToggle,
+    }, budget }, 200, env);
   }
-  if (action === "npcBudget") return json({ ok: true, budget: npcBudgetState(env) }, 200, env);
+  if (action === "npcBudget") {
+    return json({ ok: true, budget: await npcBudgetStatus(env, aiEnabled, emitBudgetMetric) }, 200, env);
+  }
 
   if (action === "npcAmbientTurn" || action === "npcPlayerChat") {
     const role = action === "npcAmbientTurn" ? "ambient" : "player";
     const featureOn = role === "ambient" ? ambientOn : playerOn;
-    const budget = npcBudgetState(env);
-    // Env-off ceiling → never a model call; client falls back to its free scripted bank.
-    const requestMeta = metricContext(body, request);
     if (String(body.speaker || "").toLowerCase() === "auri") {
-      npcMetric(env, "npc_fallback_used", { where: role, route: "grounded_kb_market", reason: "market_oracle_requires_grounding", ...requestMeta }, ctx);
+      const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
       return json({ ok: true, fallback: true, reason: "market_oracle_requires_grounding", budget }, 200, env);
     }
-    if (!featureOn) { npcMetric(env, "npc_fallback_used", { where: role, route: personaRoute(role), reason: "disabled", ...requestMeta }, ctx); return json({ ok: true, fallback: true, reason: "npc_ai_disabled", budget }, 200, env); }
-    if (budget.blocked) { npcMetric(env, "npc_budget_blocked", { where: role, route: personaRoute(role), reason: "npc_budget_exhausted", ...requestMeta }, ctx); return json({ ok: false, fallback: true, reason: "npc_budget_exhausted", budget }, 200, env); }
+    if (!featureOn) {
+      const budget = await npcBudgetStatus(env, false, emitBudgetMetric);
+      return json({ ok: true, fallback: true, reason: "npc_ai_disabled", budget }, 200, env);
+    }
     const sys = role === "ambient" ? npcAmbientPrompt(body.speaker, body.listener, body.topic, lang) : npcPlayerPrompt(body.speaker, lang, { chime: !!body.chime, prev: body.prev });
     const userMsg = role === "ambient" ? npcAmbientUser(body, lang) : npcPlayerUser(body, lang);
-    const out = await npcModelCall(env, role, sys, userMsg, aiEnabled);
-    if (!out) { npcMetric(env, "npc_fallback_used", { where: role, route: personaRoute(role), reason: "model_unavailable", ...requestMeta }, ctx); return json({ ok: true, fallback: true, reason: "model_unavailable", budget }, 200, env); }
-    const cost = npcCostUsd(env, out.usage);
-    npcChargeTurn(env, cost);
-    const budget2 = npcBudgetState(env);
-    const usage = normalizeModelUsage(out.usage);
-    npcMetric(env, role === "ambient" ? "npc_ambient_turn" : "npc_player_chat", {
-      where: role,
-      route: personaRoute(role),
-      phase: "persona",
-      npc: String(body.speaker || "resident"),
-      model: npcDeployment(env, role),
-      providerCall: true,
-      answer: true,
+    const messages = [
+      { role: "system", content: sys },
+      { role: "user", content: String(userMsg).slice(0, role === "player" ? 1500 : 600) },
+    ];
+    const turn = await runBudgetedNpcCall({
+      env,
+      role,
+      messages,
+      enabled: aiEnabled,
+      emit: emitBudgetMetric,
+      providerCall: (plan) => npcModelCall(env, role, plan, aiEnabled),
+    });
+    if (!turn.ok) {
+      const exhausted = ["day_cap_zero", "day_cap_exhausted", "daily_turn_max", "daily_attempt_max"].includes(turn.reason);
+      return json({
+        ok: !exhausted,
+        fallback: true,
+        reason: exhausted ? "npc_budget_exhausted" : turn.reason,
+        budget: turn.budget,
+      }, 200, env);
+    }
+    return json({
       ok: true,
-      ai: true,
-      line: out.text,
-      ms: out.ms,
-      tokensIn: usage.prompt_tokens,
-      cachedTokens: usage.cached_tokens,
-      tokensOut: usage.completion_tokens,
-      costUsd: cost,
-      ...requestMeta,
-    }, ctx);
-    return json({ ok: true, line: capLine(out.text, role === "ambient" ? 90 : 180), usage, model: npcDeployment(env, role), budget: budget2 }, 200, env);
+      line: capLine(turn.value.text, role === "ambient" ? 90 : 180),
+      usage: turn.usage,
+      model: turn.model,
+      budget: turn.budget,
+    }, 200, env);
   }
   return json({ error: "unknown npc_action" }, 400, env);
 }

--- a/cloudflare-taxi/src/npc-budget-governor.js
+++ b/cloudflare-taxi/src/npc-budget-governor.js
@@ -1,0 +1,1002 @@
+const NPC_BUDGET_SOURCE = "durable-object";
+const NPC_BUDGET_OBJECT_NAME = "npc-budget-canonical-v1";
+const NPC_LEDGER_KEY = "ledger";
+const NPC_ARCHIVED_LEDGER_PREFIX = "ledger:";
+const NPC_RESERVATION_PREFIX = "reservation:";
+const NPC_USD_SCALE = 1_000_000_000;
+const NPC_INPUT_OVERHEAD_TOKENS = 512;
+const NPC_DEFAULT_MAX_COMPLETION_TOKENS = 120;
+const NPC_DEFAULT_PRICING = Object.freeze({
+  "gpt-5.4-mini": Object.freeze({
+    inputPer1MUsd: 0.75,
+    cachedInputPer1MUsd: 0.075,
+    outputPer1MUsd: 4.5,
+    maxInputTokens: 272_000,
+    maxOutputTokens: 128_000,
+  }),
+});
+
+function internalJson(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+function utcDay(nowMs = Date.now()) {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+function workerUtcDay(env) {
+  return utcDay(typeof env?.__npcBudgetNow === "function" ? env.__npcBudgetNow() : Date.now());
+}
+
+function isSafeNonNegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function parseNonNegativeInteger(value, fallback) {
+  const parsed = value === undefined || value === null || value === "" ? fallback : Number(value);
+  return isSafeNonNegativeInteger(parsed) ? parsed : null;
+}
+
+function usdToNanos(value, fallback) {
+  const parsed = value === undefined || value === null || value === "" ? fallback : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  const scaled = parsed * NPC_USD_SCALE;
+  if (!Number.isSafeInteger(Math.floor(scaled))) return null;
+  return Math.floor(scaled);
+}
+
+function nanosToUsd(value) {
+  return Number((value / NPC_USD_SCALE).toFixed(9));
+}
+
+function validLedger(ledger) {
+  return !!ledger
+    && /^\d{4}-\d{2}-\d{2}$/.test(String(ledger.day || ""))
+    && isSafeNonNegativeInteger(ledger.capNanos)
+    && isSafeNonNegativeInteger(ledger.dailyTurnMax)
+    && isSafeNonNegativeInteger(ledger.dailyAttemptMax)
+    && ledger.dailyAttemptMax > 0
+    && isSafeNonNegativeInteger(ledger.spentNanos)
+    && isSafeNonNegativeInteger(ledger.reservedNanos)
+    && isSafeNonNegativeInteger(ledger.turns)
+    && isSafeNonNegativeInteger(ledger.reservedTurns)
+    && isSafeNonNegativeInteger(ledger.attempts);
+}
+
+function freshLedger(day, capNanos, dailyTurnMax, dailyAttemptMax) {
+  return {
+    day,
+    capNanos,
+    dailyTurnMax,
+    dailyAttemptMax,
+    spentNanos: 0,
+    reservedNanos: 0,
+    turns: 0,
+    reservedTurns: 0,
+    attempts: 0,
+  };
+}
+
+function tighterTurnMax(current, incoming) {
+  if (current === 0) return incoming;
+  if (incoming === 0) return current;
+  return Math.min(current, incoming);
+}
+
+function tightenPolicy(ledger, capNanos, dailyTurnMax, dailyAttemptMax) {
+  const nextCap = Math.min(ledger.capNanos, capNanos);
+  const nextTurnMax = tighterTurnMax(ledger.dailyTurnMax, dailyTurnMax);
+  const nextAttemptMax = Math.min(ledger.dailyAttemptMax, dailyAttemptMax);
+  const changed = nextCap !== ledger.capNanos
+    || nextTurnMax !== ledger.dailyTurnMax
+    || nextAttemptMax !== ledger.dailyAttemptMax;
+  if (changed) {
+    ledger.capNanos = nextCap;
+    ledger.dailyTurnMax = nextTurnMax;
+    ledger.dailyAttemptMax = nextAttemptMax;
+  }
+  return changed;
+}
+
+function budgetPolicy(env) {
+  const capNanos = usdToNanos(env?.NPC_DAY_CAP_USD, 10);
+  const dailyTurnMax = parseNonNegativeInteger(env?.NPC_DAILY_TURN_MAX, 0);
+  const dailyAttemptMax = parseNonNegativeInteger(env?.NPC_DAILY_ATTEMPT_MAX, 5000);
+  const providerTimeoutMs = parseNonNegativeInteger(env?.NPC_TIMEOUT_MS, 12_000);
+  const governorTimeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 1500);
+  const hasConfiguredLease = env?.NPC_RESERVATION_LEASE_MS !== undefined
+    && env?.NPC_RESERVATION_LEASE_MS !== null
+    && env?.NPC_RESERVATION_LEASE_MS !== "";
+  const configuredLeaseMs = hasConfiguredLease
+    ? parseNonNegativeInteger(env.NPC_RESERVATION_LEASE_MS, null)
+    : null;
+  const minimumLeaseMs = providerTimeoutMs === null || governorTimeoutMs === null
+    ? null
+    : providerTimeoutMs + governorTimeoutMs * 2 + 10_000;
+  const reservationLeaseMs = hasConfiguredLease
+    ? configuredLeaseMs
+    : Math.max(60_000, minimumLeaseMs || 0);
+  if (capNanos === null || dailyTurnMax === null
+    || dailyAttemptMax === null || dailyAttemptMax < 1
+    || providerTimeoutMs === null || providerTimeoutMs < 100 || providerTimeoutMs > 120_000
+    || governorTimeoutMs === null || governorTimeoutMs < 100 || governorTimeoutMs > 10_000
+    || reservationLeaseMs === null || reservationLeaseMs < minimumLeaseMs
+    || reservationLeaseMs > 300_000) {
+    return { ok: false, reason: "npc_budget_config_invalid" };
+  }
+  return {
+    ok: true,
+    capNanos,
+    dailyTurnMax,
+    dailyAttemptMax,
+    reservationLeaseMs,
+  };
+}
+
+function validPolicyPayload(body) {
+  return isSafeNonNegativeInteger(body?.capNanos)
+    && isSafeNonNegativeInteger(body?.dailyTurnMax)
+    && isSafeNonNegativeInteger(body?.dailyAttemptMax)
+    && body.dailyAttemptMax > 0
+    && isSafeNonNegativeInteger(body?.reservationLeaseMs)
+    && body.reservationLeaseMs > 0;
+}
+
+function publicBudget(ledger) {
+  const { capNanos, dailyTurnMax } = ledger;
+  const committedNanos = ledger.spentNanos + ledger.reservedNanos;
+  const remainingNanos = Math.max(0, capNanos - committedNanos);
+  const turnBlocked = dailyTurnMax > 0 && ledger.turns + ledger.reservedTurns >= dailyTurnMax;
+  const attemptBlocked = ledger.attempts >= ledger.dailyAttemptMax;
+  return {
+    available: true,
+    source: NPC_BUDGET_SOURCE,
+    day: ledger.day,
+    dayCapUsd: nanosToUsd(capNanos),
+    spentUsd: nanosToUsd(ledger.spentNanos),
+    reservedUsd: nanosToUsd(ledger.reservedNanos),
+    remainingUsd: nanosToUsd(remainingNanos),
+    turnsToday: ledger.turns,
+    reservedTurns: ledger.reservedTurns,
+    dailyTurnMax,
+    attemptsToday: ledger.attempts,
+    dailyAttemptMax: ledger.dailyAttemptMax,
+    blocked: capNanos === 0 || committedNanos >= capNanos || turnBlocked || attemptBlocked,
+  };
+}
+
+function unavailableBudget(reason, policy) {
+  return {
+    available: false,
+    enabled: false,
+    source: NPC_BUDGET_SOURCE,
+    day: null,
+    dayCapUsd: policy?.ok ? nanosToUsd(policy.capNanos) : null,
+    spentUsd: null,
+    reservedUsd: null,
+    remainingUsd: null,
+    turnsToday: null,
+    reservedTurns: null,
+    dailyTurnMax: policy?.ok ? policy.dailyTurnMax : null,
+    attemptsToday: null,
+    dailyAttemptMax: policy?.ok ? policy.dailyAttemptMax : null,
+    blocked: true,
+    reason,
+  };
+}
+
+function reservationKey(reservationId) {
+  return NPC_RESERVATION_PREFIX + reservationId;
+}
+
+function archivedLedgerKey(day) {
+  return NPC_ARCHIVED_LEDGER_PREFIX + day;
+}
+
+function validReservationId(value) {
+  return /^[a-f0-9-]{16,64}$/i.test(String(value || ""));
+}
+
+function validReservationRecord(record) {
+  if (!record || !/^\d{4}-\d{2}-\d{2}$/.test(String(record.day || ""))) return false;
+  if (record.status === "pending") {
+    return isSafeNonNegativeInteger(record.amountNanos) && record.amountNanos > 0
+      && isSafeNonNegativeInteger(record.expiresAtMs) && record.expiresAtMs > 0;
+  }
+  if (record.status === "settled") {
+    return isSafeNonNegativeInteger(record.chargedNanos);
+  }
+  return record.status === "released";
+}
+
+function operationMeta(result, extra = {}) {
+  const budget = result?.budget;
+  return {
+    source: NPC_BUDGET_SOURCE,
+    ...extra,
+    ...(budget?.day ? {
+      day: budget.day,
+      spentUsd: budget.spentUsd,
+      reservedUsd: budget.reservedUsd,
+      remainingUsd: budget.remainingUsd,
+      turnsToday: budget.turnsToday,
+      reservedTurns: budget.reservedTurns,
+      dailyTurnMax: budget.dailyTurnMax,
+      attemptsToday: budget.attemptsToday,
+      dailyAttemptMax: budget.dailyAttemptMax,
+    } : {}),
+  };
+}
+
+function emitReset(emit, result) {
+  if (result?.reset) emit?.("npc_budget_utc_reset", operationMeta(result));
+}
+
+export class NpcBudgetGovernor {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  now() {
+    return typeof this.env?.__npcBudgetNow === "function"
+      ? this.env.__npcBudgetNow()
+      : Date.now();
+  }
+
+  async cleanupFinalized(day, retainDay) {
+    const records = await this.state.storage.list({ prefix: NPC_RESERVATION_PREFIX });
+    const pendingDays = new Set();
+    const deleteKeys = [];
+    for (const [key, record] of records) {
+      if (!validReservationRecord(record)) throw new Error("npc_budget_corrupt");
+      if (record.status === "pending") pendingDays.add(record.day);
+      else if (record.day !== day && record.day !== retainDay) deleteKeys.push(key);
+    }
+    const archived = await this.state.storage.list({ prefix: NPC_ARCHIVED_LEDGER_PREFIX });
+    for (const [key, ledger] of archived) {
+      if (!validLedger(ledger)) throw new Error("npc_budget_corrupt");
+      if (!pendingDays.has(ledger.day)) deleteKeys.push(key);
+    }
+    for (let index = 0; index < deleteKeys.length; index += 128) {
+      await this.state.storage.delete(deleteKeys.slice(index, index + 128));
+    }
+  }
+
+  async loadLedger(capNanos, dailyTurnMax, dailyAttemptMax) {
+    const day = utcDay(this.now());
+    const stored = await this.state.storage.get(NPC_LEDGER_KEY);
+    if (!stored) {
+      const ledger = freshLedger(day, capNanos, dailyTurnMax, dailyAttemptMax);
+      await this.state.storage.put(NPC_LEDGER_KEY, ledger);
+      return { ledger, reset: false };
+    }
+    if (!validLedger(stored)) throw new Error("npc_budget_corrupt");
+    if (stored.day === day) {
+      if (tightenPolicy(stored, capNanos, dailyTurnMax, dailyAttemptMax)) {
+        await this.state.storage.put(NPC_LEDGER_KEY, stored);
+      }
+      return { ledger: stored, reset: false };
+    }
+
+    const ledger = freshLedger(day, capNanos, dailyTurnMax, dailyAttemptMax);
+    await this.state.storage.put({
+      [archivedLedgerKey(stored.day)]: stored,
+      [NPC_LEDGER_KEY]: ledger,
+    });
+    await this.cleanupFinalized(day, stored.day);
+    return { ledger, reset: true };
+  }
+
+  async reservationLedger(record, currentLedger) {
+    if (record.day === currentLedger.day) {
+      return { ledger: currentLedger, key: NPC_LEDGER_KEY };
+    }
+    const key = archivedLedgerKey(record.day);
+    const ledger = await this.state.storage.get(key);
+    if (!validLedger(ledger)) throw new Error("npc_budget_corrupt");
+    return { ledger, key };
+  }
+
+  async scheduleAlarm(expiresAtMs) {
+    const current = await this.state.storage.getAlarm();
+    if (current === null || expiresAtMs < current) {
+      await this.state.storage.setAlarm(expiresAtMs);
+    }
+  }
+
+  async reconcileExpiredReservations() {
+    const nowMs = this.now();
+    const currentLedger = await this.state.storage.get(NPC_LEDGER_KEY);
+    if (!currentLedger) return;
+    if (!validLedger(currentLedger)) throw new Error("npc_budget_corrupt");
+    const records = await this.state.storage.list({ prefix: NPC_RESERVATION_PREFIX });
+    let processed = 0;
+    let nextAlarm = null;
+    for (const [key, record] of records) {
+      if (!validReservationRecord(record)) throw new Error("npc_budget_corrupt");
+      if (record.status !== "pending") continue;
+      if (record.expiresAtMs > nowMs) {
+        nextAlarm = nextAlarm === null ? record.expiresAtMs : Math.min(nextAlarm, record.expiresAtMs);
+        continue;
+      }
+      if (processed >= 64) {
+        nextAlarm = nowMs + 1000;
+        continue;
+      }
+      const target = await this.reservationLedger(record, currentLedger);
+      if (target.ledger.reservedNanos < record.amountNanos || target.ledger.reservedTurns < 1) {
+        throw new Error("npc_budget_corrupt");
+      }
+      target.ledger.reservedNanos -= record.amountNanos;
+      target.ledger.reservedTurns -= 1;
+      target.ledger.spentNanos += record.amountNanos;
+      target.ledger.turns += 1;
+      await this.state.storage.put({
+        [target.key]: target.ledger,
+        [key]: {
+          day: record.day,
+          status: "settled",
+          chargedNanos: record.amountNanos,
+          bounded: true,
+          expired: true,
+        },
+      });
+      processed += 1;
+    }
+    if (nextAlarm !== null) await this.state.storage.setAlarm(nextAlarm);
+  }
+
+  async handle(request) {
+    if (request.method !== "POST") return internalJson({ ok: false, reason: "POST only" }, 405);
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return internalJson({ ok: false, reason: "bad body" }, 400);
+    }
+    if (!validPolicyPayload(body)) {
+      return internalJson({ ok: false, reason: "invalid_policy" }, 400);
+    }
+
+    const loaded = await this.loadLedger(body.capNanos, body.dailyTurnMax, body.dailyAttemptMax);
+    const currentBudget = () => publicBudget(loaded.ledger);
+    if (body.op === "status") {
+      return internalJson({ ok: true, reset: loaded.reset, budget: currentBudget() });
+    }
+
+    if (!validReservationId(body.reservationId)) {
+      return internalJson({ ok: false, reset: loaded.reset, reason: "invalid_reservation", budget: currentBudget() }, 400);
+    }
+    const key = reservationKey(body.reservationId);
+    const record = await this.state.storage.get(key);
+    if (record && !validReservationRecord(record)) throw new Error("npc_budget_corrupt");
+
+    if (body.op === "reserve") {
+      if (!isSafeNonNegativeInteger(body.amountNanos) || body.amountNanos <= 0) {
+        return internalJson({ ok: false, reset: loaded.reset, accepted: false, reason: "unsafe_cost_bound", budget: currentBudget() }, 400);
+      }
+      if (record) {
+        if (record.status === "pending" && record.day !== loaded.ledger.day) {
+          const target = await this.reservationLedger(record, loaded.ledger);
+          if (target.ledger.reservedNanos < record.amountNanos || target.ledger.reservedTurns < 1) {
+            throw new Error("npc_budget_corrupt");
+          }
+          target.ledger.reservedNanos -= record.amountNanos;
+          target.ledger.reservedTurns -= 1;
+          await this.state.storage.put({
+            [target.key]: target.ledger,
+            [key]: { day: record.day, status: "released" },
+          });
+          await this.state.storage.delete(key);
+          return internalJson({
+            ok: true,
+            reset: loaded.reset,
+            accepted: false,
+            idempotent: true,
+            reason: "reservation_expired",
+            budget: currentBudget(),
+          });
+        }
+        const accepted = record.day === loaded.ledger.day
+          && record.status === "pending"
+          && record.amountNanos === body.amountNanos;
+        if (accepted) await this.scheduleAlarm(record.expiresAtMs);
+        return internalJson({
+          ok: true,
+          reset: loaded.reset,
+          accepted,
+          idempotent: true,
+          reason: accepted ? null
+            : record.status === "pending" ? "reservation_mismatch" : "reservation_finalized",
+          budget: currentBudget(),
+        });
+      }
+      const committedNanos = loaded.ledger.spentNanos + loaded.ledger.reservedNanos;
+      if (loaded.ledger.capNanos === 0) {
+        return internalJson({ ok: true, reset: loaded.reset, accepted: false, reason: "day_cap_zero", budget: currentBudget() });
+      }
+      if (body.amountNanos > loaded.ledger.capNanos - Math.min(loaded.ledger.capNanos, committedNanos)) {
+        return internalJson({ ok: true, reset: loaded.reset, accepted: false, reason: "day_cap_exhausted", budget: currentBudget() });
+      }
+      if (loaded.ledger.dailyTurnMax > 0
+        && loaded.ledger.turns + loaded.ledger.reservedTurns >= loaded.ledger.dailyTurnMax) {
+        return internalJson({ ok: true, reset: loaded.reset, accepted: false, reason: "daily_turn_max", budget: currentBudget() });
+      }
+      if (loaded.ledger.attempts >= loaded.ledger.dailyAttemptMax) {
+        return internalJson({ ok: true, reset: loaded.reset, accepted: false, reason: "daily_attempt_max", budget: currentBudget() });
+      }
+
+      const expiresAtMs = this.now() + body.reservationLeaseMs;
+      if (!Number.isSafeInteger(expiresAtMs)) {
+        return internalJson({ ok: false, reset: loaded.reset, accepted: false, reason: "invalid_reservation_lease", budget: currentBudget() }, 400);
+      }
+      loaded.ledger.reservedNanos += body.amountNanos;
+      loaded.ledger.reservedTurns += 1;
+      loaded.ledger.attempts += 1;
+      await this.state.storage.put({
+        [NPC_LEDGER_KEY]: loaded.ledger,
+        [key]: {
+          day: loaded.ledger.day,
+          status: "pending",
+          amountNanos: body.amountNanos,
+          expiresAtMs,
+        },
+      });
+      await this.scheduleAlarm(expiresAtMs);
+      return internalJson({ ok: true, reset: loaded.reset, accepted: true, budget: currentBudget() });
+    }
+
+    if (body.op === "settle") {
+      if (!record) {
+        return internalJson({ ok: false, reset: loaded.reset, reason: "unknown_reservation", budget: currentBudget() }, 409);
+      }
+      if (record.status === "settled") {
+        return internalJson({
+          ok: true,
+          reset: loaded.reset,
+          idempotent: true,
+          settled: true,
+          chargedNanos: record.chargedNanos,
+          bounded: !!record.bounded,
+          budget: currentBudget(),
+        });
+      }
+      if (record.status !== "pending") {
+        return internalJson({ ok: false, reset: loaded.reset, reason: "reservation_released", budget: currentBudget() }, 409);
+      }
+      if (!isSafeNonNegativeInteger(body.actualNanos)) {
+        return internalJson({ ok: false, reset: loaded.reset, reason: "invalid_actual_cost", budget: currentBudget() }, 400);
+      }
+      const target = await this.reservationLedger(record, loaded.ledger);
+      if (target.ledger.reservedNanos < record.amountNanos || target.ledger.reservedTurns < 1) {
+        throw new Error("npc_budget_corrupt");
+      }
+
+      const chargedNanos = Math.min(body.actualNanos, record.amountNanos);
+      target.ledger.reservedNanos -= record.amountNanos;
+      target.ledger.reservedTurns -= 1;
+      target.ledger.spentNanos += chargedNanos;
+      target.ledger.turns += 1;
+      await this.state.storage.put({
+        [target.key]: target.ledger,
+        [key]: {
+          day: record.day,
+          status: "settled",
+          chargedNanos,
+          bounded: body.actualNanos > record.amountNanos,
+        },
+      });
+      return internalJson({
+        ok: true,
+        reset: loaded.reset,
+        settled: true,
+        bounded: body.actualNanos > record.amountNanos,
+        chargedNanos,
+        budget: currentBudget(),
+      });
+    }
+
+    if (body.op === "release") {
+      if (!record) {
+        return internalJson({ ok: true, reset: loaded.reset, idempotent: true, released: false, budget: currentBudget() });
+      }
+      if (record.status === "released") {
+        return internalJson({ ok: true, reset: loaded.reset, idempotent: true, released: true, budget: currentBudget() });
+      }
+      if (record.status !== "pending") {
+        return internalJson({ ok: false, reset: loaded.reset, reason: "reservation_settled", budget: currentBudget() }, 409);
+      }
+      const target = await this.reservationLedger(record, loaded.ledger);
+      if (target.ledger.reservedNanos < record.amountNanos || target.ledger.reservedTurns < 1) {
+        throw new Error("npc_budget_corrupt");
+      }
+
+      target.ledger.reservedNanos -= record.amountNanos;
+      target.ledger.reservedTurns -= 1;
+      await this.state.storage.put({
+        [target.key]: target.ledger,
+        [key]: { day: record.day, status: "released" },
+      });
+      await this.state.storage.delete(key);
+      return internalJson({ ok: true, reset: loaded.reset, released: true, budget: currentBudget() });
+    }
+
+    return internalJson({ ok: false, reset: loaded.reset, reason: "unknown_operation", budget: currentBudget() }, 400);
+  }
+
+  async fetch(request) {
+    const run = async () => {
+      try {
+        return await this.handle(request);
+      } catch (error) {
+        const reason = error?.message === "npc_budget_corrupt" ? "npc_budget_corrupt" : "npc_budget_storage_error";
+        return internalJson({ ok: false, reason }, 503);
+      }
+    };
+    return typeof this.state.blockConcurrencyWhile === "function"
+      ? this.state.blockConcurrencyWhile(run)
+      : run();
+  }
+
+  async alarm() {
+    const run = () => this.reconcileExpiredReservations();
+    return typeof this.state.blockConcurrencyWhile === "function"
+      ? this.state.blockConcurrencyWhile(run)
+      : run();
+  }
+}
+
+function npcDeployment(env, role) {
+  return (role === "ambient" && env.NPC_MODEL_AMBIENT)
+    || (role === "player" && env.NPC_MODEL_PLAYER)
+    || env.NPC_MODEL_DEFAULT
+    || "gpt-5.4-mini";
+}
+
+function parsePrice(value, allowZero) {
+  if (typeof value !== "number" || !Number.isFinite(value)
+    || value < 0 || (!allowZero && value === 0)) return null;
+  return value;
+}
+
+function modelPricing(env, deployment) {
+  let configured = {};
+  if (env?.NPC_MODEL_PRICING_JSON) {
+    try {
+      configured = JSON.parse(env.NPC_MODEL_PRICING_JSON);
+    } catch {
+      return { ok: false, reason: "npc_pricing_invalid" };
+    }
+    if (!configured || typeof configured !== "object" || Array.isArray(configured)) {
+      return { ok: false, reason: "npc_pricing_invalid" };
+    }
+  }
+  const entry = configured[deployment] || NPC_DEFAULT_PRICING[deployment];
+  if (!entry || typeof entry !== "object") {
+    return { ok: false, reason: "npc_pricing_unavailable" };
+  }
+  const inputPer1MUsd = parsePrice(entry.inputPer1MUsd, false);
+  const cachedInputPer1MUsd = parsePrice(entry.cachedInputPer1MUsd, true);
+  const outputPer1MUsd = parsePrice(entry.outputPer1MUsd, false);
+  const maxInputTokens = parseNonNegativeInteger(entry.maxInputTokens, null);
+  const maxOutputTokens = parseNonNegativeInteger(entry.maxOutputTokens, null);
+  if (inputPer1MUsd === null || cachedInputPer1MUsd === null || outputPer1MUsd === null) {
+    return { ok: false, reason: "npc_pricing_invalid" };
+  }
+  if (maxInputTokens === null || maxInputTokens < 1
+    || maxOutputTokens === null || maxOutputTokens < 1) {
+    return { ok: false, reason: "npc_model_bounds_invalid" };
+  }
+  return {
+    ok: true,
+    inputPer1MUsd,
+    cachedInputPer1MUsd,
+    outputPer1MUsd,
+    maxInputTokens,
+    maxOutputTokens,
+  };
+}
+
+function maxCostNanos(maxInputTokens, maxOutputTokens, pricing) {
+  const maxInputPrice = Math.max(pricing.inputPer1MUsd, pricing.cachedInputPer1MUsd);
+  const usd = maxInputTokens / 1_000_000 * maxInputPrice
+    + maxOutputTokens / 1_000_000 * pricing.outputPer1MUsd;
+  const nanos = Math.ceil(usd * NPC_USD_SCALE);
+  return Number.isSafeInteger(nanos) && nanos > 0 ? nanos : null;
+}
+
+export function createNpcCallPlan(env, role, messages) {
+  if (role !== "ambient" && role !== "player") {
+    return { ok: false, reason: "npc_role_invalid" };
+  }
+  if (!Array.isArray(messages) || messages.length !== 2) {
+    return { ok: false, reason: "npc_messages_invalid" };
+  }
+  const deployment = npcDeployment(env, role);
+  const pricing = modelPricing(env, deployment);
+  if (!pricing.ok) return pricing;
+  const maxOutputTokens = parseNonNegativeInteger(
+    env?.NPC_MAX_COMPLETION_TOKENS,
+    NPC_DEFAULT_MAX_COMPLETION_TOKENS,
+  );
+  if (maxOutputTokens === null || maxOutputTokens < 1 || maxOutputTokens > 4096) {
+    return { ok: false, reason: "npc_output_bound_invalid" };
+  }
+  const encodedBytes = new TextEncoder().encode(JSON.stringify(messages)).byteLength;
+  const maxInputTokens = encodedBytes + NPC_INPUT_OVERHEAD_TOKENS;
+  if (maxInputTokens > pricing.maxInputTokens || maxOutputTokens > pricing.maxOutputTokens) {
+    return { ok: false, reason: "npc_request_exceeds_model_bounds" };
+  }
+  const reservationNanos = maxCostNanos(maxInputTokens, maxOutputTokens, pricing);
+  if (reservationNanos === null) {
+    return { ok: false, reason: "npc_cost_bound_invalid" };
+  }
+  return {
+    ok: true,
+    deployment,
+    messages,
+    maxInputTokens,
+    maxOutputTokens,
+    pricing,
+    reservationNanos,
+  };
+}
+
+export function normalizeNpcUsage(usage) {
+  const raw = usage && typeof usage === "object" ? usage : {};
+  const details = raw.prompt_tokens_details || raw.input_tokens_details || {};
+  const promptTokens = Math.max(0, Number(raw.prompt_tokens ?? raw.input_tokens) || 0);
+  return {
+    prompt_tokens: promptTokens,
+    cached_tokens: Math.min(promptTokens, Math.max(0, Number(details.cached_tokens ?? raw.cached_tokens) || 0)),
+    completion_tokens: Math.max(0, Number(raw.completion_tokens ?? raw.output_tokens) || 0),
+  };
+}
+
+function usageCount(usage, primary, alternate) {
+  const key = Object.prototype.hasOwnProperty.call(usage, primary)
+    ? primary
+    : Object.prototype.hasOwnProperty.call(usage, alternate)
+      ? alternate
+      : null;
+  if (!key || !isSafeNonNegativeInteger(usage[key])) return null;
+  return usage[key];
+}
+
+function settledCost(plan, usage, requireOutputTokens) {
+  if (!usage || typeof usage !== "object") {
+    return {
+      usage: normalizeNpcUsage(null),
+      actualNanos: plan.reservationNanos,
+      usageAuthoritative: false,
+      reason: "provider_usage_missing",
+    };
+  }
+
+  const promptTokens = usageCount(usage, "prompt_tokens", "input_tokens");
+  const completionTokens = usageCount(usage, "completion_tokens", "output_tokens");
+  const totalTokens = Object.prototype.hasOwnProperty.call(usage, "total_tokens")
+    && isSafeNonNegativeInteger(usage.total_tokens)
+    ? usage.total_tokens
+    : null;
+  const details = usage.prompt_tokens_details || usage.input_tokens_details;
+  let cachedTokens = 0;
+  if (details !== undefined) {
+    if (!details || typeof details !== "object") {
+      return {
+        usage: normalizeNpcUsage(usage),
+        actualNanos: plan.reservationNanos,
+        usageAuthoritative: false,
+        reason: "provider_usage_invalid",
+      };
+    }
+    if (Object.prototype.hasOwnProperty.call(details, "cached_tokens")) {
+      cachedTokens = details.cached_tokens;
+      if (!isSafeNonNegativeInteger(cachedTokens)) {
+        return {
+          usage: normalizeNpcUsage(usage),
+          actualNanos: plan.reservationNanos,
+          usageAuthoritative: false,
+          reason: "provider_usage_invalid",
+        };
+      }
+    } else if (Object.prototype.hasOwnProperty.call(usage, "cached_tokens")) {
+      cachedTokens = usage.cached_tokens;
+      if (!isSafeNonNegativeInteger(cachedTokens)) {
+        return {
+          usage: normalizeNpcUsage(usage),
+          actualNanos: plan.reservationNanos,
+          usageAuthoritative: false,
+          reason: "provider_usage_invalid",
+        };
+      }
+    }
+  } else if (Object.prototype.hasOwnProperty.call(usage, "cached_tokens")) {
+    cachedTokens = usage.cached_tokens;
+    if (!isSafeNonNegativeInteger(cachedTokens)) {
+      return {
+        usage: normalizeNpcUsage(usage),
+        actualNanos: plan.reservationNanos,
+        usageAuthoritative: false,
+        reason: "provider_usage_invalid",
+      };
+    }
+  }
+  if (promptTokens === null || promptTokens < 1
+    || completionTokens === null
+    || (requireOutputTokens && completionTokens < 1)
+    || totalTokens === null
+    || totalTokens !== promptTokens + completionTokens
+    || cachedTokens > promptTokens) {
+    return {
+      usage: normalizeNpcUsage(usage),
+      actualNanos: plan.reservationNanos,
+      usageAuthoritative: false,
+      reason: "provider_usage_invalid",
+    };
+  }
+  const normalized = {
+    prompt_tokens: promptTokens,
+    cached_tokens: cachedTokens,
+    completion_tokens: completionTokens,
+  };
+  if (normalized.prompt_tokens > plan.maxInputTokens
+    || normalized.completion_tokens > plan.maxOutputTokens) {
+    return {
+      usage: normalized,
+      actualNanos: plan.reservationNanos,
+      usageAuthoritative: false,
+      reason: "provider_usage_out_of_bounds",
+    };
+  }
+  const uncached = normalized.prompt_tokens - normalized.cached_tokens;
+  const usd = uncached / 1_000_000 * plan.pricing.inputPer1MUsd
+    + normalized.cached_tokens / 1_000_000 * plan.pricing.cachedInputPer1MUsd
+    + normalized.completion_tokens / 1_000_000 * plan.pricing.outputPer1MUsd;
+  const actualNanos = Math.min(plan.reservationNanos, Math.ceil(usd * NPC_USD_SCALE));
+  return { usage: normalized, actualNanos, usageAuthoritative: true, reason: null };
+}
+
+function governorStub(env) {
+  const namespace = env?.NPC_BUDGET_GOVERNOR;
+  if (!namespace) throw new Error("npc_budget_binding_missing");
+  if (typeof namespace.getByName === "function") {
+    return namespace.getByName(NPC_BUDGET_OBJECT_NAME);
+  }
+  if (typeof namespace.idFromName === "function" && typeof namespace.get === "function") {
+    return namespace.get(namespace.idFromName(NPC_BUDGET_OBJECT_NAME));
+  }
+  throw new Error("npc_budget_binding_invalid");
+}
+
+async function governorCall(env, payload) {
+  const timeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 1500);
+  if (timeoutMs === null || timeoutMs < 100 || timeoutMs > 10_000) {
+    return { ok: false, reason: "npc_budget_timeout_invalid" };
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const response = await governorStub(env).fetch("https://npc-budget.internal/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    if (!response?.ok) {
+      const body = await response?.json().catch(() => null);
+      return { ok: false, reason: body?.reason || "npc_budget_governor_error" };
+    }
+    const body = await response.json();
+    return body?.ok ? body : { ok: false, reason: body?.reason || "npc_budget_governor_error" };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error?.name === "AbortError" ? "npc_budget_governor_timeout" : "npc_budget_governor_unavailable",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function retryableGovernorFailure(result) {
+  return [
+    "npc_budget_governor_timeout",
+    "npc_budget_governor_unavailable",
+    "npc_budget_governor_error",
+    "npc_budget_storage_error",
+  ].includes(result?.reason);
+}
+
+async function reliableGovernorCall(env, payload) {
+  const first = await governorCall(env, payload);
+  return retryableGovernorFailure(first) ? governorCall(env, payload) : first;
+}
+
+function withEnabled(budget, enabled) {
+  return { ...budget, enabled: !!enabled && budget.available === true };
+}
+
+export async function npcBudgetStatus(env, enabled, emit) {
+  const policy = budgetPolicy(env);
+  if (!policy.ok) return unavailableBudget(policy.reason, policy);
+  const result = await reliableGovernorCall(env, { op: "status", ...policy });
+  if (!result.ok || !result.budget) {
+    return unavailableBudget(result.reason || "npc_budget_governor_unavailable", policy);
+  }
+  emitReset(emit, result);
+  return withEnabled(result.budget, enabled);
+}
+
+async function releaseReservation(env, policy, reservationId) {
+  return reliableGovernorCall(env, { op: "release", ...policy, reservationId });
+}
+
+export async function runBudgetedNpcCall({
+  env,
+  role,
+  messages,
+  enabled,
+  emit,
+  providerCall,
+}) {
+  const policy = budgetPolicy(env);
+  if (!enabled) {
+    return {
+      ok: false,
+      reason: "npc_ai_disabled",
+      budget: await npcBudgetStatus(env, false, emit),
+    };
+  }
+  if (!policy.ok) {
+    const budget = unavailableBudget(policy.reason, policy);
+    emit?.("npc_budget_reserve", operationMeta({ budget }, {
+      role,
+      accepted: false,
+      reason: policy.reason,
+    }));
+    return { ok: false, reason: policy.reason, budget };
+  }
+
+  const plan = createNpcCallPlan(env, role, messages);
+  if (!plan.ok) {
+    const budget = await npcBudgetStatus(env, enabled, emit);
+    emit?.("npc_budget_reserve", operationMeta({ budget }, {
+      role,
+      accepted: false,
+      reason: plan.reason,
+    }));
+    return { ok: false, reason: plan.reason, budget };
+  }
+
+  const reservationId = crypto.randomUUID();
+  const reserved = await reliableGovernorCall(env, {
+    op: "reserve",
+    ...policy,
+    reservationId,
+    amountNanos: plan.reservationNanos,
+  });
+  emitReset(emit, reserved);
+  if (!reserved.ok || !reserved.accepted) {
+    const budget = reserved.budget
+      ? withEnabled(reserved.budget, enabled)
+      : unavailableBudget(reserved.reason || "npc_budget_governor_unavailable", policy);
+    emit?.("npc_budget_reserve", operationMeta({ budget }, {
+      role,
+      accepted: false,
+      reason: reserved.reason || "npc_budget_governor_unavailable",
+      maxCostUsd: nanosToUsd(plan.reservationNanos),
+    }));
+    return {
+      ok: false,
+      reason: reserved.reason || "npc_budget_governor_unavailable",
+      budget,
+    };
+  }
+  const reservedBudget = withEnabled(reserved.budget, enabled);
+  if (reservedBudget.day !== workerUtcDay(env)) {
+    const released = await releaseReservation(env, policy, reservationId);
+    const budget = released.ok && released.budget
+      ? withEnabled(released.budget, enabled)
+      : unavailableBudget(released.reason || "npc_budget_governor_unavailable", policy);
+    if (released.ok) {
+      emit?.("npc_budget_settle", operationMeta({ budget }, {
+        role,
+        outcome: "released",
+      }));
+    }
+    return { ok: false, reason: "reservation_expired", budget };
+  }
+  emit?.("npc_budget_reserve", operationMeta({ budget: reservedBudget }, {
+    role,
+    accepted: true,
+    maxCostUsd: nanosToUsd(plan.reservationNanos),
+  }));
+
+  let provider;
+  try {
+    provider = await providerCall(plan);
+  } catch (error) {
+    provider = {
+      ok: false,
+      reason: error?.name === "AbortError" ? "provider_timeout" : "provider_error",
+    };
+  }
+  if (!provider?.ok && !provider?.billable) {
+    const released = await releaseReservation(env, policy, reservationId);
+    emitReset(emit, released);
+    const budget = released.ok && released.budget
+      ? withEnabled(released.budget, enabled)
+      : unavailableBudget(released.reason || "npc_budget_governor_unavailable", policy);
+    emit?.("npc_provider_error", operationMeta({ budget }, {
+      role,
+      reason: provider?.reason || "provider_error",
+      reservationReleased: !!released.ok,
+    }));
+    if (released.ok) {
+      emit?.("npc_budget_settle", operationMeta({ budget }, {
+        role,
+        outcome: "released",
+      }));
+    }
+    return {
+      ok: false,
+      reason: provider?.reason || "provider_error",
+      budget,
+    };
+  }
+
+  const cost = settledCost(plan, provider.usage, provider.ok && !!provider.text);
+  const settled = await reliableGovernorCall(env, {
+    op: "settle",
+    ...policy,
+    reservationId,
+    actualNanos: cost.actualNanos,
+  });
+  emitReset(emit, settled);
+  if (!settled.ok || !settled.budget) {
+    const budget = unavailableBudget(settled.reason || "npc_budget_governor_unavailable", policy);
+    emit?.("npc_provider_error", operationMeta({ budget }, {
+      role,
+      reason: "npc_budget_settle_failed",
+      reservationReleased: false,
+    }));
+    return { ok: false, reason: "npc_budget_settle_failed", budget };
+  }
+
+  const budget = withEnabled(settled.budget, enabled);
+  emit?.("npc_budget_settle", operationMeta({ budget }, {
+    role,
+    outcome: "settled",
+    costUsd: nanosToUsd(settled.chargedNanos),
+    usageAuthoritative: cost.usageAuthoritative,
+    usageReason: cost.reason,
+  }));
+  if (!provider.ok) {
+    emit?.("npc_provider_error", operationMeta({ budget }, {
+      role,
+      reason: provider.reason || "provider_error",
+      reservationReleased: false,
+    }));
+    return {
+      ok: false,
+      reason: provider.reason || "provider_error",
+      budget,
+      usage: cost.usage,
+      model: plan.deployment,
+      costUsd: nanosToUsd(settled.chargedNanos),
+    };
+  }
+  return {
+    ok: true,
+    value: provider,
+    budget,
+    usage: cost.usage,
+    model: plan.deployment,
+    costUsd: nanosToUsd(settled.chargedNanos),
+  };
+}

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -8,6 +8,16 @@ main = "src/grounded.js"
 compatibility_date = "2025-04-01"
 workers_dev = true
 
+# One globally named instance serializes every resident-NPC reservation. The SQLite-backed
+# namespace persists UTC-day aggregates and idempotency records across isolates/restarts.
+[[durable_objects.bindings]]
+name = "NPC_BUDGET_GOVERNOR"
+class_name = "NpcBudgetGovernor"
+
+[[migrations]]
+tag = "v1-npc-budget-governor"
+new_sqlite_classes = ["NpcBudgetGovernor"]
+
 # ── Resident NPC live on/off (owner dashboard toggle) ─────────────────────────
 # Shared KV with the private repolis-metrics dashboard. The dashboard writes the
 # on/off flags here; this Worker reads them per request ONLY when NPC_LIVE_TOGGLE
@@ -60,6 +70,14 @@ METRICS_URL = "https://repolis-metrics.wingnut0310.workers.dev/event"
 MODEL_PRICE_IN_PER_1M_USD = "0.75"
 MODEL_PRICE_CACHED_IN_PER_1M_USD = "0.075"
 MODEL_PRICE_OUT_PER_1M_USD = "4.5"
+
+# Resident NPC reservations use deployment-specific prices and official input/output limits.
+# Unknown deployments or malformed tables fail closed. max_completion_tokens uses the same bound.
+NPC_MODEL_PRICING_JSON = '{"gpt-5.4-mini":{"inputPer1MUsd":0.75,"cachedInputPer1MUsd":0.075,"outputPer1MUsd":4.5,"maxInputTokens":272000,"maxOutputTokens":128000}}'
+NPC_MAX_COMPLETION_TOKENS = "120"
+NPC_BUDGET_TIMEOUT_MS = "1500"
+NPC_DAILY_ATTEMPT_MAX = "5000"
+NPC_RESERVATION_LEASE_MS = "60000"
 
 # Set your Azure AI Search endpoint (not secret, but account-specific). Either
 # uncomment + edit here, or keep it out of git with `wrangler secret put SEARCH_ENDPOINT`:

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { createHash } from 'crypto';
 import { runInNewContext } from 'vm';
+import { runNpcBudgetGovernorTests } from './test-npc-budget-governor.mjs';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -514,29 +515,75 @@ ok(/degrade\?NPC_CFG\.degradeMaxTurns/.test(npcBlock), 'a low budget degrades th
 // 12e — public-safe: the client ships NO api key, model deployment name, or Azure endpoint
 ok(!/AOAI_ENDPOINT|AAD_CLIENT|SEARCH_API_KEY|cognitiveservices|["']api-key["']/.test(npcBlock), 'resident client code contains no Azure endpoint / secret');
 ok(!/gpt-[0-9]/.test(npcBlock), 'resident client code names no model deployment');
-ok(!/NPC_MODEL_|NPC_DAY_CAP_USD|AOAI_DEPLOYMENT/.test(npcBlock), 'server-only NPC env names never appear in the client');
+ok(!/NPC_MODEL_|NPC_DAY_CAP_USD|NPC_DAILY_ATTEMPT_MAX|AOAI_DEPLOYMENT/.test(npcBlock), 'server-only NPC env names never appear in the client');
 // 12f — debug probes
 ok(/window\.__villagers=/.test(HTML) && /window\.__npcRoutes=/.test(HTML) && /window\.__npcEncounter=/.test(HTML), 'debug helpers __villagers/__npcRoutes/__npcEncounter present');
 ok(/window\.__npcBudget=/.test(HTML) && /window\.__npcTranscript=/.test(HTML), 'debug helpers __npcBudget/__npcTranscript present');
-// 12g — worker: additive npc_action scaffolding with the env-off ceiling + budget guard + fallback model
-let WORKER = '';
+// 12g — worker: additive npc_action scaffolding with hard kill switches + durable budget governor
+let WORKER = '', NPC_GOVERNOR = '', TAXI_WRANGLER = '';
 try { WORKER = readFileSync(join(ROOT, 'cloudflare-taxi/src/grounded.js'), 'utf8'); } catch (e) { console.log('  ✗ grounded.js load: ' + e.message); }
+try { NPC_GOVERNOR = readFileSync(join(ROOT, 'cloudflare-taxi/src/npc-budget-governor.js'), 'utf8'); } catch (e) { console.log('  ✗ npc-budget-governor.js load: ' + e.message); }
+try { TAXI_WRANGLER = readFileSync(join(ROOT, 'cloudflare-taxi/wrangler.toml'), 'utf8'); } catch (e) { console.log('  ✗ cloudflare-taxi/wrangler.toml load: ' + e.message); }
 ok(WORKER.length > 0, 'grounded.js worker source loaded');
+ok(NPC_GOVERNOR.length > 0, 'Durable NPC budget governor source loaded');
 ok(/if \(body && body\.npc_action\) return npcHandler\(body, request, env, ctx\)/.test(WORKER), 'fetch router dispatches body.npc_action to npcHandler with execution context');
 ok(/async function npcHandler\(/.test(WORKER), 'npcHandler() exists');
 ok(/grounded_mcp_mslearn/.test(WORKER) && /grounded_mcp_deepwiki/.test(WORKER) && /grounded_kb_taxi/.test(WORKER), 'grounded AI routes use the report taxonomy');
 ok(/tokensIn: u\.prompt_tokens/.test(WORKER) && /cachedTokens: u\.cached_tokens/.test(WORKER) && /tokensOut: u\.completion_tokens/.test(WORKER), 'provider usage emits input, cached-input, and output tokens');
 ok(/action === "npcConfig"/.test(WORKER) && /action === "npcBudget"/.test(WORKER) && /"npcAmbientTurn"/.test(WORKER) && /"npcPlayerChat"/.test(WORKER), 'all four npc actions (config/budget/ambientTurn/playerChat) handled');
-ok(/if \(!aiEnabled\) return null/.test(WORKER), 'hard ceiling: npcModelCall returns null unless the resolved aiEnabled is true');
+ok(/if \(!aiEnabled\) return \{ ok: false, reason: "npc_ai_disabled" \}/.test(WORKER), 'hard ceiling: npcModelCall refuses unless the resolved aiEnabled is true');
 ok(/async function npcResolveFlags\(/.test(WORKER), 'npcResolveFlags() resolves the effective NPC flags (env vs live KV)');
 ok(/env\.NPC_LIVE_TOGGLE === "true"/.test(WORKER), 'NPC_LIVE_TOGGLE is the master kill-switch for the live toggle');
 ok(/source: "env", liveToggle: false/.test(WORKER), 'live toggle OFF → resolver ignores KV and stays env-gated (safe deploy-only default)');
 ok(/env\.NPC_FLAGS\.get\(/.test(WORKER), 'live mode reads on/off from the shared NPC_FLAGS KV');
-ok(/npcModelCall\(env, role, sys, userMsg, aiEnabled\)/.test(WORKER), 'model call is gated by the resolved effective aiEnabled');
-ok(/reason: "npc_budget_exhausted"/.test(WORKER), 'over-budget returns npc_budget_exhausted (client falls back to scripted)');
-ok(/NPC_MODEL_DEFAULT \|\| "gpt-5\.4-mini"/.test(WORKER), 'provider adapter falls back to gpt-5.4-mini when no NPC_MODEL_* alias is set');
-ok(/env\.NPC_DAY_CAP_USD/.test(WORKER) && !/COUNCIL_[A-Z_]*\s*\|\|\s*env\.NPC_/.test(WORKER), 'NPC budget uses the NPC_* namespace (separate from COUNCIL_*)');
+ok(/const ai = envAi && allows\(kAi\)/.test(WORKER)
+  && /ambientEnabled: ai && envAmb && allows\(kAmb\)/.test(WORKER)
+  && /playerChatEnabled: ai && envPc && allows\(kPc\)/.test(WORKER)
+  && /source: "kv-unavailable"/.test(WORKER),
+  'KV live flags can kill resident AI, never bypass env ceilings, and fail closed on read errors');
+ok(/runBudgetedNpcCall\(\{[\s\S]*?providerCall: \(plan\) => npcModelCall\(env, role, plan, aiEnabled\)/.test(WORKER),
+  'model call is reachable only through the durable reserve/settle lifecycle');
+ok(/"npc_budget_exhausted"/.test(WORKER), 'over-budget returns npc_budget_exhausted (client falls back to scripted)');
+ok(/NPC_MODEL_DEFAULT[\s\S]*?"gpt-5\.4-mini"/.test(NPC_GOVERNOR), 'provider adapter falls back to gpt-5.4-mini when no NPC_MODEL_* alias is set');
+ok(/env\?\.NPC_DAY_CAP_USD/.test(NPC_GOVERNOR) && !/COUNCIL_/.test(NPC_GOVERNOR), 'NPC budget uses the NPC_* namespace (separate from COUNCIL_*)');
 ok(/function npcMetric\(/.test(WORKER) && /env\.METRICS_URL/.test(WORKER), 'redacted fire-and-forget metrics emit (env.METRICS_URL) present');
+ok(/export class NpcBudgetGovernor/.test(NPC_GOVERNOR)
+  && /NPC_BUDGET_OBJECT_NAME = "npc-budget-canonical-v1"/.test(NPC_GOVERNOR)
+  && /blockConcurrencyWhile\(run\)/.test(NPC_GOVERNOR),
+  'one canonical Durable Object serializes persistent budget mutations');
+ok(!/_npcLedger|source: "module"|module-scope ledger/.test(WORKER + NPC_GOVERNOR),
+  'isolate-local NPC budget ledger is fully removed');
+ok(/NPC_DAILY_ATTEMPT_MAX/.test(NPC_GOVERNOR)
+  && /reason: "daily_attempt_max"/.test(NPC_GOVERNOR)
+  && /cleanupFinalized/.test(NPC_GOVERNOR)
+  && /deleteKeys\.slice\(index, index \+ 128\)/.test(NPC_GOVERNOR),
+  'provider failures are attempt-capped and finalized Durable Object records stay bounded');
+ok(/NPC_RESERVATION_LEASE_MS/.test(NPC_GOVERNOR)
+  && /async reconcileExpiredReservations\(/.test(NPC_GOVERNOR)
+  && /async alarm\(\)/.test(NPC_GOVERNOR)
+  && /chargedNanos: record\.amountNanos/.test(NPC_GOVERNOR),
+  'orphaned reservations have a durable lease and conservatively full-settle by alarm');
+ok(/modelDispatched = true/.test(WORKER)
+  && /billable: modelDispatched/.test(WORKER)
+  && /billable: true, reason: "provider_http_error"/.test(WORKER),
+  'ambiguous failures after Azure model dispatch settle instead of reopening budget');
+ok(/NPC_INPUT_OVERHEAD_TOKENS = 512/.test(NPC_GOVERNOR)
+  && /maxInputTokens = encodedBytes \+ NPC_INPUT_OVERHEAD_TOKENS/.test(NPC_GOVERNOR)
+  && /max_completion_tokens: plan\.maxOutputTokens/.test(WORKER)
+  && /maxInputTokens: 272_000/.test(NPC_GOVERNOR)
+  && /maxOutputTokens: 128_000/.test(NPC_GOVERNOR)
+  && /npc_pricing_unavailable/.test(NPC_GOVERNOR),
+  'reservation validates model limits and covers byte-bounded input, provider output cap, and prices');
+ok(/name = "NPC_BUDGET_GOVERNOR"/.test(TAXI_WRANGLER)
+  && /class_name = "NpcBudgetGovernor"/.test(TAXI_WRANGLER)
+  && /new_sqlite_classes = \["NpcBudgetGovernor"\]/.test(TAXI_WRANGLER),
+  'Wrangler binds and migrates the SQLite-backed NPC budget Durable Object');
+ok(/source: "durable-object"/.test(WORKER)
+  && /NPC_BUDGET_SOURCE = "durable-object"/.test(NPC_GOVERNOR),
+  'npcConfig and npcBudget identify the Durable Object as their budget authority');
+
+group('Durable NPC budget governor — hermetic atomicity and fail-closed behavior');
+await runNpcBudgetGovernorTests(ok);
 
 group('AURI market oracle — grounded market KB + read-only crypto MCP');
 const marketActionSrc=(HTML.match(/function marketActionQuestion\(q\)\{[\s\S]*?(?=\nfunction marketQuestion)/)||[''])[0];

--- a/scripts/test-npc-budget-governor.mjs
+++ b/scripts/test-npc-budget-governor.mjs
@@ -1,0 +1,665 @@
+import {
+  NpcBudgetGovernor,
+  createNpcCallPlan,
+  npcBudgetStatus,
+  runBudgetedNpcCall,
+} from '../cloudflare-taxi/src/npc-budget-governor.js';
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+    this.alarmAt = null;
+  }
+
+  async get(key) {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : structuredClone(value);
+  }
+
+  async put(key, value) {
+    if (typeof key === 'object' && key !== null) {
+      for (const [entryKey, entryValue] of Object.entries(key)) {
+        this.values.set(entryKey, structuredClone(entryValue));
+      }
+      return;
+    }
+    this.values.set(key, structuredClone(value));
+  }
+
+  async list(options = {}) {
+    const prefix = String(options.prefix || '');
+    return new Map([...this.values.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, value]) => [key, structuredClone(value)]));
+  }
+
+  async delete(keys) {
+    for (const key of Array.isArray(keys) ? keys : [keys]) this.values.delete(key);
+  }
+
+  async deleteAll() {
+    this.values.clear();
+  }
+
+  async getAlarm() {
+    return this.alarmAt;
+  }
+
+  async setAlarm(timestamp) {
+    this.alarmAt = timestamp;
+  }
+}
+
+class MemoryState {
+  constructor() {
+    this.storage = new MemoryStorage();
+    this.tail = Promise.resolve();
+  }
+
+  blockConcurrencyWhile(callback) {
+    const result = this.tail.then(callback, callback);
+    this.tail = result.then(() => undefined, () => undefined);
+    return result;
+  }
+}
+
+function makeGovernor(nowRef = { value: Date.parse('2026-07-30T12:00:00Z') }) {
+  const state = new MemoryState();
+  const governor = new NpcBudgetGovernor(state, { __npcBudgetNow: () => nowRef.value });
+  return { state, governor, nowRef };
+}
+
+function namespaceFor(governor, failure) {
+  return {
+    getByName(name) {
+      if (name !== 'npc-budget-canonical-v1') throw new Error('non-canonical governor name');
+      return {
+        async fetch(input, init) {
+          if (failure) throw new Error('binding unavailable');
+          const request = input instanceof Request ? input : new Request(input, init);
+          return governor.fetch(request);
+        },
+      };
+    },
+  };
+}
+
+async function operation(governor, body) {
+  const response = await governor.fetch(new Request('https://npc-budget.internal/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+  return response.json();
+}
+
+function reservationId(index) {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+}
+
+function baseEnv(governor) {
+  return {
+    __npcBudgetNow: () => governor.now(),
+    NPC_AI_ENABLED: 'true',
+    NPC_DAY_CAP_USD: '1',
+    NPC_DAILY_TURN_MAX: '0',
+    NPC_MODEL_DEFAULT: 'gpt-5.4-mini',
+    NPC_MODEL_PRICING_JSON: JSON.stringify({
+      'gpt-5.4-mini': {
+        inputPer1MUsd: 0.75,
+        cachedInputPer1MUsd: 0.075,
+        outputPer1MUsd: 4.5,
+        maxInputTokens: 272_000,
+        maxOutputTokens: 128_000,
+      },
+    }),
+    NPC_MAX_COMPLETION_TOKENS: '120',
+    NPC_BUDGET_TIMEOUT_MS: '500',
+    NPC_BUDGET_GOVERNOR: namespaceFor(governor),
+  };
+}
+
+const MESSAGES = [
+  { role: 'system', content: 'A short resident system prompt.' },
+  { role: 'user', content: 'A unique hermetic visitor message.' },
+];
+
+export async function runNpcBudgetGovernorTests(check) {
+  {
+    const { governor } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const reservations = await Promise.all([
+      operation(governor, { op: 'reserve', ...policy, reservationId: reservationId(1), amountNanos: 600_000 }),
+      operation(governor, { op: 'reserve', ...policy, reservationId: reservationId(2), amountNanos: 600_000 }),
+    ]);
+    const status = await operation(governor, { op: 'status', ...policy });
+    check(reservations.filter((result) => result.accepted).length === 1
+      && status.budget.reservedUsd === 0.0006
+      && status.budget.reservedUsd + status.budget.spentUsd <= status.budget.dayCapUsd,
+    'Durable governor serializes simultaneous reservations without cap overshoot');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(3);
+    const first = await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    const duplicateReserve = await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    const mismatchedReserve = await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 400_000 });
+    const settled = await operation(governor, { op: 'settle', ...policy, reservationId: id, actualNanos: 250_000 });
+    const duplicateSettle = await operation(governor, { op: 'settle', ...policy, reservationId: id, actualNanos: 250_000 });
+    check(first.accepted && duplicateReserve.accepted && duplicateReserve.idempotent
+      && !mismatchedReserve.accepted && mismatchedReserve.reason === 'reservation_mismatch'
+      && settled.settled && duplicateSettle.idempotent
+      && duplicateSettle.chargedNanos === 250_000
+      && duplicateSettle.budget.spentUsd === 0.00025
+      && duplicateSettle.budget.reservedUsd === 0
+      && duplicateSettle.budget.turnsToday === 1,
+    'reserve and settle retries are idempotent');
+  }
+
+  {
+    const { governor, nowRef } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(4);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    nowRef.value = Date.parse('2026-07-31T00:00:01Z');
+    const nextDay = await operation(governor, { op: 'status', ...policy });
+    const settledAfterMidnight = await operation(governor, {
+      op: 'settle',
+      ...policy,
+      reservationId: id,
+      actualNanos: 300_000,
+    });
+    const duplicateSettle = await operation(governor, {
+      op: 'settle',
+      ...policy,
+      reservationId: id,
+      actualNanos: 300_000,
+    });
+    const priorLedger = await governor.state.storage.get('ledger:2026-07-30');
+    check(nextDay.reset && nextDay.budget.day === '2026-07-31'
+      && nextDay.budget.spentUsd === 0 && nextDay.budget.reservedUsd === 0
+      && settledAfterMidnight.settled && duplicateSettle.idempotent
+      && priorLedger.spentNanos === 300_000 && priorLedger.reservedNanos === 0
+      && priorLedger.turns === 1 && priorLedger.reservedTurns === 0,
+    'UTC rollover starts a clean day while preserving cross-midnight settlement idempotency');
+  }
+
+  {
+    const { governor, nowRef } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(42);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    await operation(governor, { op: 'settle', ...policy, reservationId: id, actualNanos: 200_000 });
+    nowRef.value = Date.parse('2026-07-31T00:00:01Z');
+    const duplicateAfterMidnight = await operation(governor, {
+      op: 'settle',
+      ...policy,
+      reservationId: id,
+      actualNanos: 200_000,
+    });
+    check(duplicateAfterMidnight.idempotent && duplicateAfterMidnight.chargedNanos === 200_000,
+      'settlement response retries remain idempotent across the next UTC rollover');
+  }
+
+  {
+    const { governor, nowRef } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(41);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    nowRef.value = Date.parse('2026-07-31T00:00:01Z');
+    const expiredRetry = await operation(governor, {
+      op: 'reserve',
+      ...policy,
+      reservationId: id,
+      amountNanos: 500_000,
+    });
+    const priorLedger = await governor.state.storage.get('ledger:2026-07-30');
+    const record = await governor.state.storage.get(`reservation:${id}`);
+    check(!expiredRetry.accepted && expiredRetry.reason === 'reservation_expired'
+      && priorLedger.reservedNanos === 0 && priorLedger.reservedTurns === 0
+      && record === undefined,
+    'a lost reserve response retried after UTC rollover releases its expired authorization');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const initial = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(5);
+    await operation(governor, { op: 'reserve', ...initial, reservationId: id, amountNanos: 500_000 });
+    await operation(governor, { op: 'settle', ...initial, reservationId: id, actualNanos: 400_000 });
+    const lowered = await operation(governor, {
+      op: 'reserve',
+      capNanos: 300_000,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+      reservationId: reservationId(6),
+      amountNanos: 1,
+    });
+    const zero = await operation(governor, {
+      op: 'reserve',
+      capNanos: 0,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+      reservationId: reservationId(7),
+      amountNanos: 1,
+    });
+    const staleHigherCap = await operation(governor, {
+      op: 'reserve',
+      capNanos: 1_000_000,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+      reservationId: reservationId(71),
+      amountNanos: 1,
+    });
+    check(!lowered.accepted && lowered.reason === 'day_cap_exhausted' && lowered.budget.blocked
+      && !zero.accepted && zero.reason === 'day_cap_zero' && zero.budget.blocked
+      && !staleHigherCap.accepted && staleHigherCap.reason === 'day_cap_zero'
+      && staleHigherCap.budget.dayCapUsd === 0,
+    'midday reductions are sticky so cap=0 cannot be reopened by a stale Worker');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const policy = { capNanos: 2_000_000, dailyTurnMax: 1, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const firstId = reservationId(8);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: firstId, amountNanos: 500_000 });
+    const whileReserved = await operation(governor, {
+      op: 'reserve',
+      ...policy,
+      reservationId: reservationId(9),
+      amountNanos: 500_000,
+    });
+    await operation(governor, { op: 'release', ...policy, reservationId: firstId });
+    const completedId = reservationId(10);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: completedId, amountNanos: 500_000 });
+    await operation(governor, { op: 'settle', ...policy, reservationId: completedId, actualNanos: 200_000 });
+    const afterTurn = await operation(governor, {
+      op: 'reserve',
+      capNanos: policy.capNanos,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+      reservationId: reservationId(11),
+      amountNanos: 500_000,
+    });
+    check(!whileReserved.accepted && whileReserved.reason === 'daily_turn_max'
+      && !afterTurn.accepted && afterTurn.reason === 'daily_turn_max'
+      && afterTurn.budget.turnsToday === 1,
+    'daily turn max counts in-flight/settled turns and cannot be relaxed by a stale Worker');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    let providerCalls = 0;
+    const failure = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: false, reason: 'provider_http_error' };
+      },
+    });
+    const timeout = await runBudgetedNpcCall({
+      env,
+      role: 'ambient',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        throw error;
+      },
+    });
+    const status = await npcBudgetStatus(env, true);
+    check(providerCalls === 2 && !failure.ok && !timeout.ok
+      && failure.budget.reservedUsd === 0 && timeout.budget.reservedUsd === 0
+      && status.spentUsd === 0 && status.reservedUsd === 0
+      && status.turnsToday === 0 && status.reservedTurns === 0,
+    'provider failure and timeout always release their reservations');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    env.NPC_DAILY_ATTEMPT_MAX = '2';
+    let providerCalls = 0;
+    const fail = () => runBudgetedNpcCall({
+      env,
+      role: 'ambient',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: false, reason: 'provider_http_error' };
+      },
+    });
+    await fail();
+    await fail();
+    const blocked = await fail();
+    const status = await npcBudgetStatus(env, true);
+    const reservationKeys = [...governor.state.storage.values.keys()]
+      .filter((key) => key.startsWith('reservation:'));
+    check(providerCalls === 2 && !blocked.ok && blocked.reason === 'daily_attempt_max'
+      && status.attemptsToday === 2 && status.dailyAttemptMax === 2
+      && status.blocked && reservationKeys.length === 0,
+    'failed providers have bounded daily attempts and leave no persistent reservation tombstones');
+  }
+
+  {
+    const { governor, nowRef } = makeGovernor();
+    const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
+    const id = reservationId(12);
+    await operation(governor, { op: 'reserve', ...policy, reservationId: id, amountNanos: 500_000 });
+    nowRef.value += 60_001;
+    await governor.alarm();
+    const afterAlarm = await operation(governor, { op: 'status', ...policy });
+    const settledRecord = await governor.state.storage.get(`reservation:${id}`);
+    nowRef.value = Date.parse('2026-07-31T00:00:01Z');
+    await operation(governor, { op: 'status', ...policy });
+    nowRef.value = Date.parse('2026-08-01T00:00:01Z');
+    await operation(governor, { op: 'status', ...policy });
+    const prunedRecord = await governor.state.storage.get(`reservation:${id}`);
+    check(afterAlarm.budget.spentUsd === 0.0005 && afterAlarm.budget.reservedUsd === 0
+      && afterAlarm.budget.turnsToday === 1 && settledRecord.status === 'settled'
+      && settledRecord.expired && prunedRecord === undefined,
+    'orphan leases full-settle by alarm and finalized tombstones prune after the retry window');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    const events = [];
+    const success = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      emit: (name, meta) => events.push({ name, meta }),
+      providerCall: async () => ({
+        ok: true,
+        text: 'hello',
+        usage: {
+          prompt_tokens: 100,
+          prompt_tokens_details: { cached_tokens: 20 },
+          completion_tokens: 50,
+          total_tokens: 150,
+        },
+      }),
+    });
+    const serializedState = JSON.stringify([...governor.state.storage.values.entries()]);
+    const serializedEvents = JSON.stringify(events);
+    check(success.ok && success.costUsd === 0.0002865
+      && success.budget.spentUsd === 0.0002865
+      && success.budget.reservedUsd === 0
+      && success.budget.remainingUsd === 0.9997135
+      && success.budget.turnsToday === 1
+      && success.budget.source === 'durable-object',
+    'npcBudget reports authoritative spent, reserved, remaining, and turn values');
+    check(!serializedState.includes('unique hermetic visitor')
+      && !serializedEvents.includes('unique hermetic visitor')
+      && !serializedEvents.includes('reservationId')
+      && events.every(({ name }) => ['npc_budget_reserve', 'npc_budget_settle', 'npc_budget_utc_reset'].includes(name)),
+    'governor persistence and metrics contain no prompt, conversation, reservation ID, or personal data');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    const plan = createNpcCallPlan(env, 'player', MESSAGES);
+    const billableEmpty = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => ({
+        ok: false,
+        billable: true,
+        reason: 'provider_empty_response',
+        usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 },
+      }),
+    });
+    const partialUsage = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => ({
+        ok: true,
+        text: 'partial usage',
+        usage: { prompt_tokens: 100 },
+      }),
+    });
+    check(!billableEmpty.ok && billableEmpty.costUsd >= 0.00012
+      && billableEmpty.costUsd <= 0.000120001,
+      'billable empty responses settle returned provider usage before fallback');
+    check(partialUsage.ok && partialUsage.costUsd === plan.reservationNanos / 1_000_000_000,
+      'partial provider usage settles the full conservative reservation');
+    check(Math.abs(partialUsage.budget.spentUsd - billableEmpty.costUsd - partialUsage.costUsd) < 1e-12
+      && partialUsage.budget.reservedUsd === 0,
+    'billable fallback and partial usage remain reflected in authoritative budget totals');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    const plan = createNpcCallPlan(env, 'player', MESSAGES);
+    const malformed = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => ({
+        ok: true,
+        text: 'malformed usage',
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 999 },
+      }),
+    });
+    const zeroOutput = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => ({
+        ok: true,
+        text: 'nonempty text requires output tokens',
+        usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+      }),
+    });
+    check(malformed.ok && malformed.costUsd === plan.reservationNanos / 1_000_000_000
+      && zeroOutput.ok && zeroOutput.costUsd === plan.reservationNanos / 1_000_000_000
+      && Math.abs(zeroOutput.budget.spentUsd - malformed.costUsd - zeroOutput.costUsd) < 1e-12,
+    'zero/inconsistent usage and nonempty zero-output responses settle the full reservation');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    let dropped = false;
+    env.NPC_BUDGET_GOVERNOR = {
+      getByName() {
+        return {
+          async fetch(input, init) {
+            const payload = JSON.parse(init.body);
+            const response = await governor.fetch(new Request(input, init));
+            if (payload.op === 'settle' && !dropped) {
+              dropped = true;
+              throw new Error('settle response lost');
+            }
+            return response;
+          },
+        };
+      },
+    };
+    const retried = await runBudgetedNpcCall({
+      env,
+      role: 'ambient',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => ({
+        ok: true,
+        text: 'idempotent retry',
+        usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+      }),
+    });
+    check(dropped && retried.ok && retried.costUsd > 0
+      && retried.budget.turnsToday === 1 && retried.budget.reservedUsd === 0,
+    'lost settlement responses retry with the same reservation and charge exactly once');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    const plan = createNpcCallPlan(env, 'ambient', MESSAGES);
+    env.NPC_DAY_CAP_USD = String(plan.reservationNanos / 1_000_000_000 * 1.5);
+    let providerCalls = 0;
+    const calls = await Promise.all([
+      runBudgetedNpcCall({
+        env,
+        role: 'ambient',
+        messages: MESSAGES,
+        enabled: true,
+        providerCall: async () => {
+          providerCalls += 1;
+          return { ok: true, text: 'one', usage: null };
+        },
+      }),
+      runBudgetedNpcCall({
+        env,
+        role: 'ambient',
+        messages: MESSAGES,
+        enabled: true,
+        providerCall: async () => {
+          providerCalls += 1;
+          return { ok: true, text: 'two', usage: null };
+        },
+      }),
+    ]);
+    const status = await npcBudgetStatus(env, true);
+    check(calls.filter((result) => result.ok).length === 1 && providerCalls === 1
+      && status.spentUsd <= status.dayCapUsd && status.reservedUsd === 0,
+    'simultaneous lifecycle calls invoke the provider only after an accepted worst-case reservation');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    env.NPC_DAY_CAP_USD = '0';
+    let providerCalls = 0;
+    const zeroCap = await runBudgetedNpcCall({
+      env,
+      role: 'ambient',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    check(!zeroCap.ok && zeroCap.reason === 'day_cap_zero' && providerCalls === 0,
+      'zero daily cap blocks the provider before invocation');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    let providerCalls = 0;
+    const disabled = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: false,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    env.NPC_MODEL_DEFAULT = 'unpriced-deployment-alias';
+    const unpriced = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    check(!disabled.ok && disabled.reason === 'npc_ai_disabled'
+      && !unpriced.ok && unpriced.reason === 'npc_pricing_unavailable'
+      && unpriced.budget.available && providerCalls === 0,
+    'kill switch and unknown model pricing both refuse before provider invocation');
+    env.NPC_MODEL_DEFAULT = 'gpt-5.4-mini';
+    env.NPC_MODEL_PRICING_JSON = JSON.stringify({
+      'gpt-5.4-mini': {
+        inputPer1MUsd: 0.75,
+        cachedInputPer1MUsd: null,
+        outputPer1MUsd: 4.5,
+        maxInputTokens: 272_000,
+        maxOutputTokens: 128_000,
+      },
+    });
+    const malformedPrice = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    check(!malformedPrice.ok && malformedPrice.reason === 'npc_pricing_invalid'
+      && providerCalls === 0,
+    'malformed cached-input pricing fails closed rather than becoming free');
+    env.NPC_MODEL_PRICING_JSON = JSON.stringify({
+      'gpt-5.4-mini': {
+        inputPer1MUsd: 0.75,
+        cachedInputPer1MUsd: 0.075,
+        outputPer1MUsd: 4.5,
+      },
+    });
+    const missingBounds = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    check(!missingBounds.ok && missingBounds.reason === 'npc_model_bounds_invalid'
+      && providerCalls === 0,
+    'pricing entries without official model input/output bounds fail closed');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = { ...baseEnv(governor) };
+    delete env.NPC_BUDGET_GOVERNOR;
+    let providerCalls = 0;
+    const unavailable = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    check(!unavailable.ok && unavailable.reason === 'npc_budget_governor_unavailable'
+      && unavailable.budget.available === false && unavailable.budget.blocked
+      && unavailable.budget.source === 'durable-object' && providerCalls === 0,
+    'missing Durable Object binding fails closed before any provider call');
+  }
+}


### PR DESCRIPTION
## Summary
- replace the isolate-local resident NPC ledger with one canonical SQLite-backed Durable Object
- reserve worst-case model cost atomically, settle authoritative usage, and fail closed on flags, pricing, provider, or binding failures
- add UTC rollover, sticky cap reductions, idempotent retries, orphan leases/alarms, bounded storage cleanup, and anonymous aggregate budget reporting
- document disable/rollback behavior and add hermetic concurrency/cost-boundary coverage

## Validation
- node council/test.mjs
- node council/test-live.mjs
- node scripts/smoke.mjs
- node --check scholars.js
- node --check cloudflare-taxi/src/grounded.js
- npx wrangler deploy --dry-run (cloudflare-taxi)