### PR TITLE
Add Town Postcard Studio

### DIFF
--- a/assets/town-postcard.js
+++ b/assets/town-postcard.js
@@ -1,0 +1,299 @@
+const PALETTES = Object.freeze([
+  Object.freeze({ name: 'harbor', primary: '#173d55', deep: '#102536', accent: '#f2b84b', paper: '#f7efdf', ink: '#17232b' }),
+  Object.freeze({ name: 'terracotta', primary: '#7d3f32', deep: '#3d2523', accent: '#f0c36c', paper: '#fbefdc', ink: '#2f211d' }),
+  Object.freeze({ name: 'garden', primary: '#2f5b4d', deep: '#18372f', accent: '#e9b95f', paper: '#f2edda', ink: '#1d2b25' }),
+  Object.freeze({ name: 'indigo', primary: '#343b73', deep: '#1d2247', accent: '#e7bd65', paper: '#f4ecdf', ink: '#20233b' }),
+  Object.freeze({ name: 'plum', primary: '#67405d', deep: '#352437', accent: '#edbd72', paper: '#f8ecdf', ink: '#32212e' }),
+  Object.freeze({ name: 'slate', primary: '#365464', deep: '#1b3039', accent: '#e9b665', paper: '#f4eddf', ink: '#1d2b31' })
+]);
+
+export const POSTCARD_FORMATS = Object.freeze({
+  landscape: Object.freeze({ id: 'landscape', width: 1600, height: 1000, bandTop: 610 }),
+  portrait: Object.freeze({ id: 'portrait', width: 1200, height: 1500, bandTop: 930 })
+});
+
+export function hashPostcardSeed(value) {
+  const text = String(value || '');
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function publicRepoIdentity(repo) {
+  return [
+    String(repo?.repo || ''),
+    String(repo?.lang || ''),
+    Math.max(0, Number(repo?.stars) || 0),
+    Math.max(0, Number(repo?.forks) || 0)
+  ].join(':');
+}
+
+export function createTownPostcardIdentity(user, repos = []) {
+  const normalizedUser = String(user || '').trim().toLowerCase();
+  const userHash = hashPostcardSeed(normalizedUser);
+  const repoSignal = repos.map(publicRepoIdentity).sort().join('|');
+  const metadataHash = hashPostcardSeed(normalizedUser + '|' + repoSignal);
+  const letters = normalizedUser.replace(/[^a-z0-9]/g, '').slice(0, 2).toUpperCase() || 'RP';
+  return Object.freeze({
+    hash: metadataHash,
+    paletteIndex: userHash % PALETTES.length,
+    palette: PALETTES[userHash % PALETTES.length],
+    letters,
+    spokes: 6 + (metadataHash % 5),
+    rings: 2 + ((metadataHash >>> 5) % 2),
+    notch: 3 + ((metadataHash >>> 9) % 5)
+  });
+}
+
+export function summarizeTownRepos(repos = []) {
+  const languages = new Map();
+  for (const repo of repos) {
+    const language = String(repo?.lang || '').trim();
+    if (!language || language === 'Other' || language === '\u2014') continue;
+    languages.set(language, (languages.get(language) || 0) + 1);
+  }
+  const languageItems = [...languages.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => (b.count - a.count) || a.name.localeCompare(b.name))
+    .slice(0, 3);
+  if (languageItems.length) return { type: 'languages', items: languageItems };
+
+  const repoItems = repos.slice()
+    .sort((a, b) => ((Number(b?.stars) || 0) - (Number(a?.stars) || 0))
+      || ((Number(b?.forks) || 0) - (Number(a?.forks) || 0))
+      || String(a?.repo || '').localeCompare(String(b?.repo || '')))
+    .slice(0, 3)
+    .map(repo => ({ name: String(repo?.repo || ''), count: Math.max(0, Number(repo?.stars) || 0) }))
+    .filter(item => item.name);
+  return { type: repoItems.length ? 'repos' : 'empty', items: repoItems };
+}
+
+export function postcardFormatForViewport(width, height) {
+  return Number(height) > Number(width) * 1.18 ? POSTCARD_FORMATS.portrait : POSTCARD_FORMATS.landscape;
+}
+
+export function postcardCaptureSize(width, height, maxPixels = 1800000, maxEdge = 1600) {
+  const sourceWidth = Math.max(1, Number(width) || 1);
+  const sourceHeight = Math.max(1, Number(height) || 1);
+  const pixelLimit = Math.max(1, Number(maxPixels) || 1);
+  const edgeLimit = Math.max(1, Number(maxEdge) || 1);
+  const scale = Math.min(
+    edgeLimit / Math.max(sourceWidth, sourceHeight),
+    Math.sqrt(pixelLimit / (sourceWidth * sourceHeight))
+  );
+  const captureWidth = Math.max(1, Math.floor(sourceWidth * scale));
+  const captureHeight = Math.max(1, Math.floor(sourceHeight * scale));
+  return {
+    width: captureWidth,
+    height: captureHeight,
+    pixels: captureWidth * captureHeight
+  };
+}
+
+export function analyzeTownFrame(pixels, width, height) {
+  const total = Math.max(1, Math.floor(Number(width) * Number(height)));
+  const stride = Math.max(1, Math.floor(total / 16000));
+  let samples = 0, opaque = 0, minLuma = 255, maxLuma = 0, sum = 0;
+  for (let pixel = 0; pixel < total; pixel += stride) {
+    const index = pixel * 4;
+    const alpha = pixels[index + 3] || 0;
+    const luma = Math.round((pixels[index] || 0) * 0.2126 + (pixels[index + 1] || 0) * 0.7152 + (pixels[index + 2] || 0) * 0.0722);
+    samples++;
+    if (alpha > 8) opaque++;
+    minLuma = Math.min(minLuma, luma);
+    maxLuma = Math.max(maxLuma, luma);
+    sum += luma;
+  }
+  const opaqueRatio = opaque / Math.max(1, samples);
+  const spread = maxLuma - minLuma;
+  return {
+    samples,
+    opaqueRatio,
+    minLuma,
+    maxLuma,
+    meanLuma: sum / Math.max(1, samples),
+    spread,
+    blank: opaqueRatio < 0.5 || spread < 6
+  };
+}
+
+export function flipPixelRows(pixels, width, height) {
+  const rowBytes = width * 4;
+  const row = new Uint8Array(rowBytes);
+  for (let y = 0; y < Math.floor(height / 2); y++) {
+    const top = y * rowBytes;
+    const bottom = (height - y - 1) * rowBytes;
+    row.set(pixels.subarray(top, top + rowBytes));
+    pixels.copyWithin(top, bottom, bottom + rowBytes);
+    pixels.set(row, bottom);
+  }
+  return pixels;
+}
+
+function roundedPath(ctx, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + width, y, x + width, y + height, r);
+  ctx.arcTo(x + width, y + height, x, y + height, r);
+  ctx.arcTo(x, y + height, x, y, r);
+  ctx.arcTo(x, y, x + width, y, r);
+  ctx.closePath();
+}
+
+function drawCover(ctx, source, width, height) {
+  const sourceRatio = source.width / source.height;
+  const targetRatio = width / height;
+  let sx = 0, sy = 0, sw = source.width, sh = source.height;
+  if (sourceRatio > targetRatio) {
+    sw = source.height * targetRatio;
+    sx = (source.width - sw) / 2;
+  } else {
+    sh = source.width / targetRatio;
+    sy = (source.height - sh) * 0.43;
+  }
+  ctx.drawImage(source, sx, sy, sw, sh, 0, 0, width, height);
+}
+
+function fittedFont(ctx, text, maxWidth, startSize, minSize, weight = 700, family = 'system-ui, sans-serif') {
+  let size = startSize;
+  do {
+    ctx.font = `${weight} ${size}px ${family}`;
+    if (ctx.measureText(text).width <= maxWidth) break;
+    size -= 2;
+  } while (size > minSize);
+  return size;
+}
+
+function drawSeal(ctx, identity, x, y, radius) {
+  const { palette } = identity;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.fillStyle = palette.paper;
+  ctx.strokeStyle = palette.accent;
+  ctx.lineWidth = Math.max(5, radius * 0.055);
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  for (let ring = 1; ring <= identity.rings; ring++) {
+    ctx.globalAlpha = 0.36 + ring * 0.12;
+    ctx.lineWidth = Math.max(2, radius * 0.018);
+    ctx.beginPath();
+    ctx.arc(0, 0, radius * (0.62 - ring * 0.11), 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 0.85;
+  ctx.strokeStyle = palette.primary;
+  ctx.lineWidth = Math.max(3, radius * 0.03);
+  for (let i = 0; i < identity.spokes; i++) {
+    const angle = (i / identity.spokes) * Math.PI * 2;
+    const inner = radius * 0.48;
+    const outer = radius * (0.72 + (i % identity.notch === 0 ? 0.09 : 0));
+    ctx.beginPath();
+    ctx.moveTo(Math.cos(angle) * inner, Math.sin(angle) * inner);
+    ctx.lineTo(Math.cos(angle) * outer, Math.sin(angle) * outer);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = palette.primary;
+  ctx.beginPath();
+  ctx.arc(0, 0, radius * 0.4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = palette.paper;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = `800 ${Math.round(radius * 0.34)}px system-ui, sans-serif`;
+  ctx.fillText(identity.letters, 0, radius * 0.02);
+  ctx.restore();
+}
+
+export function composeTownPostcard(options) {
+  const {
+    canvas, sourceCanvas, format, identity, kicker, title, repoLine,
+    signature, shareUrl, madeWith
+  } = options;
+  const width = format.width, height = format.height;
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d', { alpha: false });
+  if (!ctx) throw new Error('postcard-2d-context');
+  const { palette } = identity;
+
+  ctx.fillStyle = palette.primary;
+  ctx.fillRect(0, 0, width, height);
+  drawCover(ctx, sourceCanvas, width, height);
+
+  const wash = ctx.createLinearGradient(0, format.bandTop - 130, 0, height);
+  wash.addColorStop(0, 'rgba(0,0,0,0)');
+  wash.addColorStop(0.24, palette.deep + 'cc');
+  wash.addColorStop(1, palette.deep);
+  ctx.fillStyle = wash;
+  ctx.fillRect(0, format.bandTop - 130, width, height - format.bandTop + 130);
+
+  ctx.strokeStyle = palette.accent;
+  ctx.lineWidth = format.id === 'portrait' ? 22 : 24;
+  ctx.strokeRect(18, 18, width - 36, height - 36);
+
+  const portrait = format.id === 'portrait';
+  const pad = portrait ? 58 : 64;
+  const sealRadius = portrait ? 100 : 94;
+  const sealX = pad + sealRadius;
+  const sealY = format.bandTop + (height - format.bandTop) * 0.45;
+  drawSeal(ctx, identity, sealX, sealY, sealRadius);
+
+  const textX = sealX + sealRadius + (portrait ? 42 : 48);
+  const textWidth = width - textX - pad;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillStyle = palette.accent;
+  ctx.font = `800 ${portrait ? 27 : 25}px system-ui, sans-serif`;
+  ctx.fillText(String(kicker || '').toUpperCase(), textX, format.bandTop + (portrait ? 66 : 58));
+
+  ctx.fillStyle = palette.paper;
+  fittedFont(ctx, String(title || ''), textWidth, portrait ? 58 : 56, 34, 800);
+  ctx.fillText(String(title || ''), textX, format.bandTop + (portrait ? 137 : 126));
+
+  ctx.globalAlpha = 0.9;
+  fittedFont(ctx, String(repoLine || ''), textWidth, portrait ? 30 : 28, 21, 700);
+  ctx.fillText(String(repoLine || ''), textX, format.bandTop + (portrait ? 196 : 180));
+
+  ctx.globalAlpha = 0.78;
+  fittedFont(ctx, String(signature || ''), textWidth, portrait ? 27 : 25, 19, 600);
+  ctx.fillText(String(signature || ''), textX, format.bandTop + (portrait ? 245 : 226));
+
+  ctx.globalAlpha = 0.72;
+  ctx.fillStyle = palette.paper;
+  ctx.font = `600 ${portrait ? 24 : 22}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+  fittedFont(ctx, String(shareUrl || ''), width - pad * 2 - 260, portrait ? 24 : 22, 16, 600, 'ui-monospace, SFMono-Regular, Menlo, monospace');
+  ctx.fillText(String(shareUrl || ''), pad, height - (portrait ? 58 : 52));
+
+  ctx.textAlign = 'right';
+  ctx.font = `700 ${portrait ? 24 : 22}px system-ui, sans-serif`;
+  ctx.fillStyle = palette.accent;
+  ctx.globalAlpha = 0.84;
+  ctx.fillText(String(madeWith || ''), width - pad, height - (portrait ? 58 : 52));
+  ctx.globalAlpha = 1;
+
+  ctx.strokeStyle = palette.accent;
+  ctx.lineWidth = 2;
+  ctx.globalAlpha = 0.3;
+  roundedPath(ctx, pad - 18, format.bandTop + 22, width - pad * 2 + 36, height - format.bandTop - 105, 28);
+  ctx.stroke();
+  ctx.globalAlpha = 1;
+
+  return { width, height, orientation: format.id, identityHash: identity.hash, palette: identity.palette.name };
+}
+
+export function postcardCanvasToBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    try {
+      canvas.toBlob(blob => blob ? resolve(blob) : reject(new Error('postcard-png-empty')), 'image/png');
+    } catch (error) {
+      reject(error);
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
     #postcardStatus, .postcardPrivacy { margin-inline: 16px; }
     .postcardActions { grid-template-columns: 1fr 1fr; padding: 12px 12px 16px; }
     .postcardActions button { min-height: 46px; font-size: 12px; }
-    #postcardShare { grid-column: 1 / -1; }
+    #postcardShare, #postcardRetake { grid-column: 1 / -1; }
   }
   /* Repository Atelier — one isolated, reusable 3D room */
   #atelierFade { position: fixed; inset: 0; z-index: 90; pointer-events: none; opacity: 0;
@@ -945,10 +945,10 @@
     <div id="postcardStatus" role="status" aria-live="polite" aria-atomic="true"></div>
     <div class="postcardPrivacy" data-i18n="postcardPrivacy">모든 작업은 이 브라우저 안에서만 이뤄지며 이미지는 업로드되지 않아요.</div>
     <div class="postcardActions">
-      <button id="postcardRetake" type="button" data-i18n="postcardRetake">↻ 다시 찍기</button>
       <button id="postcardShare" class="primary" type="button" data-i18n="postcardShare" hidden>공유</button>
       <button id="postcardDownload" class="download" type="button" data-i18n="postcardDownload">PNG 저장</button>
       <button id="postcardCopy" type="button" data-i18n="postcardCopy">링크 복사</button>
+      <button id="postcardRetake" type="button" data-i18n="postcardRetake">↻ 다시 찍기</button>
     </div>
   </section>
 </div>
@@ -1439,6 +1439,7 @@ const I18N = {
     postcardCaptureContext:'WebGL 연결이 끊겨 엽서를 만들 수 없어요. 페이지를 새로고침한 뒤 다시 시도해 주세요.',
     postcardCaptureSecurity:'브라우저 보안 정책(CORS)이 장면 캡처를 막았어요. 링크 복사는 계속 사용할 수 있어요.',
     postcardCaptureError:'엽서를 만들지 못했어요. 링크 복사는 계속 사용할 수 있어요.',
+    postcardMotionBusy:'이동 중에는 카메라가 계속 움직여요. 탑승이 끝난 뒤 엽서를 찍어 주세요.',
     postcardShareDone:'이미지와 링크를 공유했어요.', postcardShareCanceled:'공유를 취소했어요. PNG 저장과 링크 복사는 그대로 사용할 수 있어요.',
     postcardShareFailed:'이 기기에서는 이미지 공유를 완료하지 못했어요. PNG 저장이나 링크 복사를 사용해 주세요.',
     postcardDownloadDone:'PNG를 저장했어요.', postcardDownloadFailed:'PNG를 저장하지 못했어요. 다시 찍어 주세요.',
@@ -1631,6 +1632,7 @@ const I18N = {
     postcardCaptureContext:'The WebGL context was lost. Reload the page, then try again.',
     postcardCaptureSecurity:'The browser security policy (CORS) blocked capture. You can still copy the town link.',
     postcardCaptureError:'The postcard could not be rendered. You can still copy the town link.',
+    postcardMotionBusy:'The camera is moving with your ride. Take the postcard after you get off.',
     postcardShareDone:'Shared the image and town link.', postcardShareCanceled:'Share canceled. Download PNG and Copy link are still available.',
     postcardShareFailed:'This device could not finish sharing the image. Use Download PNG or Copy link instead.',
     postcardDownloadDone:'PNG downloaded.', postcardDownloadFailed:'The PNG could not be downloaded. Retake the postcard and try again.',
@@ -7939,7 +7941,7 @@ const postcardModal=document.getElementById('postcardModal'),postcardStudio=post
   postcardShare=document.getElementById('postcardShare'),postcardDownload=document.getElementById('postcardDownload'),
   postcardCopy=document.getElementById('postcardCopy'),postcardMenuBtn=document.getElementById('postcardMenuBtn');
 const POSTCARD={open:false,busy:false,blob:null,entry:'menu',previousFocus:null,pausedTour:null,renderId:0,renderPromise:null,
-  forceBlank:false,forceFallback:false,activeTargets:0,renders:0,failures:0,last:null,lastStatus:null,resourceBefore:null,resourceAfter:null};
+  forceBlank:false,forceFallback:false,activeTargets:0,renders:0,failures:0,last:null,lastStatus:null,resourceBefore:null,resourceAfter:null,stateRestored:null};
 
 function _postcardShareUrl(){
   const base=location.origin+location.pathname;
@@ -8004,13 +8006,15 @@ function _capturePostcardComposite(){
   const viewWidth=renderer.domElement.clientWidth||innerWidth,viewHeight=renderer.domElement.clientHeight||innerHeight;
   const size=postcardCaptureSize(viewWidth,viewHeight),pixels=new Uint8Array(size.width*size.height*4);
   const savedTarget=renderer.getRenderTarget(),savedAutoClear=renderer.autoClear;
+  const outputPass=finalComposer.passes[1],savedMixToScreen=finalMix.renderToScreen,
+    savedOutputToScreen=outputPass.renderToScreen,savedOutputTexture=outputPass.uniforms.tDiffuse.value;
   let target=null,captureComposer=null;
   POSTCARD.resourceBefore=_postcardRendererMemory();
   try{
     target=new THREE.WebGLRenderTarget(size.width,size.height,{type:THREE.UnsignedByteType,format:THREE.RGBAFormat,depthBuffer:false,stencilBuffer:false});
     target.texture.name='TownPostcardCapture';
     captureComposer=new EffectComposer(renderer,target); captureComposer.renderToScreen=false; captureComposer.setPixelRatio(1);
-    captureComposer.addPass(finalMix); captureComposer.addPass(finalComposer.passes[1]);
+    captureComposer.addPass(finalMix); captureComposer.addPass(outputPass);
     POSTCARD.activeTargets+=2; captureComposer.render(0);
     renderer.readRenderTargetPixels(captureComposer.readBuffer,0,0,size.width,size.height,pixels);
     if(POSTCARD.forceBlank) pixels.fill(0);
@@ -8023,6 +8027,10 @@ function _capturePostcardComposite(){
     return {canvas:source,width:size.width,height:size.height,stats};
   }finally{
     renderer.autoClear=savedAutoClear; renderer.setRenderTarget(savedTarget);
+    finalMix.renderToScreen=savedMixToScreen; outputPass.renderToScreen=savedOutputToScreen; outputPass.uniforms.tDiffuse.value=savedOutputTexture;
+    POSTCARD.stateRestored={rendererTarget:renderer.getRenderTarget()===savedTarget,autoClear:renderer.autoClear===savedAutoClear,
+      mixToScreen:finalMix.renderToScreen===savedMixToScreen,outputToScreen:outputPass.renderToScreen===savedOutputToScreen,
+      outputTexture:outputPass.uniforms.tDiffuse.value===savedOutputTexture};
     if(captureComposer){ captureComposer.renderTarget1.dispose(); captureComposer.renderTarget2.dispose(); captureComposer.copyPass.material.dispose(); }
     if(POSTCARD.activeTargets) POSTCARD.activeTargets=Math.max(0,POSTCARD.activeTargets-2);
     POSTCARD.resourceAfter=_postcardRendererMemory();
@@ -8070,6 +8078,7 @@ async function renderTownPostcard(trigger='retake'){
 
 function openPostcardStudio(entry='menu'){
   if(repositoryAtelierActive()||(modalOpen&&!POSTCARD.open)) return false;
+  if(ride||ferris||carousel||canalFerryRide||performance.now()<ridePostActionUntil){ showWave(t('postcardMotionBusy'),2800); return false; }
   if(POSTCARD.open) return true;
   POSTCARD.open=true; POSTCARD.entry=['menu','kiosk','debug'].includes(entry)?entry:'menu';
   POSTCARD.previousFocus=POSTCARD.entry==='menu'?menuBtn:document.activeElement;
@@ -8095,6 +8104,7 @@ function _postcardDebugState(){
     ready:!!POSTCARD.blob,shareMode:_postcardCanShare()?'native':'fallback',activeTargets:POSTCARD.activeTargets,
     resources:{before,after,delta:{geometries:(after.geometries||0)-(before.geometries||0),
       textures:(after.textures||0)-(before.textures||0),programs:(after.programs||0)-(before.programs||0)}},
+    stateRestored:POSTCARD.stateRestored?{...POSTCARD.stateRestored}:null,
     canvas:{width:postcardCanvas.width,height:postcardCanvas.height},identity:{hash:identity.hash,palette:identity.palette.name,
       letters:identity.letters,spokes:identity.spokes,rings:identity.rings,notch:identity.notch},
     url:_postcardShareUrl(),last:POSTCARD.last?{...POSTCARD.last}:null};
@@ -8727,18 +8737,18 @@ async function sendChat(){ const q=chatText.value.trim(); if(!q||busy) return; b
     if(!_drainQueuedChat()&&!_resumePendingChatNpc()&&!repositoryAtelierActive()&&!chatEl.classList.contains('hidden')) chatText.focus(); } }
 
 /* ---- taxi ride: the cab drives to you, picks you up, carries you there ---- */
-let ride=null; // {repo, phase:'coming'|'boarding'|'riding'|'arriving', t}
+let ride=null, ridePostActionUntil=0; // ride phases plus a brief guard for delayed arrival UI
 function driveTaxiToward(px,pz,speed,dt,stop=0){
   const dx=px-taxi.position.x, dz=pz-taxi.position.z, dd=Math.hypot(dx,dz);
   if(dd>stop+0.01){ const step=Math.min(dd-stop, speed*dt); taxi.position.x+=dx/dd*step; taxi.position.z+=dz/dd*step;
     taxi.rotation.y=lerpA(taxi.rotation.y, Math.atan2(-dz,dx), 0.2); }
   return dd;
 }
-function taxiTo(repo){ standUp(); ride={repo, phase:'coming', t:0}; setNav(repo); closeChat(); freeLook=false; model.visible=true;
+function taxiTo(repo){ standUp(); ridePostActionUntil=0; ride={repo, phase:'coming', t:0}; setNav(repo); closeChat(); freeLook=false; model.visible=true;
   if(document.activeElement&&document.activeElement.blur) document.activeElement.blur();
   driveNameEl.textContent=repo.label; driveBar.style.display='flex'; }
-function endDrive(){ if(ride){ taxi.position.copy(TAXI_POS); taxi.rotation.y=-0.85; } ride=null; driveBar.style.display='none'; model.visible=true; }
-function arriveTaxi(repo){ ride=null; driveBar.style.display='none'; model.visible=true; _settleClearSightArrival(repo);
+function endDrive(){ if(ride){ taxi.position.copy(TAXI_POS); taxi.rotation.y=-0.85; } ride=null; ridePostActionUntil=0; driveBar.style.display='none'; model.visible=true; }
+function arriveTaxi(repo){ ride=null; ridePostActionUntil=0; driveBar.style.display='none'; model.visible=true; _settleClearSightArrival(repo);
   if(repo._courseResident){ const L=_residentLive(repo._courseResident), res=L&&L.res; if(L&&res){ const met=courseMark('resident',res.id); openChat(L._npc);
       if(met) showWave(tf('chronicleMet',{name:(res[LANG]||res.ko).name}),2800); } else openChat(); return; }
   openChat();
@@ -8758,14 +8768,14 @@ function arriveTaxi(repo){ ride=null; driveBar.style.display='none'; model.visib
   if(repo._landmark){
     const k=repo._landmark, key='lmArrive'+k.charAt(0).toUpperCase()+k.slice(1);
     addMsg('bot', t(key)||(LANG==='ko'?`🚕 <b>${repo.label}</b>에 도착했어요!`:`🚕 We've arrived at <b>${repo.label}</b>!`), {noHist:true});
-    if(k==='chrono') setTimeout(()=>{ try{ openChrono(repo._chronoPreset||undefined); }catch(e){} }, 700);
-    if(k==='obs') setTimeout(()=>{ try{ openObservatory(); }catch(e){} }, 700);
-    if(k==='ferris') setTimeout(()=>{ try{ boardFerris(); }catch(e){} }, 800);
-    if(k==='carousel') setTimeout(()=>{ try{ boardCarousel(); }catch(e){} }, 800);
+    if(k==='chrono'){ ridePostActionUntil=performance.now()+900; setTimeout(()=>{ try{ openChrono(repo._chronoPreset||undefined); }catch(e){} }, 700); }
+    if(k==='obs'){ ridePostActionUntil=performance.now()+900; setTimeout(()=>{ try{ openObservatory(); }catch(e){} }, 700); }
+    if(k==='ferris'){ ridePostActionUntil=performance.now()+1000; setTimeout(()=>{ try{ boardFerris(); }catch(e){} }, 800); }
+    if(k==='carousel'){ ridePostActionUntil=performance.now()+1000; setTimeout(()=>{ try{ boardCarousel(); }catch(e){} }, 800); }
     return;
   }
   addMsg('bot',(LANG==='ko'?`🚕 <b>${repo.label}</b> 집에 도착했어요! 문을 열어드릴게요 🚪`:`🚕 We've arrived at <b>${repo.label}</b>! Opening the door for you 🚪`),{noHist:true});
-  setTimeout(()=>openCard(repo),500); }
+  ridePostActionUntil=performance.now()+700; setTimeout(()=>openCard(repo),500); }
 
 /* ---- 🗺️ World map / minimap v1 — district overview + click/tap to ride to a district centre ---- */
 var _mapReady=false;                                                 // hoisted flag: applyLang() runs before this module, so gate its syncMapChrome() call

--- a/index.html
+++ b/index.html
@@ -51,6 +51,16 @@
   #panel.hidden { opacity: 0; transform: scale(.94); pointer-events: none; }
   #panel h3 { font-size: 12px; letter-spacing: .04em; text-transform: uppercase; color: #b08a5e;
     padding: 4px 8px 10px; }
+  #postcardMenuBtn { width: 100%; min-height: 48px; margin: 0 0 9px; padding: 8px 10px; border: 1px solid #dfc9a6;
+    border-radius: 12px; background: linear-gradient(135deg,#fffaf0,#f3e3ca); color: #5a3b24; cursor: pointer;
+    display: flex; align-items: center; gap: 10px; text-align: left; font: inherit; }
+  #postcardMenuBtn:hover { border-color: #c89b62; background: linear-gradient(135deg,#fffdf7,#efdbbc); }
+  #postcardMenuBtn:active { transform: translateY(1px); }
+  #postcardMenuBtn .pmIcon { flex: 0 0 auto; width: 32px; height: 32px; border-radius: 10px; display: grid; place-items: center;
+    color: #fff8e7; background: linear-gradient(145deg,#365464,#173d55); box-shadow: inset 0 0 0 1px rgba(255,255,255,.18); font-size: 17px; }
+  #postcardMenuBtn .pmCopy { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+  #postcardMenuBtn .pmTitle { font-size: 12.5px; font-weight: 800; color: #4a2f1e; }
+  #postcardMenuBtn .pmSub { font-size: 10.5px; color: #9b7c59; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .repoRow { display: flex; align-items: center; gap: 10px; padding: 9px 8px; border-radius: 12px;
     cursor: pointer; transition: background .12s; }
   .repoRow:hover { background: #f6ecdb; }
@@ -268,6 +278,60 @@
   .btn.atelier:disabled { cursor: default; opacity: .72; }
   .btn.close { flex: 0 0 auto; min-width: 0; background: #f1e6d6; color: #6a523d; }
   .btn.chrono { background: linear-gradient(135deg,#4b3b8f,#6b4fb0); color: #fff; }
+  /* Town Postcard Studio — one local canvas artifact, never uploaded */
+  #postcardModal { position: fixed; inset: 0; z-index: 35; display: none; align-items: center; justify-content: center;
+    padding: max(14px,env(safe-area-inset-top,0px)) max(14px,env(safe-area-inset-right,0px))
+      max(14px,env(safe-area-inset-bottom,0px)) max(14px,env(safe-area-inset-left,0px));
+    background: rgba(18,19,24,.68); backdrop-filter: blur(7px); }
+  #postcardModal.show { display: flex; }
+  .postcardStudio { --postcard-primary:#173d55; --postcard-accent:#f2b84b; position: relative; width: min(760px,100%);
+    max-height: calc(100dvh - 28px); overflow-y: auto; border-radius: 24px; background: #fffaf0; color: #33281f;
+    box-shadow: 0 28px 90px rgba(0,0,0,.48); animation: pop .22s cubic-bezier(.2,.9,.3,1.12); }
+  .postcardStudio:focus { outline: none; }
+  .postcardClose { position: absolute; z-index: 2; top: 12px; right: 12px; width: 44px; height: 44px; border: 0;
+    border-radius: 999px; display: grid; place-items: center; cursor: pointer; background: rgba(255,255,255,.88);
+    color: #4a3425; font-size: 17px; box-shadow: 0 4px 15px rgba(20,18,14,.18); }
+  .postcardHead { padding: 20px 66px 14px 22px; border-bottom: 1px solid #eadbc5; }
+  .postcardHead .pk { color: var(--postcard-primary); font-size: 10.5px; font-weight: 900; letter-spacing: .12em; }
+  .postcardHead h2 { margin: 3px 0 3px; font-size: 21px; color: #3f2b1f; }
+  .postcardHead p { margin: 0; color: #8a6f52; font-size: 12px; line-height: 1.45; }
+  #postcardPreview { position: relative; min-height: 260px; margin: 16px 18px 10px; border-radius: 16px; overflow: hidden;
+    display: grid; place-items: center; background: linear-gradient(145deg,var(--postcard-primary),#172431);
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.14),0 8px 24px rgba(30,25,18,.18); }
+  #postcardCanvas { display: none; width: 100%; max-height: min(48vh,520px); object-fit: contain; background: #172431; }
+  #postcardPreview.ready #postcardCanvas { display: block; }
+  .postcardBusy { display: none; align-items: center; gap: 10px; padding: 22px; color: #fff8e9; font-size: 13px; font-weight: 700; text-align: center; }
+  #postcardPreview.busy .postcardBusy, #postcardPreview.error .postcardBusy { display: flex; }
+  #postcardPreview.error .postcardBusy { color: #ffe4d9; }
+  .postcardSpinner { width: 20px; height: 20px; flex: 0 0 auto; border: 3px solid rgba(255,255,255,.28);
+    border-top-color: var(--postcard-accent); border-radius: 50%; animation: postcardSpin .8s linear infinite; }
+  #postcardPreview.error .postcardSpinner { display: none; }
+  @keyframes postcardSpin { to { transform: rotate(360deg); } }
+  #postcardStatus { min-height: 20px; margin: 0 22px; color: #6c5847; font-size: 11.5px; line-height: 1.45; }
+  #postcardStatus.error { color: #b44530; font-weight: 700; }
+  #postcardStatus.success { color: #2f7d5b; font-weight: 700; }
+  .postcardPrivacy { margin: 8px 22px 0; color: #a08464; font-size: 10.5px; line-height: 1.45; }
+  .postcardActions { padding: 14px 18px 20px; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 8px; }
+  .postcardActions button { min-height: 46px; border: 0; border-radius: 12px; padding: 9px 10px; cursor: pointer;
+    font: 800 12px/1.25 inherit; color: #4c3827; background: #efe3d2; }
+  .postcardActions button:hover:not(:disabled) { filter: brightness(.97); transform: translateY(-1px); }
+  .postcardActions button:active:not(:disabled) { transform: translateY(1px); }
+  .postcardActions button:disabled { cursor: wait; opacity: .48; }
+  .postcardActions .primary { color: #fff; background: linear-gradient(145deg,var(--postcard-primary),#203744); }
+  .postcardActions .download { color: #3d2b13; background: linear-gradient(145deg,var(--postcard-accent),#e2a63e); }
+  .postcardActions [hidden] { display: none; }
+  @media (max-width: 520px) {
+    .postcardStudio { max-height: calc(100dvh - 20px); border-radius: 20px; }
+    .postcardHead { padding: 16px 58px 11px 16px; }
+    .postcardHead h2 { font-size: 18px; }
+    .postcardHead p { font-size: 11px; }
+    #postcardPreview { min-height: 230px; margin: 11px 12px 8px; }
+    #postcardCanvas { max-height: 49vh; }
+    #postcardStatus, .postcardPrivacy { margin-inline: 16px; }
+    .postcardActions { grid-template-columns: 1fr 1fr; padding: 12px 12px 16px; }
+    .postcardActions button { min-height: 46px; font-size: 12px; }
+    #postcardShare { grid-column: 1 / -1; }
+  }
   /* Repository Atelier — one isolated, reusable 3D room */
   #atelierFade { position: fixed; inset: 0; z-index: 90; pointer-events: none; opacity: 0;
     background: #11171a; will-change: opacity; }
@@ -768,7 +832,7 @@
   }
   /* ---- respect prefers-reduced-motion: keep every bit of info, drop the looping motion ---- */
   @media (prefers-reduced-motion: reduce) {
-    #trainOverlay .rail, #trainOverlay .train, .msg .tdots i, a.libitem { animation: none !important; }
+    #trainOverlay .rail, #trainOverlay .train, .msg .tdots i, a.libitem, .postcardSpinner { animation: none !important; }
     .msg .tdots i { opacity: .6; }
     a.libitem { opacity: 1; }
   }
@@ -811,10 +875,14 @@
   <div class="badge" id="liveBadge" title="online now · entries today · total entries · all-time unique guests · UTC">🟢 <b id="liveCount">1</b><span id="entryWrap" style="display:none;"> · <span class="hudFull" data-i18n="entriesTodayWord">오늘 입장</span><span class="hudShort" data-i18n="entriesTodayShort">입장</span> <b id="entryCount">0</b><span data-i18n="entriesUnit">회</span></span><span id="entryTotalWrap" style="display:none;"> · <span class="hudFull" data-i18n="entriesTotalWord">누적 입장</span><span class="hudShort" data-i18n="entriesTotalShort">누적</span> <b id="entryTotalCount">0</b><span data-i18n="entriesUnit">회</span></span><span id="allWrap" style="display:none;"> · <span data-i18n="uniqueWord">고유</span> <b id="allCount">0</b><span data-i18n="peopleUnit">명</span></span></div>
   <div class="badge" id="navBadge" style="display:none;">🧭 <span id="navName"></span> · <span id="navDist"></span>m</div>
 </div>
-<button id="menuBtn">☰<span class="dot"></span></button>
+<button id="menuBtn" type="button" aria-controls="panel" aria-expanded="false" data-i18n-aria="wayfinding">☰<span class="dot"></span></button>
 
 <div id="panel" class="hidden">
   <h3>Repolis · <span data-i18n="wayfinding">길찾기</span></h3>
+  <button id="postcardMenuBtn" type="button">
+    <span class="pmIcon" aria-hidden="true">📸</span>
+    <span class="pmCopy"><span class="pmTitle" data-i18n="postcardMenu">타운 엽서 만들기</span><span class="pmSub" data-i18n="postcardMenuSub">지금 보이는 마을을 PNG로</span></span>
+  </button>
   <input id="repoSearch" type="text" placeholder="레포·언어·주제 검색…" data-i18n-ph="searchPh" autocomplete="off" />
   <div id="repoList"></div>
 </div>
@@ -860,6 +928,29 @@
     <div class="shome" id="stationHome" style="display:none;"></div>
   </div>
   <div class="sshare"><button id="shareBtn" data-i18n="copyLink">🔗 링크 복사</button></div>
+</div>
+
+<div id="postcardModal" role="dialog" aria-modal="true" aria-labelledby="postcardTitle" aria-describedby="postcardSub" aria-hidden="true">
+  <section class="postcardStudio" tabindex="-1">
+    <button id="postcardClose" class="postcardClose" type="button" data-i18n-aria="close" aria-label="닫기">✕</button>
+    <header class="postcardHead">
+      <div class="pk" data-i18n="postcardKicker">TOWN POSTCARD STUDIO</div>
+      <h2 id="postcardTitle" data-i18n="postcardTitle">타운 엽서 스튜디오</h2>
+      <p id="postcardSub" data-i18n="postcardSub">현재 카메라에 보이는 실제 마을을 엽서로 만들어요.</p>
+    </header>
+    <div id="postcardPreview" class="busy">
+      <canvas id="postcardCanvas" role="img" data-i18n-aria="postcardCanvasAria" aria-label="생성된 타운 엽서"></canvas>
+      <div class="postcardBusy" aria-hidden="true"><span class="postcardSpinner"></span><span id="postcardBusyText" data-i18n="postcardRendering">현재 마을 풍경을 현상하는 중…</span></div>
+    </div>
+    <div id="postcardStatus" role="status" aria-live="polite" aria-atomic="true"></div>
+    <div class="postcardPrivacy" data-i18n="postcardPrivacy">모든 작업은 이 브라우저 안에서만 이뤄지며 이미지는 업로드되지 않아요.</div>
+    <div class="postcardActions">
+      <button id="postcardRetake" type="button" data-i18n="postcardRetake">↻ 다시 찍기</button>
+      <button id="postcardShare" class="primary" type="button" data-i18n="postcardShare" hidden>공유</button>
+      <button id="postcardDownload" class="download" type="button" data-i18n="postcardDownload">PNG 저장</button>
+      <button id="postcardCopy" type="button" data-i18n="postcardCopy">링크 복사</button>
+    </div>
+  </section>
 </div>
 
 <div id="trainOverlay">
@@ -1073,6 +1164,7 @@ import { createRepolisHero, REPOLIS_FACTORY_REVISION } from './assets/world-tree
 import { CAMERA_OBSTRUCTION_DEFAULTS, CAMERA_ARRIVAL_OFFSETS, resolveCameraObstruction, stepCameraResolvedDistance, chooseCameraArrivalYaw } from './assets/camera-obstruction.js?v=clearsight-v1';
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from './assets/canal-ferry.js?v=petite-venise-ferry-v1';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from './assets/rain-garden.js?v=weather-bell-v1';
+import { analyzeTownFrame, composeTownPostcard, createTownPostcardIdentity, flipPixelRows, postcardCanvasToBlob, postcardCaptureSize, postcardFormatForViewport, summarizeTownRepos } from './assets/town-postcard.js?v=town-postcard-v1';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -1336,6 +1428,24 @@ const I18N = {
     publicNetMsg:'마을을 불러오지 못했어요. 연결을 확인하고 다시 시도해 주세요.',
     stationRetry:'🚉 다른 마을 가기', goOwnerCity:'🏙️ {user} 님의 도시 가기',
     shareTown:'이 마을 공유', copyLink:'🔗 링크 복사', copied:'복사됨!',
+    postcardMenu:'타운 엽서 만들기', postcardMenuSub:'지금 보이는 마을을 PNG로',
+    postcardKiosk:'타운 포토 키오스크', postcardReached:' — 지금 보이는 마을을 엽서로 남기는 포토 키오스크. <span class="key">Enter</span> 또는 클릭으로 열기',
+    postcardKicker:'TOWN POSTCARD STUDIO', postcardTitle:'타운 엽서 스튜디오', postcardSub:'현재 카메라에 보이는 실제 마을을 엽서로 만들어요.',
+    postcardCanvasAria:'생성된 타운 엽서', postcardRendering:'현재 마을 풍경을 현상하는 중…', postcardReady:'엽서가 준비됐어요. 기기에서 공유하거나 PNG로 저장하세요.',
+    postcardRetake:'↻ 다시 찍기', postcardShare:'공유', postcardDownload:'PNG 저장', postcardCopy:'링크 복사',
+    postcardPrivacy:'모든 작업은 이 브라우저 안에서만 이뤄지며 이미지는 업로드되지 않아요.',
+    postcardFallback:'이 기기는 이미지 공유를 지원하지 않아 PNG 저장과 링크 복사를 사용할 수 있어요.',
+    postcardCaptureBlank:'WebGL 장면이 비어 있어 엽서를 만들지 못했어요. 카메라를 조금 움직인 뒤 다시 찍어 주세요.',
+    postcardCaptureContext:'WebGL 연결이 끊겨 엽서를 만들 수 없어요. 페이지를 새로고침한 뒤 다시 시도해 주세요.',
+    postcardCaptureSecurity:'브라우저 보안 정책(CORS)이 장면 캡처를 막았어요. 링크 복사는 계속 사용할 수 있어요.',
+    postcardCaptureError:'엽서를 만들지 못했어요. 링크 복사는 계속 사용할 수 있어요.',
+    postcardShareDone:'이미지와 링크를 공유했어요.', postcardShareCanceled:'공유를 취소했어요. PNG 저장과 링크 복사는 그대로 사용할 수 있어요.',
+    postcardShareFailed:'이 기기에서는 이미지 공유를 완료하지 못했어요. PNG 저장이나 링크 복사를 사용해 주세요.',
+    postcardDownloadDone:'PNG를 저장했어요.', postcardDownloadFailed:'PNG를 저장하지 못했어요. 다시 찍어 주세요.',
+    postcardCopied:'마을 링크를 복사했어요.', postcardCopyFailed:'링크를 복사하지 못했어요. 아래 엽서의 URL을 직접 사용해 주세요.',
+    postcardRepoCount:'공개 저장소 {count}개', postcardTopLanguages:'주요 언어', postcardTopRepos:'대표 저장소',
+    postcardNoSignal:'공개 저장소로 지은 나만의 마을', postcardMadeWith:'Made with RePolis',
+    postcardShareTitle:'@{user}의 RePolis 마을', postcardShareText:'공개 GitHub 저장소로 만든 RePolis 마을 엽서',
     hint:'집(레포)으로 걸어가 보세요 · ☰ 길찾기 · 🚕 깃버에게 물어보기',
     drivePre:'🚕 ', drivePost:' (으)로 가는 중…', stop:'🛑 꾹 눌러 내리기',
     taxiTitle:'🚕 깃버',
@@ -1510,6 +1620,24 @@ const I18N = {
     publicNetMsg:"Couldn't load the town. Check your connection and try again.",
     stationRetry:'🚉 Visit another town', goOwnerCity:"🏙️ Visit {user}'s city",
     shareTown:'Share this town', copyLink:'🔗 Copy link', copied:'Copied!',
+    postcardMenu:'Make a town postcard', postcardMenuSub:'Turn this live view into a PNG',
+    postcardKiosk:'Town Photo Kiosk', postcardReached:' — turn the town in your current camera into a postcard. Press <span class="key">Enter</span> or click to open',
+    postcardKicker:'TOWN POSTCARD STUDIO', postcardTitle:'Town Postcard Studio', postcardSub:'Make a postcard from the real town currently in your camera.',
+    postcardCanvasAria:'Generated town postcard', postcardRendering:'Developing the current town view…', postcardReady:'Your postcard is ready. Share it from this device or save the PNG.',
+    postcardRetake:'↻ Retake', postcardShare:'Share', postcardDownload:'Download PNG', postcardCopy:'Copy link',
+    postcardPrivacy:'Everything stays in this browser. The image is never uploaded.',
+    postcardFallback:'This device cannot share an image file, so Download PNG and Copy link remain available.',
+    postcardCaptureBlank:'The WebGL frame was blank. Move the camera a little, then retake the postcard.',
+    postcardCaptureContext:'The WebGL context was lost. Reload the page, then try again.',
+    postcardCaptureSecurity:'The browser security policy (CORS) blocked capture. You can still copy the town link.',
+    postcardCaptureError:'The postcard could not be rendered. You can still copy the town link.',
+    postcardShareDone:'Shared the image and town link.', postcardShareCanceled:'Share canceled. Download PNG and Copy link are still available.',
+    postcardShareFailed:'This device could not finish sharing the image. Use Download PNG or Copy link instead.',
+    postcardDownloadDone:'PNG downloaded.', postcardDownloadFailed:'The PNG could not be downloaded. Retake the postcard and try again.',
+    postcardCopied:'Town link copied.', postcardCopyFailed:'The link could not be copied. Use the exact URL printed on the postcard.',
+    postcardRepoCount:'{count} public repositories', postcardTopLanguages:'Top languages', postcardTopRepos:'Top repositories',
+    postcardNoSignal:'A personal town built from public repositories', postcardMadeWith:'Made with RePolis',
+    postcardShareTitle:"@{user}'s RePolis town", postcardShareText:'A RePolis town postcard built from public GitHub repositories',
     hint:'Walk up to a house (repo) · ☰ Wayfinding · 🚕 Ask Gitber',
     drivePre:'🚕 Driving to ', drivePost:'…', stop:'🛑 Hold to get off',
     taxiTitle:'🚕 Gitber',
@@ -1615,6 +1743,8 @@ function applyLang(){
   if(typeof refreshHubSigns==='function') refreshHubSigns();
   if(typeof refreshResidentTags==='function') refreshResidentTags();
   if(typeof refreshResidentHomeSigns==='function') refreshResidentHomeSigns();
+  if(typeof refreshPostcardKioskSign==='function') refreshPostcardKioskSign();
+  if(typeof window.__postcardLangRefresh==='function') window.__postcardLangRefresh();
   { const _zb=document.getElementById('zoneBoard'); if(typeof renderZoneBoard==='function' && _zb && _zb.classList.contains('show') && _zb._zid) renderZoneBoard(_zb._zid); }
   if(_mapReady && typeof syncMapChrome==='function') syncMapChrome();
   if(typeof window.__updateLiveTitle==='function') window.__updateLiveTitle();
@@ -4652,8 +4782,15 @@ const OBS_POS = new THREE.Vector3(203, 0, 22);   // east clearing (r≈204 < pla
 let OBS=null, nearObs=null, obsScope=null;
 let FERRIS=null, nearFerris=null, ferris=null;   // 🎡 grand Ferris wheel — board it to ride up high for a whole-village panorama
 let CAROUSEL=null, nearCarousel=null, carousel=null;   // 🎠 carousel — board a horse for a gentle spin-and-bob at the ESE funfair
-/* ───────── 🚉 GitHub Station — civic landmark beside the taxi stand; board a train to any public user's town (visual-only prop, non-colliding) ───────── */
+/* ───────── civic arrival landmarks — visual-only props keep the busy plaza walkable ───────── */
 let STATION=null, nearStation=null, openStationModal=()=>{};
+let POSTCARD_KIOSK=null, nearPostcardKiosk=null;
+function refreshPostcardKioskSign(){
+  if(!POSTCARD_KIOSK) return;
+  const map=POSTCARD_KIOSK._signMaps[LANG]||POSTCARD_KIOSK._signMaps.en;
+  POSTCARD_KIOSK._boards.forEach(board=>{ board.material.map=map; board.material.needsUpdate=true; });
+  POSTCARD_KIOSK.label=t('postcardKiosk');
+}
 (function buildObservatory(){
   const og=new THREE.Group(); og.position.copy(OBS_POS);
   og.rotation.y=Math.atan2(-OBS_POS.x,-OBS_POS.z);   // local +Z faces the town centre (the arrival side)
@@ -5465,6 +5602,32 @@ NPCS.push({ group:driver, pos:driver.position.clone(), kind:'taxi', reach:4.6 })
   // gold destination ring on the ground (matches the other landmarks)
   const ring=new THREE.Mesh(new THREE.RingGeometry(2.5,2.8,32), new THREE.MeshBasicMaterial({color:0xe8c061,transparent:true,opacity:0.5,side:THREE.DoubleSide})); ring.rotation.x=-Math.PI/2; ring.position.y=0.06; g.add(ring);
   STATION={ _isStation:true, _pos:SP.clone(), label:t('stationLm'), _group:g };
+})();
+
+/* ---- 📸 Town Photo Kiosk — the current live camera becomes a local PNG postcard. ---- */
+(function buildPostcardKiosk(){
+  const KP=new THREE.Vector3(-9.5,0,14.5), NAVY=0x294b5c, DEEP=0x173342, BRASS=0xe2b45f, CREAM=0xf5ead7;
+  const g=new THREE.Group(); g.position.copy(KP); g.rotation.y=Math.atan2(-KP.x,-KP.z); scene.add(g);
+  const base=new THREE.Mesh(new THREE.CylinderGeometry(1.65,1.85,0.28,24),toon(0xcdbfa6)); base.position.y=0.14; base.receiveShadow=true; g.add(base);
+  const body=rbox(2.5,2.35,0.86,NAVY,0.16); body.position.y=1.48; outline(body,0.035); g.add(body);
+  const inset=rbox(1.92,1.25,0.08,CREAM,0.12); inset.position.set(0,1.63,0.47); g.add(inset);
+  const lens=new THREE.Mesh(new THREE.CylinderGeometry(0.42,0.42,0.3,24),toon(DEEP)); lens.rotation.x=Math.PI/2; lens.position.set(0,1.87,0.69); g.add(lens);
+  const lensRing=new THREE.Mesh(new THREE.TorusGeometry(0.46,0.08,10,28),toon(BRASS)); lensRing.position.set(0,1.87,0.87); g.add(lensRing);
+  const glass=new THREE.Mesh(new THREE.CircleGeometry(0.31,24),new THREE.MeshBasicMaterial({color:0x8fc9d9,transparent:true,opacity:0.86}));
+  glass.position.set(0,1.87,0.93); g.add(glass);
+  const shutter=rbox(0.54,0.18,0.12,BRASS,0.06); shutter.position.set(0,1.08,0.54); g.add(shutter);
+  const slot=rbox(1.32,0.13,0.1,DEEP,0.03); slot.position.set(0,0.65,0.52); g.add(slot);
+  const print=rbox(1.12,0.62,0.06,0xfffaf0,0.04); print.position.set(0,0.34,0.58); print.rotation.x=-0.12; g.add(print);
+  const roof=rbox(3.05,0.24,1.35,BRASS,0.08); roof.position.y=2.85; outline(roof,0.03); g.add(roof);
+  const signMaps={ko:signTexture(I18N.ko.postcardKiosk,NAVY),en:signTexture(I18N.en.postcardKiosk,NAVY)};
+  const board=new THREE.Mesh(new THREE.PlaneGeometry(2.55,0.87),new THREE.MeshBasicMaterial({map:signMaps[LANG],transparent:true}));
+  board.position.set(0,3.42,0.7); g.add(board);
+  const board2=board.clone(); board2.position.z=-0.7; board2.rotation.y=Math.PI; g.add(board2);
+  const halo=new THREE.Sprite(new THREE.SpriteMaterial({map:GLOW_TEX,color:0xffdf9a,transparent:true,opacity:0,depthWrite:false,fog:false,blending:THREE.AdditiveBlending}));
+  halo.scale.set(3.1,3.1,1); halo.position.set(0,2.3,0); halo._nightOp=0.68; g.add(halo); LAMP_GLOWS.push(halo);
+  const ring=new THREE.Mesh(new THREE.RingGeometry(1.85,2.12,32),new THREE.MeshBasicMaterial({color:BRASS,transparent:true,opacity:0.5,side:THREE.DoubleSide}));
+  ring.rotation.x=-Math.PI/2; ring.position.y=0.05; g.add(ring);
+  POSTCARD_KIOSK={_isPostcardKiosk:true,_pos:KP.clone(),label:t('postcardKiosk'),_group:g,_boards:[board,board2],_signMaps:signMaps};
 })();
 
 // 📘 Microsoft Docs engineer — answers from the live Microsoft Learn MCP server (official docs)
@@ -6833,7 +6996,7 @@ addEventListener('keydown',e=>{ if(isTyping()||isUiKeyTarget(e)) return;
   keys[e.code]=true;
   if(e.code==='Space') e.preventDefault();
   if(e.code==='Enter'&&!modalOpen){ doAct(); }
-  if(e.code==='Escape'){ closeCard(); closeChat(); } });
+  if(e.code==='Escape'){ closePostcardStudio(); closeCard(); closeChat(); } });
 addEventListener('keyup',e=>{ keys[e.code]=false; });   /* always clear — never let a key stick when focus jumps to an input mid-press */
 addEventListener('blur',clearKeys); window.addEventListener('pagehide',clearKeys);
 document.addEventListener('visibilitychange',()=>{ if(document.hidden){ clearKeys(); if(_sharedJoy) _endSharedJoy('hidden'); } });   /* tab/alt-tab away mid-press → don't keep walking or resume an excursion that lost its frames */
@@ -7028,7 +7191,8 @@ actBtn.addEventListener('click',()=>{ if(modalOpen) return; doAct(); });
 /* ====================== UI ====================== */
 document.getElementById('totalCount').textContent=REPOS.length;
 const panel=document.getElementById('panel');
-document.getElementById('menuBtn').onclick=()=> panel.classList.toggle('hidden');
+const menuBtn=document.getElementById('menuBtn');
+menuBtn.onclick=()=>{ const hidden=panel.classList.toggle('hidden'); menuBtn.setAttribute('aria-expanded',String(!hidden)); };
 
 /* ───────── 🛂 Explorer Passport — local-only visit stamps (no server, no PII) ───────── */
 const PASSPORT_KEY='repolisPassport';
@@ -7298,7 +7462,7 @@ function tourCap(dot,html){ const e=document.getElementById('tourCap'); if(!e) r
   document.getElementById('tourDot').textContent=dot; document.getElementById('tourTxt').innerHTML=html; e.classList.remove('hidden'); }
 function hideTourCap(){ const e=document.getElementById('tourCap'); if(e) e.classList.add('hidden'); }
 function tourCloseModals(){ try{ if(modal.classList.contains('show')) closeCard(); }catch(e){}
-  try{ if(chronoModal.classList.contains('show')) closeChrono(); }catch(e){} try{ passportEl.classList.add('hidden'); }catch(e){} }
+  try{ if(chronoModal.classList.contains('show')) closeChrono(); }catch(e){} try{ closePostcardStudio(); }catch(e){} try{ passportEl.classList.add('hidden'); }catch(e){} }
 function buildTourSteps(){ const pop=REPOS.slice().sort((a,b)=>(b.stars||0)-(a.stars||0));
   const repo=pop[0]||REPOS[0]; const steps=[{kind:'welcome',dot:'👋',cap:'tourCap1',dwell:3.2}];
   if(repo) steps.push({kind:'repo',repo,dot:'🏠',cap:'tourCap2',dwell:3.6});
@@ -7316,7 +7480,7 @@ function runTourStep(){ if(!tour||!tour.active) return; const s=tour.steps[tour.
     tourSchedule(s.dwell);
   } else if(s.kind==='repo'){ tour.waiting=true; try{ taxiTo(s.repo); }catch(e){ tour.waiting=false; tourSchedule(s.dwell); } }
   else if(s.kind==='chrono'){ const d=lmCourseDest('chrono'); if(d){ tour.waiting=true; try{ taxiTo(d); }catch(e){ tour.waiting=false; tourSchedule(s.dwell); } } else tourSchedule(s.dwell); }
-  else if(s.kind==='passport'){ try{ panel.classList.add('hidden'); passportEl.classList.remove('hidden'); renderPassport(); }catch(e){} tourSchedule(s.dwell); } }
+  else if(s.kind==='passport'){ try{ panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); passportEl.classList.remove('hidden'); renderPassport(); }catch(e){} tourSchedule(s.dwell); } }
 function _armTourTimer(delay){ if(!tour||!tour.active) return; if(tour._timer) clearTimeout(tour._timer);
   delay=Math.max(0,delay); tour._deadline=performance.now()+delay;
   tour._timer=setTimeout(()=>{ if(!tour) return; tour._timer=null; tour._deadline=0; tourCloseModals(); tourNext(); },delay); }
@@ -7347,7 +7511,7 @@ function renderCourse(){ const box=document.getElementById('courseBox'); if(!box
 function onCourseProgress(){ if(!REPOS.length) return; if(!passportEl.classList.contains('hidden')) renderCourse();
   const pr=courseProgress(); if(pr.total>0&&pr.done>=pr.total&&course&&!course.rewarded){ course.rewarded=true;
     try{ localStorage.setItem(COURSE_KEY,JSON.stringify(course)); }catch(e){} fireworksShow(12); showWave(t('courseReward'),3400); } }
-document.getElementById('passBtn').onclick=()=>{ const hidden=passportEl.classList.toggle('hidden'); if(!hidden){ panel.classList.add('hidden'); renderPassport(); } };
+document.getElementById('passBtn').onclick=()=>{ const hidden=passportEl.classList.toggle('hidden'); if(!hidden){ panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); renderPassport(); } };
 document.getElementById('menuBtn').addEventListener('click',()=> passportEl.classList.add('hidden'));
 const repoList=document.getElementById('repoList');
 function buildRow(repo){
@@ -7356,7 +7520,7 @@ function buildRow(repo){
   row.innerHTML=`<div class="pin" style="background:${repo.color}">${repo.label[0]}</div>
     <div class="meta"><div class="nm">${repo.label}</div><div class="sub">${repo.lang} · 👁${repo.visitors} · ⑂${repo.forks} · ★${repo.stars}</div></div>
     <div class="go">${t('go')}</div>`;
-  row.querySelector('.go').onclick=ev=>{ ev.stopPropagation(); setNav(repo); panel.classList.add('hidden'); };
+  row.querySelector('.go').onclick=ev=>{ ev.stopPropagation(); setNav(repo); panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); };
   row.onclick=()=> openCard(repo);
   return row;
 }
@@ -7602,7 +7766,7 @@ const promptEl=document.getElementById('prompt'); let nearest=null, nearNpc=null
 let nearInviteCircle=null;   // an active gathering that has waved you over (join it with Enter from a little further out than the walk-up reach)
 let sitting=null, nearestSeat=null;
 /* one action resolves to whatever you're standing at: an NPC to talk to, a building to open, or a seat */
-function doAct(){ if(repositoryAtelierActive()){ repositoryAtelierAct(); return; } if(ferris||carousel||canalFerryRide) return; if(sitting) standUp(); else if(nearNpc) openChat(nearNpc); else if(nearChrono) openChrono(); else if(nearObs) openObservatory(); else if(nearStation) openStationModal(); else if(nearRainGarden) ringRainGarden(); else if(nearFerris) boardFerris(); else if(nearCarousel) boardCarousel(); else if(nearCanalFerry) boardCanalFerry(); else if(nearest) openCard(nearest); else if(nearHub) openZoneBoard(nearHub.id); else if(nearResident){ const met=courseMark('resident',nearResident.id), _g=_groupNear(nearResident); if(met){ const r=RESIDENTS.find(x=>x.id===nearResident.id); if(r) showWave(tf('chronicleMet',{name:(r[LANG]||r.ko).name}),2800); } if(_g) openGroupChat(_g); else openChat(nearResident); } else if(nearInviteCircle){ openGroupChat(nearInviteCircle.members.slice()); } else if(nearestSeat) sitDown(nearestSeat); }
+function doAct(){ if(repositoryAtelierActive()){ repositoryAtelierAct(); return; } if(ferris||carousel||canalFerryRide) return; if(sitting) standUp(); else if(nearNpc) openChat(nearNpc); else if(nearChrono) openChrono(); else if(nearObs) openObservatory(); else if(nearStation) openStationModal(); else if(nearPostcardKiosk) openPostcardStudio('kiosk'); else if(nearRainGarden) ringRainGarden(); else if(nearFerris) boardFerris(); else if(nearCarousel) boardCarousel(); else if(nearCanalFerry) boardCanalFerry(); else if(nearest) openCard(nearest); else if(nearHub) openZoneBoard(nearHub.id); else if(nearResident){ const met=courseMark('resident',nearResident.id), _g=_groupNear(nearResident); if(met){ const r=RESIDENTS.find(x=>x.id===nearResident.id); if(r) showWave(tf('chronicleMet',{name:(r[LANG]||r.ko).name}),2800); } if(_g) openGroupChat(_g); else openChat(nearResident); } else if(nearInviteCircle){ openGroupChat(nearInviteCircle.members.slice()); } else if(nearestSeat) sitDown(nearestSeat); }
 function npcPrompt(n){ const sc=window.scholarByKind&&n&&window.scholarByKind(n.kind);
   const nm = sc ? `${sc.emoji||'\u2726'} ${sc.star} \u00b7 ${LANG==='ko'?sc.epithetKo:sc.epithetEn}` : ((n&&n.kind==='msdocs')? t('npcEng') : t('npcTaxi'));
   return (LANG==='ko'?`<b>${nm}</b> · <span class="key">Enter</span>/클릭으로 <b>말 걸기</b> 💬`:`<b>${nm}</b> · <span class="key">Enter</span>/click to <b>talk</b> 💬`); }
@@ -7712,7 +7876,7 @@ document.getElementById('loading').style.display='none';
     shareBtn.textContent=t('copyLink'); shareBtn.classList.remove('ok');
     if(stationClose) stationClose.setAttribute('aria-label', t('close'));
   }
-  function openStation(){ panel.classList.add('hidden'); passportEl.classList.add('hidden'); stationEl.classList.remove('hidden'); renderStation(); track('station_open'); setTimeout(()=>{ try{ inp.focus(); }catch(e){} },80); }
+  function openStation(){ panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); passportEl.classList.add('hidden'); stationEl.classList.remove('hidden'); renderStation(); track('station_open'); setTimeout(()=>{ try{ inp.focus(); }catch(e){} },80); }
   function closeStation(){ stationEl.classList.add('hidden'); }
   if(stationClose) stationClose.onclick=closeStation;
   openStationModal=openStation;   // let the spatial station prop (walk-up) open the same ticket office
@@ -7766,6 +7930,229 @@ document.getElementById('loading').style.display='none';
   setTimeout(()=>track('session_10s'),10000);
   setTimeout(()=>track('session_60s'),60000);
 })();
+
+/* ====================== 📸 TOWN POSTCARD STUDIO ====================== */
+const postcardModal=document.getElementById('postcardModal'),postcardStudio=postcardModal.querySelector('.postcardStudio'),
+  postcardPreview=document.getElementById('postcardPreview'),postcardCanvas=document.getElementById('postcardCanvas'),
+  postcardBusyText=document.getElementById('postcardBusyText'),postcardStatus=document.getElementById('postcardStatus'),
+  postcardClose=document.getElementById('postcardClose'),postcardRetake=document.getElementById('postcardRetake'),
+  postcardShare=document.getElementById('postcardShare'),postcardDownload=document.getElementById('postcardDownload'),
+  postcardCopy=document.getElementById('postcardCopy'),postcardMenuBtn=document.getElementById('postcardMenuBtn');
+const POSTCARD={open:false,busy:false,blob:null,entry:'menu',previousFocus:null,pausedTour:null,renderId:0,renderPromise:null,
+  forceBlank:false,forceFallback:false,activeTargets:0,renders:0,failures:0,last:null,lastStatus:null,resourceBefore:null,resourceAfter:null};
+
+function _postcardShareUrl(){
+  const base=location.origin+location.pathname;
+  return cityMode==='public' ? base+'?user='+encodeURIComponent(currentUser) : base;
+}
+function _postcardIdentity(){ return createTownPostcardIdentity(currentUser,REPOS); }
+function _postcardRendererMemory(){ const memory=renderer.info.memory||{};
+  return {geometries:memory.geometries||0,textures:memory.textures||0,programs:(renderer.info.programs||[]).length}; }
+function _postcardStatusSet(key,tone='',vars){
+  POSTCARD.lastStatus={key,tone,vars:vars||null}; postcardStatus.className=tone||'';
+  postcardStatus.textContent=key?(vars?tf(key,vars):t(key)):'';
+}
+function _postcardPreviewSet(state,key){
+  postcardPreview.className=state; postcardCanvas.setAttribute('aria-busy',String(state==='busy'));
+  if(key) postcardBusyText.textContent=t(key);
+}
+function _postcardSummary(){
+  const summary=summarizeTownRepos(REPOS);
+  if(summary.type==='languages') return t('postcardTopLanguages')+' · '+summary.items.map(item=>item.name+' '+item.count).join(' · ');
+  if(summary.type==='repos') return t('postcardTopRepos')+' · '+summary.items.map(item=>item.name).join(' · ');
+  return t('postcardNoSignal');
+}
+function _postcardFile(){
+  if(!POSTCARD.blob||typeof File!=='function') return null;
+  const slug=String(currentUser||'town').toLowerCase().replace(/[^a-z0-9-]+/g,'-').replace(/^-|-$/g,'')||'town';
+  return new File([POSTCARD.blob],`repolis-${slug}-town-postcard.png`,{type:'image/png',lastModified:Date.now()});
+}
+function _postcardCanShare(){
+  if(POSTCARD.forceFallback||!navigator.share||!navigator.canShare) return false;
+  const file=_postcardFile(); if(!file) return false;
+  try{ return navigator.canShare({files:[file]}); }catch(e){ return false; }
+}
+function _syncPostcardActions(){
+  const ready=!!POSTCARD.blob&&!POSTCARD.busy,canShare=ready&&_postcardCanShare();
+  postcardRetake.disabled=POSTCARD.busy;
+  postcardDownload.disabled=!ready;
+  postcardShare.disabled=!ready;
+  postcardShare.hidden=!canShare;
+  postcardCopy.disabled=false;
+  return canShare;
+}
+function syncPostcardStudioLang(){
+  const identity=_postcardIdentity();
+  postcardStudio.style.setProperty('--postcard-primary',identity.palette.primary);
+  postcardStudio.style.setProperty('--postcard-accent',identity.palette.accent);
+  postcardCanvas.setAttribute('aria-label',t('postcardCanvasAria'));
+  if(POSTCARD.busy) postcardBusyText.textContent=t('postcardRendering');
+  if(POSTCARD.lastStatus) _postcardStatusSet(POSTCARD.lastStatus.key,POSTCARD.lastStatus.tone,POSTCARD.lastStatus.vars);
+  _syncPostcardActions();
+}
+window.__postcardLangRefresh=syncPostcardStudioLang;
+
+function _postcardCaptureError(code,cause){ const error=new Error(code); error.code=code; if(cause) error.cause=cause; return error; }
+function _postcardFailure(error){
+  if(error&&error.code==='blank') return {reason:'blank',key:'postcardCaptureBlank'};
+  if(error&&error.code==='context') return {reason:'context',key:'postcardCaptureContext'};
+  if(error&&error.name==='SecurityError') return {reason:'security',key:'postcardCaptureSecurity'};
+  return {reason:'capture',key:'postcardCaptureError'};
+}
+function _capturePostcardComposite(){
+  const gl=renderer.getContext(); if(!gl||gl.isContextLost()) throw _postcardCaptureError('context');
+  const viewWidth=renderer.domElement.clientWidth||innerWidth,viewHeight=renderer.domElement.clientHeight||innerHeight;
+  const size=postcardCaptureSize(viewWidth,viewHeight),pixels=new Uint8Array(size.width*size.height*4);
+  const savedTarget=renderer.getRenderTarget(),savedAutoClear=renderer.autoClear;
+  let target=null,captureComposer=null;
+  POSTCARD.resourceBefore=_postcardRendererMemory();
+  try{
+    target=new THREE.WebGLRenderTarget(size.width,size.height,{type:THREE.UnsignedByteType,format:THREE.RGBAFormat,depthBuffer:false,stencilBuffer:false});
+    target.texture.name='TownPostcardCapture';
+    captureComposer=new EffectComposer(renderer,target); captureComposer.renderToScreen=false; captureComposer.setPixelRatio(1);
+    captureComposer.addPass(finalMix); captureComposer.addPass(finalComposer.passes[1]);
+    POSTCARD.activeTargets+=2; captureComposer.render(0);
+    renderer.readRenderTargetPixels(captureComposer.readBuffer,0,0,size.width,size.height,pixels);
+    if(POSTCARD.forceBlank) pixels.fill(0);
+    const stats=analyzeTownFrame(pixels,size.width,size.height);
+    if(stats.blank) throw _postcardCaptureError('blank');
+    flipPixelRows(pixels,size.width,size.height);
+    const source=document.createElement('canvas'); source.width=size.width; source.height=size.height;
+    const context=source.getContext('2d',{alpha:false}); if(!context) throw _postcardCaptureError('canvas');
+    const image=context.createImageData(size.width,size.height); image.data.set(pixels); context.putImageData(image,0,0);
+    return {canvas:source,width:size.width,height:size.height,stats};
+  }finally{
+    renderer.autoClear=savedAutoClear; renderer.setRenderTarget(savedTarget);
+    if(captureComposer){ captureComposer.renderTarget1.dispose(); captureComposer.renderTarget2.dispose(); captureComposer.copyPass.material.dispose(); }
+    if(POSTCARD.activeTargets) POSTCARD.activeTargets=Math.max(0,POSTCARD.activeTargets-2);
+    POSTCARD.resourceAfter=_postcardRendererMemory();
+  }
+}
+async function renderTownPostcard(trigger='retake'){
+  if(POSTCARD.busy) return POSTCARD.renderPromise;
+  const renderId=++POSTCARD.renderId,started=performance.now();
+  POSTCARD.busy=true; POSTCARD.blob=null; POSTCARD.last=null;
+  _postcardPreviewSet('busy','postcardRendering'); _postcardStatusSet(''); _syncPostcardActions();
+  POSTCARD.renderPromise=(async()=>{
+    let frame=null;
+    try{
+      await new Promise(resolve=>requestAnimationFrame(resolve));
+      if(renderId!==POSTCARD.renderId||!POSTCARD.open) return false;
+      frame=_capturePostcardComposite();
+      const format=postcardFormatForViewport(innerWidth,innerHeight),identity=_postcardIdentity(),shareUrl=_postcardShareUrl();
+      const composed=composeTownPostcard({canvas:postcardCanvas,sourceCanvas:frame.canvas,format,identity,
+        kicker:t('postcardKicker'),title:'@'+currentUser+' · '+(cityMode==='public'?tf('townOf',{user:currentUser}):t('myCity')),
+        repoLine:tf('postcardRepoCount',{count:REPOS.length}),signature:_postcardSummary(),shareUrl,madeWith:t('postcardMadeWith')});
+      const blob=await postcardCanvasToBlob(postcardCanvas);
+      if(renderId!==POSTCARD.renderId) return false;
+      POSTCARD.blob=blob; POSTCARD.last={ok:true,trigger,orientation:composed.orientation,width:composed.width,height:composed.height,
+        captureWidth:frame.width,captureHeight:frame.height,nonblank:!frame.stats.blank,spread:frame.stats.spread,opaqueRatio:+frame.stats.opaqueRatio.toFixed(3),
+        bytes:blob.size,identityHash:composed.identityHash,palette:composed.palette,day:isNight?'night':'day',
+        renderMs:+(performance.now()-started).toFixed(1)};
+      POSTCARD.renders++;
+      _postcardPreviewSet('ready'); const native=_syncPostcardActions();
+      _postcardStatusSet(native?'postcardReady':'postcardFallback',native?'success':'');
+      track('postcard_render',{ok:true,trigger,orientation:composed.orientation,width:composed.width,height:composed.height});
+      return true;
+    }catch(error){
+      if(renderId!==POSTCARD.renderId) return false;
+      POSTCARD.failures++;
+      const failure=_postcardFailure(error); POSTCARD.last={ok:false,trigger,reason:failure.reason,renderMs:+(performance.now()-started).toFixed(1)};
+      _postcardPreviewSet('error',failure.key); _postcardStatusSet(failure.key,'error'); _syncPostcardActions();
+      track('postcard_render',{ok:false,trigger,reason:failure.reason}); return false;
+    }finally{
+      if(frame&&frame.canvas){ frame.canvas.width=1; frame.canvas.height=1; }
+      if(renderId===POSTCARD.renderId){ POSTCARD.busy=false; _syncPostcardActions(); }
+    }
+  })();
+  return POSTCARD.renderPromise;
+}
+
+function openPostcardStudio(entry='menu'){
+  if(repositoryAtelierActive()||(modalOpen&&!POSTCARD.open)) return false;
+  if(POSTCARD.open) return true;
+  POSTCARD.open=true; POSTCARD.entry=['menu','kiosk','debug'].includes(entry)?entry:'menu';
+  POSTCARD.previousFocus=POSTCARD.entry==='menu'?menuBtn:document.activeElement;
+  POSTCARD.pausedTour=typeof _pauseTourForAtelier==='function'?_pauseTourForAtelier():null;
+  panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); passportEl.classList.add('hidden');
+  document.getElementById('station').classList.add('hidden'); if(typeof closeMap==='function') closeMap();
+  modalOpen=true; postcardModal.classList.add('show'); postcardModal.setAttribute('aria-hidden','false');
+  syncPostcardStudioLang(); track('postcard_open',{entry:POSTCARD.entry,orientation:postcardFormatForViewport(innerWidth,innerHeight).id});
+  setTimeout(()=>{ try{ postcardClose.focus(); }catch(e){} },0);
+  renderTownPostcard('open'); return true;
+}
+function closePostcardStudio(){
+  if(!POSTCARD.open) return false;
+  POSTCARD.open=false; postcardModal.classList.remove('show'); postcardModal.setAttribute('aria-hidden','true'); modalOpen=false;
+  const paused=POSTCARD.pausedTour,previous=POSTCARD.previousFocus; POSTCARD.pausedTour=null; POSTCARD.previousFocus=null;
+  if(typeof _resumeTourAfterAtelier==='function') _resumeTourAfterAtelier(paused);
+  if(previous&&previous.isConnected) setTimeout(()=>{ try{ previous.focus(); }catch(e){} },0);
+  flushStarNudge(); return true;
+}
+function _postcardDebugState(){
+  const before=POSTCARD.resourceBefore||{},after=POSTCARD.resourceAfter||{},identity=_postcardIdentity();
+  return {open:POSTCARD.open,busy:POSTCARD.busy,entry:POSTCARD.entry,renders:POSTCARD.renders,failures:POSTCARD.failures,
+    ready:!!POSTCARD.blob,shareMode:_postcardCanShare()?'native':'fallback',activeTargets:POSTCARD.activeTargets,
+    resources:{before,after,delta:{geometries:(after.geometries||0)-(before.geometries||0),
+      textures:(after.textures||0)-(before.textures||0),programs:(after.programs||0)-(before.programs||0)}},
+    canvas:{width:postcardCanvas.width,height:postcardCanvas.height},identity:{hash:identity.hash,palette:identity.palette.name,
+      letters:identity.letters,spokes:identity.spokes,rings:identity.rings,notch:identity.notch},
+    url:_postcardShareUrl(),last:POSTCARD.last?{...POSTCARD.last}:null};
+}
+function _postcardPixelStats(){
+  const context=postcardCanvas.getContext('2d',{willReadFrequently:true});
+  if(!context||!postcardCanvas.width||!postcardCanvas.height) return null;
+  const image=context.getImageData(0,0,postcardCanvas.width,postcardCanvas.height);
+  const stats=analyzeTownFrame(image.data,postcardCanvas.width,postcardCanvas.height);
+  return {width:postcardCanvas.width,height:postcardCanvas.height,blank:stats.blank,spread:stats.spread,opaqueRatio:+stats.opaqueRatio.toFixed(3)};
+}
+async function shareTownPostcard(){
+  const file=_postcardFile(); if(!file||!_postcardCanShare()){ _postcardStatusSet('postcardFallback'); _syncPostcardActions(); return false; }
+  try{
+    await navigator.share({files:[file],title:tf('postcardShareTitle',{user:currentUser}),text:t('postcardShareText'),url:_postcardShareUrl()});
+    _postcardStatusSet('postcardShareDone','success'); track('postcard_share',{ok:true,orientation:POSTCARD.last?.orientation||'unknown'}); return true;
+  }catch(error){
+    const canceled=error&&error.name==='AbortError'; _postcardStatusSet(canceled?'postcardShareCanceled':'postcardShareFailed',canceled?'':'error');
+    track('postcard_share',{ok:false,reason:canceled?'cancel':'share_error'}); return false;
+  }
+}
+function downloadTownPostcard(){
+  if(!POSTCARD.blob) return false;
+  let url=null;
+  try{
+    url=URL.createObjectURL(POSTCARD.blob); const a=document.createElement('a'); a.href=url; a.download=_postcardFile()?.name||'repolis-town-postcard.png';
+    a.style.display='none'; document.body.appendChild(a); a.click(); a.remove(); setTimeout(()=>URL.revokeObjectURL(url),0);
+    _postcardStatusSet('postcardDownloadDone','success'); track('postcard_download',{ok:true,orientation:POSTCARD.last?.orientation||'unknown'}); return true;
+  }catch(error){
+    if(url) URL.revokeObjectURL(url); _postcardStatusSet('postcardDownloadFailed','error'); track('postcard_download',{ok:false,reason:'download_error'}); return false;
+  }
+}
+async function copyPostcardLink(){
+  const text=_postcardShareUrl(); let ok=false,area=null;
+  try{
+    if(navigator.clipboard&&navigator.clipboard.writeText){ await navigator.clipboard.writeText(text); ok=true; }
+    else { area=document.createElement('textarea'); area.value=text; area.setAttribute('readonly',''); area.style.position='fixed'; area.style.top='-9999px';
+      document.body.appendChild(area); area.select(); ok=document.execCommand('copy'); }
+  }catch(error){ ok=false; }
+  finally{ if(area) area.remove(); }
+  _postcardStatusSet(ok?'postcardCopied':'postcardCopyFailed',ok?'success':'error'); track('postcard_copy',{ok}); return ok;
+}
+function _postcardFocusables(){ return [...postcardStudio.querySelectorAll('button:not([disabled])')].filter(button=>!button.hidden); }
+postcardModal.addEventListener('keydown',event=>{
+  if(event.key==='Escape'){ event.preventDefault(); event.stopPropagation(); closePostcardStudio(); return; }
+  if(event.key!=='Tab') return; const items=_postcardFocusables(); if(!items.length) return;
+  const first=items[0],last=items[items.length-1];
+  if(event.shiftKey&&document.activeElement===first){ event.preventDefault(); last.focus(); }
+  else if(!event.shiftKey&&document.activeElement===last){ event.preventDefault(); first.focus(); }
+});
+postcardModal.addEventListener('click',event=>{ if(event.target===postcardModal) closePostcardStudio(); });
+postcardClose.onclick=closePostcardStudio;
+postcardRetake.onclick=()=>renderTownPostcard('retake');
+postcardShare.onclick=shareTownPostcard;
+postcardDownload.onclick=downloadTownPostcard;
+postcardCopy.onclick=copyPostcardLink;
+postcardMenuBtn.onclick=()=>openPostcardStudio('menu');
+syncPostcardStudioLang();
 
 /* ====================== LLM TAXI DRIVER ====================== */
 const chatEl=document.getElementById('chat'), chatLog=document.getElementById('chatLog'), chatText=document.getElementById('chatText');
@@ -8409,6 +8796,7 @@ function drawMinimap(){
   if(typeof OBS!=='undefined'&&OBS) LM.push([OBS._pos.x,OBS._pos.z,'🔭']);
   if(typeof FERRIS!=='undefined'&&FERRIS) LM.push([FERRIS._pos.x,FERRIS._pos.z,'🎡']);
   if(typeof CAROUSEL!=='undefined'&&CAROUSEL) LM.push([CAROUSEL._pos.x,CAROUSEL._pos.z,'🎠']);
+  if(POSTCARD_KIOSK) LM.push([POSTCARD_KIOSK._pos.x,POSTCARD_KIOSK._pos.z,'📸']);
   if(RAIN_GARDEN) LM.push([RAIN_GARDEN.center.x,RAIN_GARDEN.center.z,'🌦️']);
   if(RES_QUARTER) LM.push([RES_QUARTER_POS.x,RES_QUARTER_POS.z,'🏘️']);
   ctx.textAlign='center'; ctx.textBaseline='middle';
@@ -9007,6 +9395,7 @@ function animate(){
   nearChrono = (CHRONO && player.position.distanceTo(CHRONO._pos) < 8.5) ? CHRONO : null;
   nearObs = (OBS && player.position.distanceTo(OBS._pos) < 8.5) ? OBS : null;
   nearStation = (STATION && player.position.distanceTo(STATION._pos) < 6.0) ? STATION : null;
+  nearPostcardKiosk = (POSTCARD_KIOSK && player.position.distanceTo(POSTCARD_KIOSK._pos) < 5.5) ? POSTCARD_KIOSK : null;
   nearRainGarden = (RAIN_GARDEN && player.position.distanceTo(RAIN_GARDEN._pos) < 5.8) ? RAIN_GARDEN : null;
   nearFerris = (FERRIS && !ferris && player.position.distanceTo(FERRIS.board) < 6.0) ? FERRIS : null;
   nearCarousel = (CAROUSEL && !carousel && player.position.distanceTo(CAROUSEL.board) < 6.0) ? CAROUSEL : null;
@@ -9038,6 +9427,7 @@ function animate(){
   else if(nearChrono&&!modalOpen){ promptEl.innerHTML=`<b>${t('chronoTitle')}</b>${t('chronoReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='⏳'; }
   else if(nearObs&&!modalOpen){ promptEl.innerHTML=`<b>${t('obsName')}</b>${t('obsReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🔭'; }
   else if(nearStation&&!modalOpen){ promptEl.innerHTML=`<b>${t('stationLm')}</b>${t('stationReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🚉'; }
+  else if(nearPostcardKiosk&&!modalOpen){ promptEl.innerHTML=`<b>${t('postcardKiosk')}</b>${t('postcardReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='📸'; }
   else if(nearRainGarden&&!modalOpen){ promptEl.innerHTML=`<b>${t('rainName')}</b>${t(rainGardenActive?'rainReachedWet':'rainReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent=rainGardenActive?'☀️':'🌦️'; }
   else if(nearFerris&&!modalOpen){ promptEl.innerHTML=`<b>${t('ferrisName')}</b>${t('ferrisReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🎡'; }
   else if(nearCarousel&&!modalOpen){ promptEl.innerHTML=`<b>${t('carouselName')}</b>${t('carouselReached')}`; promptEl.classList.add('show'); actBtn.classList.add('avail'); actBtn.textContent='🎠'; }
@@ -9266,6 +9656,20 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__cam=()=>({camYaw:+camYaw.toFixed(6),camPitch:+camPitch.toFixed(6),camDist:+camDist.toFixed(4),charYaw:+model.rotation.y.toFixed(6),freeLook,dragging,dragBtn,
     camera:{position:_debugVec(camera.position),quaternion:[+camera.quaternion.x.toFixed(6),+camera.quaternion.y.toFixed(6),+camera.quaternion.z.toFixed(6),+camera.quaternion.w.toFixed(6)]},
     player:{position:_debugVec(player.position)},renderMode:WORLD_TREE_RENDER_MODE,night:isNight});
+  window.__postcard=()=>_postcardDebugState();
+  window.__postcardOpen=async()=>{ const opened=openPostcardStudio('debug'); if(!opened) return _postcardDebugState();
+    await POSTCARD.renderPromise; return _postcardDebugState(); };
+  window.__postcardRetake=async(mode='normal')=>{ if(!POSTCARD.open) openPostcardStudio('debug'); if(POSTCARD.busy) await POSTCARD.renderPromise;
+    const previous=POSTCARD.forceBlank; POSTCARD.forceBlank=mode==='blank';
+    try{ await renderTownPostcard('debug'); }finally{ POSTCARD.forceBlank=previous; } return _postcardDebugState(); };
+  window.__postcardFallback=(enabled=true)=>{ POSTCARD.forceFallback=enabled!==false; _syncPostcardActions(); return _postcardDebugState(); };
+  window.__postcardPixels=()=>_postcardPixelStats();
+  window.__postcardClose=()=>{ closePostcardStudio(); return _postcardDebugState(); };
+  window.__postcardKiosk=()=>POSTCARD_KIOSK?({position:_debugVec(POSTCARD_KIOSK._pos),near:!!nearPostcardKiosk,
+    distance:+player.position.distanceTo(POSTCARD_KIOSK._pos).toFixed(2),colliders:0}):null;
+  window.__tpPostcard=(back=4.6)=>{ if(!POSTCARD_KIOSK) return null; const p=POSTCARD_KIOSK._pos; player.position.set(p.x,0,p.z+back);
+    const yaw=Math.atan2(p.x-player.position.x,p.z-player.position.z); camYaw=yaw; camPitch=.2; camDist=14; model.rotation.y=Math.PI-yaw;
+    return {position:_debugVec(p),camera:window.__cam()}; };
   const _clearSightCandidates=(count=CLEAR_SIGHT_CAMERA.arrivalCount)=>{ const rows=[]; for(let i=0;i<count;i++) rows.push({
       index:i,yaw:+CAMERA_ARRIVAL_RESULT.yaws[i].toFixed(6),distance:+CAMERA_ARRIVAL_RESULT.distances[i].toFixed(4),
       score:+CAMERA_ARRIVAL_RESULT.scores[i].toFixed(5),softBlocked:!!CAMERA_ARRIVAL_RESULT.softHits[i]}); return rows; };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -25,6 +25,15 @@ import {
 } from '../assets/camera-obstruction.js';
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from '../assets/canal-ferry.js';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from '../assets/rain-garden.js';
+import {
+  POSTCARD_FORMATS,
+  createTownPostcardIdentity,
+  summarizeTownRepos,
+  postcardFormatForViewport,
+  postcardCaptureSize,
+  analyzeTownFrame,
+  flipPixelRows
+} from '../assets/town-postcard.js';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -42,6 +51,7 @@ const LAUNCH_CONFIG_SRC = readFileSync(join(ROOT, 'repolis.config.js'), 'utf8');
 const REFRESH_WORKFLOW = readFileSync(join(ROOT, '.github/workflows/refresh.yml'), 'utf8');
 const REPO_BUILDER = readFileSync(join(ROOT, 'scripts/build_repos.py'), 'utf8');
 const CAMERA_MATH_SRC = readFileSync(join(ROOT, 'assets/camera-obstruction.js'), 'utf8');
+const POSTCARD_SRC = readFileSync(join(ROOT, 'assets/town-postcard.js'), 'utf8');
 
 let pass = 0, fail = 0; const fails = [];
 function ok(cond, msg) { if (cond) { pass++; } else { fail++; fails.push(msg); console.log('  ✗ ' + msg); } }
@@ -192,6 +202,99 @@ ok(/if\s*\(\s*!dest\s*\)\s*return/.test(HTML), 'absent stops are skipped (public
 ok(/taxiTo\s*\(\s*dest\s*\)/.test(HTML), 'landmark stop button rides via taxiTo(dest)');
 ok(/track\(\s*['"]landmark_stop_ride['"]/.test(HTML), 'landmark stop ride is tracked');
 ok(/stationDistrictsH\s*:/.test(HTML), 'stationDistrictsH i18n key present');
+
+group('Town Postcard Studio — current-view local artifact loop');
+const postcardRepos = [
+  { repo: 'atlas', lang: 'JavaScript', stars: 9, forks: 2 },
+  { repo: 'beacon', lang: 'Rust', stars: 4, forks: 1 },
+  { repo: 'canopy', lang: 'JavaScript', stars: 2, forks: 0 }
+];
+const postcardIdentity = createTownPostcardIdentity('Octo-Cat', postcardRepos);
+const postcardIdentityReordered = createTownPostcardIdentity('octo-cat', postcardRepos.slice().reverse());
+const postcardIdentityChanged = createTownPostcardIdentity('octo-cat', [{ ...postcardRepos[0], stars: 10 }, ...postcardRepos.slice(1)]);
+ok(JSON.stringify(postcardIdentity) === JSON.stringify(postcardIdentityReordered),
+  'username normalization and sorted public metadata produce one deterministic civic identity');
+ok(postcardIdentity.palette.name === postcardIdentityChanged.palette.name
+  && postcardIdentity.hash !== postcardIdentityChanged.hash && postcardIdentity.letters === 'OC',
+  'username fixes the recognizable palette while public repository metadata personalizes the seal');
+const postcardLanguageSummary = summarizeTownRepos(postcardRepos);
+const postcardRepoSummary = summarizeTownRepos(postcardRepos.map(repo => ({ ...repo, lang: 'Other' })));
+ok(postcardLanguageSummary.type === 'languages' && postcardLanguageSummary.items[0].name === 'JavaScript'
+  && postcardLanguageSummary.items[0].count === 2 && postcardRepoSummary.type === 'repos'
+  && postcardRepoSummary.items.map(item => item.name).join(',') === 'atlas,beacon,canopy',
+  'truthful signatures prefer counted top languages and deterministically fall back to top public repositories');
+ok(postcardFormatForViewport(390, 844) === POSTCARD_FORMATS.portrait
+  && postcardFormatForViewport(1440, 900) === POSTCARD_FORMATS.landscape
+  && POSTCARD_FORMATS.portrait.width === 1200 && POSTCARD_FORMATS.portrait.height === 1500
+  && POSTCARD_FORMATS.landscape.width === 1600 && POSTCARD_FORMATS.landscape.height === 1000,
+  'mobile and desktop choose legible fixed social-card output dimensions');
+const postcardCapture = postcardCaptureSize(4000, 3000);
+ok(postcardCapture.pixels <= 1800000 && Math.max(postcardCapture.width, postcardCapture.height) <= 1600
+  && Math.abs(postcardCapture.width / postcardCapture.height - 4 / 3) < 0.002,
+  'one-shot capture keeps its aspect ratio inside the 1.8MP and 1600px GPU budget');
+const blankPixels = new Uint8Array(4 * 4 * 4);
+const flatPixels = new Uint8Array(4 * 4 * 4);
+const variedPixels = new Uint8Array(4 * 4 * 4);
+for (let i = 0; i < 16; i++) {
+  flatPixels.set([48, 48, 48, 255], i * 4);
+  variedPixels.set(i % 2 ? [244, 225, 180, 255] : [18, 42, 60, 255], i * 4);
+}
+ok(analyzeTownFrame(blankPixels, 4, 4).blank && analyzeTownFrame(flatPixels, 4, 4).blank
+  && !analyzeTownFrame(variedPixels, 4, 4).blank,
+  'transparent and flat WebGL frames fail explicitly while an opaque varied town frame passes');
+const flippedPixels = new Uint8Array([1, 2, 3, 255, 4, 5, 6, 255, 7, 8, 9, 255, 10, 11, 12, 255]);
+flipPixelRows(flippedPixels, 2, 2);
+ok(flippedPixels[0] === 7 && flippedPixels[4] === 10 && flippedPixels[8] === 1 && flippedPixels[12] === 4,
+  'readback rows are deterministically flipped from WebGL to canvas coordinates');
+
+const postcardBlock = (HTML.match(/\/\* ====================== 📸 TOWN POSTCARD STUDIO ====================== \*\/([\s\S]*?)\/\* ====================== LLM TAXI DRIVER/) || [, ''])[1];
+const postcardCaptureBlock = (postcardBlock.match(/function _capturePostcardComposite\(\)\{([\s\S]*?)\n\}/) || [, ''])[1];
+ok(/id="postcardMenuBtn"/.test(HTML) && /id="postcardModal" role="dialog" aria-modal="true"/.test(HTML)
+  && /aria-labelledby="postcardTitle" aria-describedby="postcardSub"/.test(HTML)
+  && /id="postcardStatus" role="status" aria-live="polite"/.test(HTML),
+  'Wayfinding exposes one native dialog with named controls and a polite live status');
+ok(/buildPostcardKiosk/.test(HTML) && /new THREE\.Vector3\(-9\.5,0,14\.5\)/.test(HTML)
+  && /nearPostcardKiosk\) openPostcardStudio\('kiosk'\)/.test(HTML)
+  && /actBtn\.textContent='📸'/.test(HTML) && /LM\.push\(\[POSTCARD_KIOSK\._pos\.x,POSTCARD_KIOSK\._pos\.z,'📸'\]\)/.test(HTML),
+  'a non-HUD civic kiosk supports Enter/mobile action and the existing minimap vocabulary');
+ok(/renderer\.getRenderTarget\(\)/.test(postcardCaptureBlock)
+  && /captureComposer\.addPass\(finalMix\)/.test(postcardCaptureBlock)
+  && /captureComposer\.addPass\(finalComposer\.passes\[1\]\)/.test(postcardCaptureBlock)
+  && /readRenderTargetPixels/.test(postcardCaptureBlock),
+  'capture replays the latest real base/bloom composite through the existing final color pass');
+ok(/renderer\.setRenderTarget\(savedTarget\)/.test(postcardCaptureBlock)
+  && /renderer\.autoClear=savedAutoClear/.test(postcardCaptureBlock)
+  && /renderTarget1\.dispose\(\)/.test(postcardCaptureBlock) && /renderTarget2\.dispose\(\)/.test(postcardCaptureBlock)
+  && /activeTargets=Math\.max\(0,POSTCARD\.activeTargets-2\)/.test(postcardCaptureBlock),
+  'temporary targets are disposed and renderer target/autoclear state is restored on every outcome');
+ok(!/preserveDrawingBuffer|renderer\.setSize|camera\.position|player\.position|requestAnimationFrame/.test(postcardCaptureBlock)
+  && !/renderTownPostcard|_capturePostcardComposite/.test((HTML.match(/function animate\([\s\S]*?requestAnimationFrame\(animate\)/) || [''])[0]),
+  'export neither resizes/moves the live world nor enters the steady frame loop');
+ok(!/fetch\(|XMLHttpRequest|FormData|WebSocket|GROUNDED/.test(postcardBlock + POSTCARD_SRC)
+  && /Everything stays in this browser\. The image is never uploaded\./.test(HTML)
+  && /이 브라우저 안에서만 이뤄지며 이미지는 업로드되지 않아요/.test(HTML),
+  'image composition is local-only and the bilingual privacy boundary is explicit');
+ok(/navigator\.canShare\(\{files:\[file\]\}\)/.test(postcardBlock)
+  && /navigator\.share\(\{files:\[file\],[\s\S]*?url:_postcardShareUrl\(\)\}\)/.test(postcardBlock)
+  && /URL\.createObjectURL\(POSTCARD\.blob\)/.test(postcardBlock)
+  && /navigator\.clipboard&&navigator\.clipboard\.writeText/.test(postcardBlock),
+  'native PNG file sharing includes the exact URL with download and copy-link fallbacks');
+ok(/postcardCaptureBlank/.test(postcardBlock) && /postcardCaptureContext/.test(postcardBlock)
+  && /postcardCaptureSecurity/.test(postcardBlock) && /forceBlank/.test(postcardBlock)
+  && /forceFallback/.test(postcardBlock),
+  'blank, lost-context, CORS/security, generic capture, and forced fallback paths stay visible and testable');
+['postcard_open', 'postcard_render', 'postcard_share', 'postcard_download'].forEach(event =>
+  ok(postcardBlock.includes(`track('${event}'`), `postcard event ${event} is instrumented`));
+ok(!/track\('postcard_[^']+',\{[^}]*?(?:url|blob|image|user)/.test(postcardBlock),
+  'postcard analytics payloads stay bounded and omit username, URL, blob, and image data');
+ok((HTML.match(/postcardTitle:/g) || []).length === 2 && (HTML.match(/postcardPrivacy:/g) || []).length === 2
+  && (HTML.match(/postcardCaptureBlank:/g) || []).length === 2 && /@media \(max-width: 520px\)[\s\S]*?\.postcardActions \{ grid-template-columns: 1fr 1fr/.test(HTML)
+  && /\.postcardActions button \{ min-height: 46px/.test(HTML) && /\.postcardClose \{[^}]*width: 44px; height: 44px/.test(HTML),
+  'KO/EN states and 44px-plus responsive controls remain legible at 390×844');
+ok(/window\.__postcardOpen=/.test(HTML) && /window\.__postcardRetake=/.test(HTML)
+  && /window\.__postcardFallback=/.test(HTML) && /window\.__postcardPixels=/.test(HTML)
+  && /window\.__postcardKiosk=/.test(HTML) && /activeTargets:POSTCARD\.activeTargets/.test(HTML),
+  'bounded diagnostics cover open/render/blank/fallback/pixels/kiosk and resource lifetime');
 
 group('ClearSight camera — pure obstruction math, arrival framing, and ownership');
 const nearNumber = (actual, expected, epsilon = 1e-6) => Math.abs(actual - expected) <= epsilon;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -259,11 +259,15 @@ ok(/buildPostcardKiosk/.test(HTML) && /new THREE\.Vector3\(-9\.5,0,14\.5\)/.test
   'a non-HUD civic kiosk supports Enter/mobile action and the existing minimap vocabulary');
 ok(/renderer\.getRenderTarget\(\)/.test(postcardCaptureBlock)
   && /captureComposer\.addPass\(finalMix\)/.test(postcardCaptureBlock)
-  && /captureComposer\.addPass\(finalComposer\.passes\[1\]\)/.test(postcardCaptureBlock)
+  && /const outputPass=finalComposer\.passes\[1\]/.test(postcardCaptureBlock)
+  && /captureComposer\.addPass\(outputPass\)/.test(postcardCaptureBlock)
   && /readRenderTargetPixels/.test(postcardCaptureBlock),
   'capture replays the latest real base/bloom composite through the existing final color pass');
 ok(/renderer\.setRenderTarget\(savedTarget\)/.test(postcardCaptureBlock)
   && /renderer\.autoClear=savedAutoClear/.test(postcardCaptureBlock)
+  && /finalMix\.renderToScreen=savedMixToScreen/.test(postcardCaptureBlock)
+  && /outputPass\.renderToScreen=savedOutputToScreen/.test(postcardCaptureBlock)
+  && /outputPass\.uniforms\.tDiffuse\.value=savedOutputTexture/.test(postcardCaptureBlock)
   && /renderTarget1\.dispose\(\)/.test(postcardCaptureBlock) && /renderTarget2\.dispose\(\)/.test(postcardCaptureBlock)
   && /activeTargets=Math\.max\(0,POSTCARD\.activeTargets-2\)/.test(postcardCaptureBlock),
   'temporary targets are disposed and renderer target/autoclear state is restored on every outcome');
@@ -283,17 +287,22 @@ ok(/postcardCaptureBlank/.test(postcardBlock) && /postcardCaptureContext/.test(p
   && /postcardCaptureSecurity/.test(postcardBlock) && /forceBlank/.test(postcardBlock)
   && /forceFallback/.test(postcardBlock),
   'blank, lost-context, CORS/security, generic capture, and forced fallback paths stay visible and testable');
+ok(/if\(ride\|\|ferris\|\|carousel\|\|canalFerryRide\|\|performance\.now\(\)<ridePostActionUntil\)/.test(postcardBlock)
+  && (HTML.match(/postcardMotionBusy:/g) || []).length === 2
+  && /ridePostActionUntil=performance\.now\(\)\+700; setTimeout\(\(\)=>openCard\(repo\),500\)/.test(HTML),
+  'moving rides and delayed arrival UI cannot overlap the postcard dialog');
 ['postcard_open', 'postcard_render', 'postcard_share', 'postcard_download'].forEach(event =>
   ok(postcardBlock.includes(`track('${event}'`), `postcard event ${event} is instrumented`));
-ok(!/track\('postcard_[^']+',\{[^}]*?(?:url|blob|image|user)/.test(postcardBlock),
-  'postcard analytics payloads stay bounded and omit username, URL, blob, and image data');
+ok(!/track\('postcard_[^']+',\{[^}]*?(?:url|blob|image)/.test(postcardBlock),
+  'postcard-specific analytics payloads stay bounded and omit URL, blob, and image data');
 ok((HTML.match(/postcardTitle:/g) || []).length === 2 && (HTML.match(/postcardPrivacy:/g) || []).length === 2
   && (HTML.match(/postcardCaptureBlank:/g) || []).length === 2 && /@media \(max-width: 520px\)[\s\S]*?\.postcardActions \{ grid-template-columns: 1fr 1fr/.test(HTML)
   && /\.postcardActions button \{ min-height: 46px/.test(HTML) && /\.postcardClose \{[^}]*width: 44px; height: 44px/.test(HTML),
   'KO/EN states and 44px-plus responsive controls remain legible at 390×844');
 ok(/window\.__postcardOpen=/.test(HTML) && /window\.__postcardRetake=/.test(HTML)
   && /window\.__postcardFallback=/.test(HTML) && /window\.__postcardPixels=/.test(HTML)
-  && /window\.__postcardKiosk=/.test(HTML) && /activeTargets:POSTCARD\.activeTargets/.test(HTML),
+  && /window\.__postcardKiosk=/.test(HTML) && /activeTargets:POSTCARD\.activeTargets/.test(HTML)
+  && /stateRestored:POSTCARD\.stateRestored/.test(HTML),
   'bounded diagnostics cover open/render/blank/fallback/pixels/kiosk and resource lifetime');
 
 group('ClearSight camera — pure obstruction math, arrival framing, and ownership');


### PR DESCRIPTION
## Summary
- add an in-world civic photo kiosk and Wayfinding entry for a local-only postcard workflow
- capture the current real base/bloom town composite into deterministic KO/EN social-card PNGs
- support native mobile file sharing plus Download PNG and Copy Link fallbacks without uploads or backend cost
- preserve camera/render resources, rides, resident motion, guided tours, and accessible desktop/mobile interaction
- add deterministic helper and wiring regressions for capture, identity, fallback, i18n, and resource lifetime

## Validation
- `node council/test.mjs`
- `node council/test-live.mjs`
- `node scripts/smoke.mjs` (812 checks)
- `node --check scholars.js`
- `node --check cloudflare-taxi/src/grounded.js`
- local Chrome: owner/public towns, day/night, 1440x900 and 390x844, nonblank 1600x1000 and 1200x1500 PNGs, Web Share/fallback actions, keyboard/mobile paths, zero console errors, and stable renderer resources across repeated captures