### PR TITLE
Show personalized town proof before entry

### DIFF
--- a/assets/public-town-proof.js
+++ b/assets/public-town-proof.js
@@ -1,0 +1,33 @@
+function nonNegative(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.round(number)) : 0;
+}
+
+export function summarizePublicTown(user, repos = []) {
+  const login = String(user || '').trim();
+  const list = Array.isArray(repos) ? repos.filter(Boolean) : [];
+  const languages = new Set();
+  let stars = 0;
+
+  for (const repo of list) {
+    stars = Math.min(Number.MAX_SAFE_INTEGER, stars + nonNegative(repo.stars));
+    const language = String(repo.lang || '').trim();
+    if (language && language !== 'Other' && language !== '\u2014') languages.add(language);
+  }
+
+  const topRepos = list.slice()
+    .filter(repo => String(repo.repo || '').trim())
+    .sort((a, b) => nonNegative(b.stars) - nonNegative(a.stars)
+      || nonNegative(b.forks) - nonNegative(a.forks)
+      || String(a.repo).localeCompare(String(b.repo)))
+    .slice(0, 3)
+    .map(repo => String(repo.repo).trim());
+
+  return Object.freeze({
+    user: login,
+    count: list.length,
+    stars,
+    languages: languages.size,
+    topRepos: Object.freeze(topRepos)
+  });
+}

--- a/index.html
+++ b/index.html
@@ -660,6 +660,7 @@
   #introLaunch { margin: -5px auto 20px; padding: 12px; border: 1px solid rgba(255,255,255,.46); border-radius: 16px;
     background: rgba(35,73,73,.16); box-shadow: 0 8px 22px rgba(41,45,35,.12); }
   #introLaunch .launchLabel { margin-bottom: 8px; font-size: 12px; font-weight: 800; letter-spacing: .02em; }
+  #introLaunch.ready { background: rgba(25,63,60,.25); }
   #introLaunchForm { display: flex; gap: 7px; align-items: stretch; }
   #introLaunchForm .at { display: grid; place-items: center; flex: 0 0 35px; border-radius: 10px;
     background: rgba(255,255,255,.22); font-size: 15px; font-weight: 900; }
@@ -669,6 +670,13 @@
   #introLaunchGo { flex: 0 0 auto; border: 0; border-radius: 10px; padding: 10px 13px; background: #234d49; color: #fff;
     font: inherit; font-size: 13px; font-weight: 800; cursor: pointer; }
   #introLaunch .launchHint { margin-top: 7px; font-size: 10.5px; color: rgba(255,255,255,.82); }
+  #introPublicProof { display: grid; gap: 7px; text-align: center; }
+  #introPublicProof[hidden], #introLaunchForm[hidden], #introLaunchHint[hidden] { display: none; }
+  .introProofStats { color: #fff; font-size: 14px; font-weight: 800; line-height: 1.4; }
+  .introProofTop { min-width: 0; overflow: hidden; color: rgba(255,255,255,.84); font-size: 11px;
+    line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+  #introTryAnother { justify-self: center; min-height: 36px; border: 1px solid rgba(255,255,255,.48); border-radius: 10px;
+    padding: 7px 12px; background: rgba(255,255,255,.14); color: #fff; font: inherit; font-size: 11.5px; font-weight: 800; cursor: pointer; }
   #introLaunchErr { min-height: 0; margin-top: 6px; color: #fff2ce; font-size: 11px; font-weight: 700; }
   #introLaunchErr:empty { display: none; }
   #startBtn { background: #fff; color: #c2702f; border: none; border-radius: 14px; padding: 14px 40px;
@@ -1126,7 +1134,12 @@
         <input id="introUser" data-i18n-ph="introUserPh" placeholder="GitHub username" autocomplete="username" spellcheck="false" />
         <button id="introLaunchGo" type="submit" data-i18n="introLaunchGo">내 마을 만들기 →</button>
       </form>
-      <div class="launchHint" data-i18n="introLaunchHint">공개 레포만 사용 · 로그인 없음 · 포크 없음</div>
+      <div id="introPublicProof" hidden role="status" aria-live="polite">
+        <div class="introProofStats" id="introProofStats"></div>
+        <div class="introProofTop" id="introProofTop"></div>
+        <button id="introTryAnother" type="button" data-i18n="introTryAnother">↻ 다른 GitHub 계정 보기</button>
+      </div>
+      <div class="launchHint" id="introLaunchHint" data-i18n="introLaunchHint">공개 레포만 사용 · 로그인 없음 · 포크 없음</div>
       <div id="introLaunchErr" role="alert"></div>
     </div>
     <div class="ctrls">
@@ -1203,6 +1216,7 @@ import { CAMERA_OBSTRUCTION_DEFAULTS, CAMERA_ARRIVAL_OFFSETS, resolveCameraObstr
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from './assets/canal-ferry.js?v=petite-venise-ferry-v1';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from './assets/rain-garden.js?v=weather-bell-v1';
 import { analyzeTownFrame, composeTownPostcard, createTownPostcardIdentity, createTownReadmePortal, flipPixelRows, postcardCanvasToBlob, postcardCaptureSize, postcardFormatForViewport, summarizeTownRepos } from './assets/town-postcard.js?v=town-postcard-v2';
+import { summarizePublicTown } from './assets/public-town-proof.js?v=personal-ready-v1';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -1452,6 +1466,8 @@ const I18N = {
     introSubPublic:'{user} 님의 공개 레포로 지은 도시예요.<br>함께 걸으며 둘러보고,<br>🚉 역에서 또 다른 마을로 떠날 수 있어요.',
     introLaunchLabel:'내 공개 레포로 바로 보기', introUserPh:'GitHub username', introLaunchGo:'내 마을 만들기 →',
     introLaunchHint:'공개 레포만 사용 · 로그인 없음 · 포크 없음', introLaunchInvalid:'올바른 GitHub username을 입력해 주세요.',
+    introReady:'@{user}의 마을이 준비됐어요', introProofStats:'공개 레포 {count}개 · ★ {stars} · 사용 언어 {languages}개',
+    introProofTop:'대표 집 · {repos}', introTryAnother:'↻ 다른 GitHub 계정 보기', enterTownPublic:'이 마을 입장 →',
     starNudge:'이 마을이 마음에 드셨나요? Repolis는 오픈소스예요.', starNudgeGo:'⭐ GitHub에서 Star',
     privacyNote:'익명 집계 통계만 측정해요 · 개인정보·계정·검색어는 저장하지 않아요.',
     ctrlWalk:'걷기', ctrlLookL:'시점 회전(자유 시점)', ctrlAimR:'캐릭터 조준 · WoW식 · 휠 줌', ctrlOpen:'레포 열기',
@@ -1656,6 +1672,8 @@ const I18N = {
     introSubPublic:"A city built from {user}'s public repos.<br>Stroll around and explore —<br>or hop the train at 🚉 Station to visit another town.",
     introLaunchLabel:'See the same engine with your public repos', introUserPh:'GitHub username', introLaunchGo:'Build my town →',
     introLaunchHint:'Public repos only · no login · no fork', introLaunchInvalid:'Enter a valid GitHub username.',
+    introReady:"@{user}'s town is ready", introProofStats:'{count} public repos · ★ {stars} · {languages} languages',
+    introProofTop:'Featured houses · {repos}', introTryAnother:'↻ Try another GitHub account', enterTownPublic:'Enter this town →',
     starNudge:'Enjoying the town? Repolis is open source.', starNudgeGo:'⭐ Star on GitHub',
     privacyNote:'Anonymous, aggregate stats only — no personal data, accounts, or search queries are stored.',
     ctrlWalk:'Walk', ctrlLookL:'Orbit camera (free look)', ctrlAimR:'Steer character · WoW-style · wheel = zoom', ctrlOpen:'Open repo',
@@ -1802,6 +1820,7 @@ function applyLang(){
   if(typeof renderStarTrailHud==='function') renderStarTrailHud();
   if(typeof renderLanternWatchHud==='function') renderLanternWatchHud();
   if(typeof window.__cityLangRefresh==='function') window.__cityLangRefresh();
+  if(typeof window.__publicIntroRefresh==='function') window.__publicIntroRefresh();
   if(typeof refreshDistrictSigns==='function') refreshDistrictSigns();
   if(typeof refreshHubSigns==='function') refreshHubSigns();
   if(typeof refreshResidentTags==='function') refreshResidentTags();
@@ -8039,7 +8058,30 @@ document.getElementById('startBtn').onclick=()=>{ document.getElementById('intro
       if(news) setTimeout(()=>{ try{ showWave(tf('freshBanner',{count:repoFreshness.total}),4200); }catch(e){} },delay);
       else if(c.available) setTimeout(()=>{ try{ showWave(t('courseBanner'),4200); }catch(e){} },delay); } }catch(e){}
   setTimeout(()=>{ try{ openRepoFromHash(); }catch(e){} }, 480); };
-(function(){ const form=document.getElementById('introLaunchForm'), input=document.getElementById('introUser'), err=document.getElementById('introLaunchErr');
+const introLaunch=document.getElementById('introLaunch'),introLaunchLabel=introLaunch.querySelector('.launchLabel'),
+  introLaunchForm=document.getElementById('introLaunchForm'),introLaunchHint=document.getElementById('introLaunchHint'),
+  introPublicProof=document.getElementById('introPublicProof'),introProofStats=document.getElementById('introProofStats'),
+  introProofTop=document.getElementById('introProofTop'),introTryAnother=document.getElementById('introTryAnother'),
+  introStartBtn=document.getElementById('startBtn');
+let introChoosingAnother=false;
+function publicIntroSummary(){ return summarizePublicTown(currentUser,REPOS); }
+function introProofNumber(value){ try{ return new Intl.NumberFormat(LANG==='ko'?'ko-KR':'en-US').format(value); }catch(e){ return String(value); } }
+function renderPublicIntro(){
+  const summary=publicIntroSummary(),ready=cityMode==='public'&&!cityError&&summary.count>0&&!introChoosingAnother;
+  introLaunch.classList.toggle('ready',ready); introPublicProof.hidden=!ready; introLaunchForm.hidden=ready; introLaunchHint.hidden=ready;
+  if(ready){
+    introLaunchLabel.textContent=tf('introReady',{user:summary.user});
+    introProofStats.textContent=tf('introProofStats',{count:introProofNumber(summary.count),stars:introProofNumber(summary.stars),languages:introProofNumber(summary.languages)});
+    const featured=summary.topRepos.join(' · '); introProofTop.textContent=tf('introProofTop',{repos:featured}); introProofTop.title=featured;
+    introStartBtn.textContent=t('enterTownPublic');
+  }else{
+    introLaunchLabel.textContent=t('introLaunchLabel'); introStartBtn.textContent=t('enterTown');
+  }
+  return {ready,choosingAnother:introChoosingAnother,summary};
+}
+window.__publicIntroRefresh=renderPublicIntro;
+introTryAnother.onclick=()=>{ introChoosingAnother=true; renderPublicIntro(); const input=document.getElementById('introUser'); input.value=''; setTimeout(()=>input.focus(),0); };
+(function(){ const form=introLaunchForm, input=document.getElementById('introUser'), err=document.getElementById('introLaunchErr');
   if(!form||!input) return; if(cityMode==='public') input.value=currentUser;
   if(new URLSearchParams(location.search).has('launch')) setTimeout(()=>input.focus(),80);
   input.addEventListener('keydown',e=>e.stopPropagation());
@@ -8047,7 +8089,7 @@ document.getElementById('startBtn').onclick=()=>{ document.getElementById('intro
     if(!GH_LOGIN_RE.test(user)){ if(err) err.textContent=t('introLaunchInvalid'); track('intro_launch_invalid'); input.focus(); return; }
     if(err) err.textContent=''; track('intro_personal_preview',{targetUser:user});
     const url=location.origin+location.pathname+(user.toLowerCase()===OWNER.toLowerCase()?'':'?user='+encodeURIComponent(user));
-    location.href=url; }; })();
+    location.href=url; }; renderPublicIntro(); })();
 (function(){ const it=document.getElementById('introTour'); if(it) it.onclick=()=>{ document.getElementById('intro').classList.add('hidden');
     document.getElementById('loading').style.display='none'; setTimeout(()=>{ try{ startTour(); }catch(e){} }, 650); };
   const sk=document.getElementById('tourSkip'); if(sk) sk.onclick=()=>{ try{ endTour(false); }catch(e){} }; })();
@@ -9932,6 +9974,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__postcardPixels=()=>_postcardPixelStats();
   window.__postcardPortal=()=>_postcardReadmePortal();
   window.__postcardCopyReadme=()=>copyPostcardReadme();
+  window.__introProof=()=>renderPublicIntro();
   window.__postcardClose=()=>{ closePostcardStudio(); return _postcardDebugState(); };
   window.__postcardKiosk=()=>POSTCARD_KIOSK?({position:_debugVec(POSTCARD_KIOSK._pos),near:!!nearPostcardKiosk,
     distance:+player.position.distanceTo(POSTCARD_KIOSK._pos).toFixed(2),colliders:0}):null;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -25,6 +25,7 @@ import {
 } from '../assets/camera-obstruction.js';
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from '../assets/canal-ferry.js';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from '../assets/rain-garden.js';
+import { summarizePublicTown } from '../assets/public-town-proof.js';
 import {
   POSTCARD_FORMATS,
   createTownPostcardIdentity,
@@ -53,6 +54,7 @@ const REFRESH_WORKFLOW = readFileSync(join(ROOT, '.github/workflows/refresh.yml'
 const REPO_BUILDER = readFileSync(join(ROOT, 'scripts/build_repos.py'), 'utf8');
 const CAMERA_MATH_SRC = readFileSync(join(ROOT, 'assets/camera-obstruction.js'), 'utf8');
 const POSTCARD_SRC = readFileSync(join(ROOT, 'assets/town-postcard.js'), 'utf8');
+const PUBLIC_TOWN_PROOF_SRC = readFileSync(join(ROOT, 'assets/public-town-proof.js'), 'utf8');
 
 let pass = 0, fail = 0; const fails = [];
 function ok(cond, msg) { if (cond) { pass++; } else { fail++; fails.push(msg); console.log('  ✗ ' + msg); } }
@@ -126,6 +128,28 @@ ok(/id="introLaunchForm"/.test(HTML) && /id="introUser"/.test(HTML) && /data-i18
 ok(/form\.onsubmit=e=>[\s\S]*?GH_LOGIN_RE\.test\(user\)[\s\S]*?\?user='\+encodeURIComponent\(user\)/.test(HTML), 'launchpad validates a GitHub login and reuses the established public-town URL');
 ok(/new URLSearchParams\(location\.search\)\.has\('launch'\)/.test(HTML), '?launch=1 focuses the personal preview field');
 ok((HTML.match(/introLaunchLabel:/g)||[]).length===2 && (HTML.match(/introLaunchInvalid:/g)||[]).length===2, 'launchpad labels and errors are bilingual');
+const townProof = summarizePublicTown('Octo-Cat', [
+  { repo:'beacon', lang:'Rust', stars:3, forks:4 },
+  { repo:'atlas', lang:'JavaScript', stars:9, forks:1 },
+  { repo:'canopy', lang:'JavaScript', stars:9, forks:2 }
+]);
+ok(townProof.user==='Octo-Cat' && townProof.count===3 && townProof.stars===21 && townProof.languages===2
+  && townProof.topRepos.join(',')==='canopy,atlas,beacon', 'personal-town proof truthfully summarizes loaded public metadata and ranks featured houses deterministically');
+ok(/id="introPublicProof" hidden role="status" aria-live="polite"/.test(HTML)
+  && /id="introTryAnother" type="button" data-i18n="introTryAnother"/.test(HTML)
+  && /function renderPublicIntro\(\)/.test(HTML) && /introLaunchForm\.hidden=ready/.test(HTML)
+  && /introPublicProof\.hidden=!ready/.test(HTML), 'a completed public town replaces the duplicate username form with an accessible proof state');
+ok(/introProofStats\.textContent=tf\('introProofStats'/.test(HTML)
+  && /new Intl\.NumberFormat\(LANG==='ko'\?'ko-KR':'en-US'\)/.test(HTML)
+  && /introProofTop\.textContent=tf\('introProofTop'/.test(HTML)
+  && !/introProofTop\.innerHTML/.test(HTML), 'untrusted GitHub names enter the first-screen proof through textContent only');
+ok((HTML.match(/introReady:/g)||[]).length===2 && (HTML.match(/introProofStats:/g)||[]).length===2
+  && (HTML.match(/enterTownPublic:/g)||[]).length===2
+  && /window\.__publicIntroRefresh=renderPublicIntro/.test(HTML)
+  && /window\.__introProof=\(\)=>renderPublicIntro\(\)/.test(HTML), 'the personalized ready state is bilingual, language-refreshable, and diagnosable');
+ok(/#introPublicProof\[hidden\], #introLaunchForm\[hidden\], #introLaunchHint\[hidden\] \{ display: none; \}/.test(HTML)
+  && /\.introProofTop \{[^}]*overflow: hidden[^}]*text-overflow: ellipsis[^}]*white-space: nowrap/.test(HTML), 'the replacement state stays compact and clips long repository names on mobile');
+ok(!/innerHTML/.test(PUBLIC_TOWN_PROOF_SRC) && /Object\.freeze\(topRepos\)/.test(PUBLIC_TOWN_PROOF_SRC), 'the pure proof helper is immutable and has no DOM injection surface');
 function launchConfig(hostname) {
   const sandbox = { window: {}, location: { hostname } };
   runInNewContext(LAUNCH_CONFIG_SRC, sandbox);


### PR DESCRIPTION
## Why

After someone enters a GitHub username, the resulting public-town intro repeated the same username form and gave no immediate proof of what had been built. This adds a compact personalized confirmation before the visitor enters the 3D town.

## What changed

- summarize loaded public metadata into repo, Star, language, and featured-house proof
- replace the duplicate username form only in `?user=` towns
- preserve an explicit "Try another GitHub account" path
- keep GitHub names text-only and owner mode unchanged
- add bilingual, responsive, hermetic regression coverage

## Verification

- `node scripts/smoke.mjs` (849 checks)
- `node council/test.mjs` (130 checks)
- `node council/test-live.mjs` (56 checks)
- `node --check scholars.js`
- `node --check cloudflare-taxi/src/grounded.js`
- `node --check assets/public-town-proof.js`
- desktop + 390x844 mobile, KO/EN, zero console warnings/errors