### PR TITLE
Seat the player on the canal ferry

### DIFF
--- a/index.html
+++ b/index.html
@@ -3058,11 +3058,16 @@ function _placeCanalFerry(elapsed,dt){
   F.wake.material.opacity=canalFerryRide?(REDUCED?0.12:0.18+Math.sin(clock.elapsedTime*3.4)*0.04):0.08;
   return F.sample;
 }
+function _placeCanalFerryRider(){
+  const F=CANAL_FERRY; if(!F) return;
+  player.position.set(F.group.position.x,F.group.position.y-F.baseY,F.group.position.z);
+  model.rotation.y=F.group.rotation.y;
+}
 function boardCanalFerry(){
   if(!CANAL_FERRY||canalFerryRide||ride||ferris||carousel||modalOpen||repositoryAtelierActive()) return false;
   standUp(); clearKeys(); canalFerryRide={elapsed:0}; CANAL_FERRY.lastDirection=1; _placeCanalFerry(0,1);
-  player.position.set(CANAL_FERRY.group.position.x,CANAL_FERRY.group.position.y,CANAL_FERRY.group.position.z);
-  model.visible=false; blob.visible=false; freeLook=true; camYaw=CANAL_FERRY.group.rotation.y+Math.PI; camPitch=0.3; camDist=16;
+  _placeCanalFerryRider(); model.visible=true; blob.visible=false; emoteT=0;
+  freeLook=true; camYaw=CANAL_FERRY.group.rotation.y+Math.PI; camPitch=0.3; camDist=16;
   if(addStamp('canal')) popSparkle(CANAL_FERRY.dock.x,2.6,CANAL_FERRY.dock.z,0x7fe3da);
   promptEl.classList.remove('show'); actBtn.classList.remove('avail'); track('canal_ferry_board',{}); showWave(t('ferryBoard'),3000); return true;
 }
@@ -3079,7 +3084,7 @@ function updateCanalFerry(dt){
   if(canalFerryRide) canalFerryRide.elapsed=Math.min(CANAL_FERRY.duration,canalFerryRide.elapsed+dt);
   const state=_placeCanalFerry(canalFerryRide?canalFerryRide.elapsed:0,dt);
   if(!canalFerryRide) return;
-  player.position.set(CANAL_FERRY.group.position.x,CANAL_FERRY.group.position.y,CANAL_FERRY.group.position.z);
+  _placeCanalFerryRider();
   if(state.complete) disembarkCanalFerry();
 }
 /*CANAL_FERRY:END*/
@@ -8838,7 +8843,7 @@ function animate(){
     player.position.set(w.x, w.y-1.6, w.z);                  // ride the horse — the camera circles with the carousel
     if(carousel.turned>=Math.PI*2) disembarkCarousel();      // one full turn → step off at the platform
   } else if(canalFerryRide){
-    player.position.set(CANAL_FERRY.group.position.x,CANAL_FERRY.group.position.y,CANAL_FERRY.group.position.z);
+    _placeCanalFerryRider();
   } else {
     if(sitting&&userInput) standUp();
     if(keys['KeyW']||keys['ArrowUp']) mv.add(tF);
@@ -8853,7 +8858,11 @@ function animate(){
       model.rotation.y=lerpA(model.rotation.y,Math.atan2(mv.x,mv.z),0.2); walk+=dt*10; }
   }
   if(!moving) walk*=0.85;
-  if(sitting){
+  if(canalFerryRide){
+    legL.rotation.x=legR.rotation.x=-1.5; legL.rotation.z=legR.rotation.z=0;
+    armL.rotation.x=armR.rotation.x=-0.38; armL.rotation.z=0.16; armR.rotation.z=-0.16;
+    model.position.y=-0.34; model.rotation.y=CANAL_FERRY.group.rotation.y; model.rotation.z=0;
+  } else if(sitting){
     legL.rotation.x=legR.rotation.x=-1.5; legL.rotation.z=legR.rotation.z=0;
     armL.rotation.x=armR.rotation.x=-0.25; armL.rotation.z=0.12; armR.rotation.z=-0.12;
     model.position.y=-0.34; model.rotation.z=0;
@@ -9458,6 +9467,8 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     bridge:CANAL_FERRY?{underY:CANAL_FERRY.bridgeUnderY,maxWorldY:CANAL_FERRY.maxWorldY,clearance:CANAL_FERRY.bridgeClearance}:null,
     silhouette:CANAL_FERRY?{profile:'open-skiff',hull:CANAL_FERRY.hull.visible,deck:CANAL_FERRY.deck.visible,opaque:CANAL_FERRY.hull.material.transparent!==true,
       hullColor:'#'+CANAL_FERRY.hull.material.color.getHexString(),deckColor:'#'+CANAL_FERRY.deck.material.color.getHexString()}:null,
+    rider:CANAL_FERRY?{aboard:!!canalFerryRide,visible:model.visible,seat:canalFerryRide?'center':null,
+      pose:canalFerryRide?'seated':null,contactShadow:blob.visible,yaw:+model.rotation.y.toFixed(4)}:null,
     meshes:CANAL_FERRY?CANAL_FERRY.group.children.length:0,owner:_cameraOwnerAtFrameStart() });
   window.__boardFerry=()=>{ if(!CANAL_FERRY) return {has:false}; player.position.copy(CANAL_FERRY.dock); nearCanalFerry=CANAL_FERRY; boardCanalFerry(); return window.__canalFerry(); };
   window.__finishFerry=()=>{ if(canalFerryRide) canalFerryRide.elapsed=CANAL_FERRY.duration-0.05; return window.__canalFerry(); };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -340,6 +340,7 @@ ok(sampleCanalFerryRoute(Infinity,CANAL_FERRY_DEFAULTS,ferryReuse)===ferryReuse
 const ferryBlock=(HTML.match(/\/\*CANAL_FERRY:START\*\/([\s\S]*?)\/\*CANAL_FERRY:END\*\//)||[,''])[1];
 const ferryMove=(ferryBlock.match(/function _placeCanalFerry\(elapsed,dt\)\{([\s\S]*?)\n\}/)||[,''])[1];
 const ferryUpdate=(ferryBlock.match(/function updateCanalFerry\(dt\)\{([\s\S]*?)\n\}/)||[,''])[1];
+const ferryRider=(ferryBlock.match(/function _placeCanalFerryRider\(\)\{([\s\S]*?)\n\}/)||[,''])[1];
 ok(ferryBlock.length>0 && /makeCanalFerry\(curve,RIVER_LANDMARK\)/.test(HTML),
   'the grand river creates exactly one dedicated boardable ferry from its existing curve');
 ok(/root\.name='petite-venise-canal-ferry'/.test(ferryBlock)
@@ -359,6 +360,16 @@ ok(!/LOW_END/.test(ferryBlock) && /disableDynamicShadowCasters\(root\)/.test(fer
   'desktop and mobile keep the same single lightweight craft without dynamic shadow churn');
 ok(ferryMove.length>0 && ferryUpdate.length>0 && !/new THREE|\.clone\(|scene\.traverse|\.map\(/.test(ferryMove+ferryUpdate),
   'steady ferry motion reuses its route sample and fixed curve vectors without per-frame allocation or traversal');
+ok(ferryRider.length>0
+  && /player\.position\.set\(F\.group\.position\.x,F\.group\.position\.y-F\.baseY,F\.group\.position\.z\)/.test(ferryRider)
+  && /model\.rotation\.y=F\.group\.rotation\.y/.test(ferryRider),
+  'the existing player root follows the center bench, ferry yaw, and bob without parenting or another avatar');
+ok(/_placeCanalFerryRider\(\); model\.visible=true; blob\.visible=false; emoteT=0/.test(ferryBlock)
+  && /if\(canalFerryRide\)\{[\s\S]*?legL\.rotation\.x=legR\.rotation\.x=-1\.5[\s\S]*?model\.position\.y=-0\.34; model\.rotation\.y=CANAL_FERRY\.group\.rotation\.y/.test(HTML),
+  'boarding keeps the character visible in the seated pose and hides only its ground contact shadow');
+ok(/rider:CANAL_FERRY\?\{aboard:!!canalFerryRide,visible:model\.visible,seat:canalFerryRide\?'center':null/.test(HTML)
+  && !/CANAL_FERRY\.group\.add\(model\)/.test(HTML),
+  'debug state exposes the reused center-seat rider while the ferry remains a nine-child craft');
 ok(/nearCanalFerry = \(CANAL_FERRY && !canalFerryRide/.test(HTML)
   && /else if\(nearCanalFerry\) boardCanalFerry\(\)/.test(HTML)
   && /actBtn\.textContent='🛶'/.test(HTML), 'the canal dock owns a walk-up prompt and the shared Enter/mobile action path');


### PR DESCRIPTION
## Summary
- keep the existing player avatar visible and seated on the ferry center bench
- follow the ferry position, bob, and yaw without parenting or creating another character
- reuse the existing seated leg/arm pose and hide only the ground contact blob over water
- expose bounded rider diagnostics while keeping the ferry at nine root children

## Validation
- `node council/test.mjs` — 130 checks
- `node council/test-live.mjs` — 56 checks
- `node scripts/smoke.mjs` — 774 checks
- desktop 1440x900 and mobile 390x844: empty runtime error arrays, seated center rider visible, active cadence ~16.9 ms
- top-down mobile evidence increases light character pixels from 0.29% to 3.50%