### PR TITLE
feat: harden resident AI controls and telemetry

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -38,7 +38,7 @@ wait for the slow KB to finish. Free plan, no card, and you already run a Worker
 
 ## What it holds (and what it doesn't)
 
-The Worker needs **two secrets** for the existing live KB/persona path:
+The Worker needs **two provider secrets** for the existing live KB/persona path:
 
 - your **Azure AI Search key** (`SEARCH_API_KEY`) — for KB retrieval, and
 - an **Entra ID service-principal secret** (`AAD_CLIENT_SECRET`) — so it can call Azure
@@ -58,6 +58,12 @@ AURI's stock source optionally adds `MARKET_LONGBRIDGE_ACCESS_TOKEN`, a dedicate
 OAuth access token. The Worker forwards it only to `longbridge-market-mcp-ks` through Azure AI
 Search query-time control headers. Coinbase spot data is public and keyless. Never use a
 full-trading token when a read-only market-data token is available.
+
+When `METRICS_URL` points at Repolis Observatory, also set `METRICS_INGEST_TOKEN` to the
+same random value configured on `repolis-metrics`. The Worker sends it only as
+`X-Repolis-Metrics-Key` to that collector. This keeps server provider calls, delivered answers,
+KB attempts, and final grounding paths out of the untrusted browser lane; prompt and answer text
+are never included.
 
 Deterministic navigation ("take me to the most popular repo") is handled in the client
 and never reaches here. If the KB is unreachable / slow / unconfigured, the Worker returns
@@ -97,7 +103,17 @@ npx wrangler secret put AAD_CLIENT_SECRET    # service principal password (the o
 If you skip (2), grounded answers still work; off-KB / small-talk questions just fall
 back to the client's Local reply instead of an in-persona answer.
 
-**(3) Ship it:**
+**(3) Authoritative Observatory telemetry** (required before publishing per-answer economics):
+
+```bash
+# Use the identical random value already set on repolis-metrics:
+npx wrangler secret put METRICS_INGEST_TOKEN
+```
+
+Deploy `repolis-metrics` first, then this Worker. Without the shared token, telemetry remains
+public diagnostic data and is deliberately excluded from provider/cost/answer attribution.
+
+**(4) Ship it:**
 
 ```bash
 npx wrangler deploy
@@ -105,7 +121,7 @@ npx wrangler deploy
 
 `wrangler deploy` prints your URL, e.g. `https://repolis-taxi.<you>.workers.dev`.
 
-**(4) AURI's optional market KB** — create the two MCP Knowledge Sources and the
+**(5) AURI's optional market KB** — create the two MCP Knowledge Sources and the
 `repolis-market-kb` described in [`../SCHOLARS.md`](../SCHOLARS.md), then set the Longbridge
 token server-side:
 
@@ -297,8 +313,10 @@ possibly billable dollars.
 
 ```jsonc
 { "npc_action": "npcConfig", "lang": "ko" }
-// → { ok, config:{ aiEnabled, ambientEnabled, playerChatEnabled, maxTurns, hardMaxTurns,
-//                  source:"durable-object", flagSource, liveToggle },
+// → { ok, config:{ requested, effective, pending, canEnable, blockReason,
+//                  aiEnabled, ambientEnabled, playerChatEnabled,
+//                  hardAiEnabled, hardAmbientEnabled, hardPlayerChatEnabled,
+//                  maxTurns, hardMaxTurns, source:"durable-object", flagSource, liveToggle },
 //      budget:{ source:"durable-object", available, ... } }
 { "npc_action": "npcBudget" }
 // → { ok, budget:{ enabled, available, source:"durable-object", day, dayCapUsd,
@@ -327,7 +345,7 @@ isolate-local estimate.
 | `NPC_MODEL_AMBIENT` / `NPC_MODEL_PLAYER` | — | Optional per-role deployment overrides; each deployed name needs a pricing entry. |
 | `NPC_MODEL_PRICING_JSON` | built-in `gpt-5.4-mini` table | JSON map of deployment alias to `inputPer1MUsd`, `cachedInputPer1MUsd`, `outputPer1MUsd`, `maxInputTokens`, and `maxOutputTokens`. Invalid/unknown/incomplete means no call. |
 | `NPC_MAX_COMPLETION_TOKENS` | `120` | Provider output cap and reservation output bound (1–4096). |
-| `NPC_DAY_CAP_USD` | `10` | Durable UTC-day hard cap. `0` disables calls. Invalid values fail closed. |
+| `NPC_DAY_CAP_USD` | `0.15` in this deployment (`10` code default) | Durable UTC-day hard cap. The committed value bounds a 31-day month to `$4.65` of resident Azure model calls. `0` disables calls; invalid values fail closed. |
 | `NPC_DAILY_TURN_MAX` | `0` (off) | Optional durable daily turn cap; in-flight reservations consume slots. |
 | `NPC_DAILY_ATTEMPT_MAX` | `5000` | Hard abuse/storage ceiling for accepted reservations, including provider failures. Must be positive. |
 | `NPC_BUDGET_TIMEOUT_MS` | `1500` | Internal Governor response deadline (100–10000 ms); timeout fails closed. |
@@ -335,16 +353,23 @@ isolate-local estimate.
 | `NPC_TIMEOUT_MS` | `12000` | Entra token + model request deadline; timeout aborts the request and releases its reservation. |
 | `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient conversation caps. |
 | `METRICS_URL` | — | Optional private collector. Resident budget telemetry is anonymous aggregate operations only. |
+| `METRICS_INGEST_TOKEN` | — | Shared Worker secret for `X-Repolis-Metrics-Key`; identical value on `repolis-metrics`. Required for authoritative per-answer/provider/grounding attribution. |
 
 Model turns reuse the **same** Entra ID service principal as scholar chat (`AAD_*` + `AOAI_ENDPOINT`); no
 new secret is needed. Keep the committed `NPC_MODEL_PRICING_JSON` synchronized with the actual deployment
 meter before enabling the pilot. A custom deployment alias without a matching entry is deliberately rejected.
 
 Allowed resident-budget telemetry is limited to `npc_budget_reserve` (accepted/rejected),
-`npc_budget_settle` (settled/released), `npc_provider_error`, and `npc_budget_utc_reset`. Events may include
-role, reason, aggregate dollars/turns, and whether provider usage was authoritative. They never include prompt
-text, conversation text, speaker/visitor identity, instance ID, or reservation ID. Scholar/KB/MCP telemetry
-remains on its existing independent path.
+`npc_budget_settle` (settled/released), `npc_provider_error`, and `npc_budget_utc_reset`. Separate
+`ai_chat_turn` records distinguish each provider call (`providerCall=true`, `answer=false`) from the one
+user-visible delivered answer (`providerCall=false`, `answer=true`). Scholar grounding additionally emits
+one `ai_kb_query` only for a real Azure `/retrieve` attempt and one `ai_grounding_outcome` for the final
+KB or direct-MCP path. `pathRole=primary` distinguishes configured direct scholars from a real
+`pathRole=fallback`; only the latter carries `timeout`, `empty`, `error`, or `unconfigured`. Budget events
+may include role, categorical reason, aggregate dollars/turns, and
+whether provider usage was authoritative; they never include prompt text, conversation text, speaker/visitor
+identity, instance ID, or reservation ID. AI attribution events may add the coarse traffic class and an
+anonymous installation UUID already accepted by Observatory, but still never include prompt or answer text.
 
 ### Live kill switches
 
@@ -359,9 +384,11 @@ npx wrangler secret put NPC_LIVE_TOGGLE   # enter: true
 ```
 
 With `NPC_LIVE_TOGGLE="true"`, the Worker reads `ai_enabled`, `ambient_enabled`, and
-`player_chat_enabled` (`"true"`/`"false"`) on every resident request. KV may turn an env-enabled feature off,
-but can never turn an env-disabled feature on. A missing binding or KV read failure disables all resident AI
-for that request.
+`player_chat_enabled` (`"true"`/`"false"`) on every resident request. Every enabled feature requires an
+explicit KV `"true"`; missing or malformed keys fail closed. KV may permit an env-enabled feature, but can
+never turn an env-disabled feature on. A missing binding or KV read failure disables all resident AI for that
+request. `npcConfig` exposes the requested KV state separately from the effective env/budget-gated state so
+the dashboard can confirm asynchronous propagation instead of treating a successful write as activation.
 Cloudflare KV propagation can take up to about 60 seconds; use `NPC_AI_ENABLED=false` plus a Worker deploy for
 the account-level hard stop.
 

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -28,6 +28,7 @@
 //   GROUNDED_TIMEOUT_MS    optional fetch abort ms (default 25000; CF has no 10 s wall)
 //   GROUNDED_MAX_RUNTIME_S optional KB runtime budget seconds (default 30; KB requires 11–599)
 //   ALLOW_ORIGIN           optional, e.g. https://<you>.github.io (default *)
+//   METRICS_INGEST_TOKEN   shared Observatory secret (X-Repolis-Metrics-Key; never commit)
 //
 // Chronopolis Kronos Council (POST {action:"council"}) — see councilHandler near the bottom.
 //   COUNCIL_LIVE_ENABLED   "true" turns on the money-spending Live debate. DEFAULT OFF: every
@@ -53,9 +54,9 @@ import {
 
 export { NpcBudgetGovernor };
 
-// --- Direct-MCP fallback for scholar NPCs. Used ONLY when the scholar's Azure Knowledge
-// Base is unreachable/unconfigured (clone-friendly, keyless). Normally scholars go through
-// the shared KB-retrieve pipeline below (GPT synthesis in the user's language + trace). ---
+// --- Direct MCP for scholar NPCs. DeepWiki/Context7/Hugging Face use it as their configured
+// primary path; MS Learn uses it only when Azure KB retrieval fails (clone-friendly, keyless).
+// Other scholars normally go through the shared KB pipeline below. ---
 const MCP_NPCS = {
   msdocs: {
     url: "https://learn.microsoft.com/api/mcp",
@@ -262,18 +263,24 @@ async function directMcpResponse(npc, question, evidence, refs, tools, env, extr
       phase: "direct_mcp_synthesis", model: synthesis.model, usage: synthesis.usage, ms: synthesis.ms,
     }, { refs: refs.length, ...(extra.requestMeta || {}) });
   }
-  npcMetric(env, "ai_kb_query", {
-    route: groundedRoute(npc), phase: "direct_mcp", ks: cfg.source, kb: "direct",
-    npc, ms: elapsed, refs: refs.length, ok: true, ...(extra.requestMeta || {}),
-  }, extra.ctx);
   const ko = String(extra.lang || "").toLowerCase().startsWith("ko");
   const rawMessage = npc === "huggingface" && refs.length
     ? (ko ? "Hugging Face에서 찾은 결과예요:\n" : "Here are the Hugging Face results:\n")
       + refs.map((r, i) => `${i + 1}. ${r.name}${r.snippet ? ` — ${r.snippet}` : ""}`).join("\n")
     : cleanProse(evidence).slice(0, 1800);
+  const message = synthesis?.text || rawMessage;
+  emitDirectGrounding(env, extra, npc, { ok: true, ms: elapsed, refs: refs.length });
+  if (hasDeliveredContent(message, refs.length)) {
+    emitDeliveredAnswer(env, extra.ctx, groundedRoute(npc), extra.groundingTelemetry?.ks || cfg.source, npc, {
+      ms: elapsed,
+      refs: refs.length,
+      model: synthesis?.model || "none",
+      ...(extra.requestMeta || {}),
+    });
+  }
   return json({
     kind: "docs",
-    message: synthesis?.text || rawMessage,
+    message,
     usage: synthesis?.usage || null,
     items: refs,
     trace: { ks: cfg.source, tools, refs, docs: true, direct: true, mcpMs: elapsed, totalMs: elapsed },
@@ -303,6 +310,7 @@ async function context7Ask(question, env, extra) {
     }
     if (!libraryId) {
       clearTimeout(timer);
+      emitDirectGrounding(env, extra, "context7", { ok: false, ms: Date.now() - started, refs: 0 });
       return json({ kind: "docs", notFound: true, items: [], trace: { ks: cfg.source, tools: ["resolve-library-id"] } }, 200, env);
     }
     tools.push("query-docs");
@@ -316,14 +324,19 @@ async function context7Ask(question, env, extra) {
       if (publicDocs.ok) { text = await publicDocs.text(); tools.push("context7-llms"); }
     }
     clearTimeout(timer);
-    if (!text) return json({ fallback: true, reason: "empty Context7 docs" }, 200, env);
+    if (!text) {
+      emitDirectGrounding(env, extra, "context7", { ok: false, ms: Date.now() - started, refs: 0 });
+      return json({ fallback: true, reason: "empty Context7 docs" }, 200, env);
+    }
     if (/quota exceeded|rate limit|too many requests/i.test(text)) {
+      emitDirectGrounding(env, extra, "context7", { ok: false, ms: Date.now() - started, refs: 0 });
       return json({ fallback: true, reason: "Context7 quota exceeded" }, 200, env);
     }
     const refs = refsFromMarkdown(text, `https://context7.com/${libraryId.replace(/^\//, "")}`, libraryId);
     return directMcpResponse("context7", question, text, refs, tools, env, extra, started);
   } catch (e) {
     clearTimeout(timer);
+    emitDirectGrounding(env, extra, "context7", { ok: false, ms: Date.now() - started, refs: 0 });
     return json({ fallback: true, reason: e?.name === "AbortError" ? `timeout ${timeoutMs}ms` : String(e).slice(0, 160) }, 200, env);
   }
 }
@@ -346,8 +359,12 @@ async function huggingFaceAsk(question, env, extra) {
     const call = await mcpRpc(cfg.url, "tools/call", { name: tool, arguments: args }, sid, false, ctrl.signal, headers);
     clearTimeout(timer);
     const result = mcpResult(call), text = mcpText(call);
-    if (!text || result?.isError) return json({ fallback: true, reason: "empty Hugging Face results" }, 200, env);
+    if (!text || result?.isError) {
+      emitDirectGrounding(env, extra, "huggingface", { ok: false, ms: Date.now() - started, refs: 0 });
+      return json({ fallback: true, reason: "empty Hugging Face results" }, 200, env);
+    }
     if (/^\s*No (?:repositories|papers) found/i.test(text)) {
+      emitDirectGrounding(env, extra, "huggingface", { ok: false, ms: Date.now() - started, refs: 0 });
       return json({ kind: "docs", notFound: true, items: [], trace: { ks: cfg.source, tools: [tool] } }, 200, env);
     }
     const entries = Array.isArray(result?.structuredContent?.entries) ? result.structuredContent.entries : [];
@@ -357,6 +374,7 @@ async function huggingFaceAsk(question, env, extra) {
     return directMcpResponse("huggingface", question, text, refs, [tool], env, extra, started);
   } catch (e) {
     clearTimeout(timer);
+    emitDirectGrounding(env, extra, "huggingface", { ok: false, ms: Date.now() - started, refs: 0 });
     return json({ fallback: true, reason: e?.name === "AbortError" ? `timeout ${timeoutMs}ms` : String(e).slice(0, 160) }, 200, env);
   }
 }
@@ -421,15 +439,27 @@ async function mcpAsk(npc, question, env, extra = {}) {
 
     // DeepWiki-style: the text block IS the answer (free-form markdown prose).
     if (cfg.prose) {
-      if (!textBlock) return json({ fallback: true, reason: "empty mcp" }, 200, env);
+      if (!textBlock) {
+        emitDirectGrounding(env, extra, npc, { ok: false, ms: Date.now() - started, refs: 0 });
+        return json({ fallback: true, reason: "empty mcp" }, 200, env);
+      }
       // DeepWiki returns isError:false even when the repo isn't indexed — detect that text.
       if (/Repository not found|to index it|not been indexed|isn'?t indexed/i.test(textBlock)) {
+        emitDirectGrounding(env, extra, npc, { ok: false, ms: Date.now() - started, refs: 0 });
         return json({ kind: "docs", notFound: true, repoName: extra.repoName, items: [],
           trace: { source: cfg.source, tool: cfg.tool, repo: extra.repoName } }, 200, env);
       }
       const prose = cleanProse(textBlock).slice(0, 1500);
-      if (!prose) return json({ fallback: true, reason: "empty prose" }, 200, env);
+      if (!prose) {
+        emitDirectGrounding(env, extra, npc, { ok: false, ms: Date.now() - started, refs: 0 });
+        return json({ fallback: true, reason: "empty prose" }, 200, env);
+      }
       const url = "https://deepwiki.com/" + extra.repoName;
+      const elapsed = Date.now() - started;
+      emitDirectGrounding(env, extra, npc, { ok: true, ms: elapsed, refs: 1 });
+      emitDeliveredAnswer(env, extra.ctx, groundedRoute(npc), extra.groundingTelemetry?.ks || cfg.source, npc, {
+        ms: elapsed, refs: 1, model: "none", ...(extra.requestMeta || {}),
+      });
       return json({
         kind: "docs",
         message: prose,
@@ -450,7 +480,15 @@ async function mcpAsk(npc, question, env, extra = {}) {
       snippet: cleanDoc(r.content).slice(0, 420),
     })).filter((i) => i.title || i.snippet);
 
-    if (!items.length) return json({ fallback: true, reason: "no docs" }, 200, env);
+    if (!items.length) {
+      emitDirectGrounding(env, extra, npc, { ok: false, ms: Date.now() - started, refs: 0 });
+      return json({ fallback: true, reason: "no docs" }, 200, env);
+    }
+    const elapsed = Date.now() - started;
+    emitDirectGrounding(env, extra, npc, { ok: true, ms: elapsed, refs: items.length });
+    emitDeliveredAnswer(env, extra.ctx, groundedRoute(npc), extra.groundingTelemetry?.ks || cfg.source, npc, {
+      ms: elapsed, refs: items.length, model: "none", ...(extra.requestMeta || {}),
+    });
     return json({
       kind: "docs",
       items,
@@ -459,6 +497,7 @@ async function mcpAsk(npc, question, env, extra = {}) {
   } catch (e) {
     clearTimeout(timer);
     const reason = e.name === "AbortError" ? "timeout " + timeoutMs + "ms" : String(e).slice(0, 160);
+    emitDirectGrounding(env, extra, npc, { ok: false, ms: Date.now() - started, refs: 0 });
     return json({ fallback: true, reason }, 200, env);
   }
 }
@@ -1307,7 +1346,10 @@ function npcRedact(m) {
 }
 function npcMetric(env, name, meta, ctx) {
   try { const url = env.METRICS_URL; if (!url) return;
-    const task = fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ev: name, ts: Date.now(), ...npcRedact(meta) }) }).catch(() => {});
+    const headers = { "Content-Type": "application/json" };
+    const ingestToken = String(env.METRICS_INGEST_TOKEN || "").trim();
+    if (ingestToken && !/[\r\n]/.test(ingestToken)) headers["X-Repolis-Metrics-Key"] = ingestToken;
+    const task = fetch(url, { method: "POST", headers, body: JSON.stringify({ ev: name, ts: Date.now(), ...npcRedact(meta) }) }).catch(() => {});
     if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(task);
     return task;
   } catch { /* metrics never break a turn */ }
@@ -1375,16 +1417,35 @@ function emitProviderUsage(env, ctx, route, ks, npc, activity, base) {
     npc: npc || "unknown",
     model: activity.model || "unknown",
     ms: activity.ms,
-    ok: true,
+    ok: activity.ok !== false,
     ai: true,
     providerCall: true,
     answer: false,
     tokensIn: u.prompt_tokens,
     cachedTokens: u.cached_tokens,
     tokensOut: u.completion_tokens,
-    costUsd: modelCostUsd(env, u),
+    costUsd: Number.isFinite(Number(activity.costUsd)) ? Math.max(0, Number(activity.costUsd)) : modelCostUsd(env, u),
     ...(base || {}),
   }, ctx);
+}
+function emitDeliveredAnswer(env, ctx, route, ks, npc, delivery) {
+  npcMetric(env, "ai_chat_turn", {
+    route,
+    phase: "delivered_answer",
+    ks: ks || "none",
+    npc: npc || "unknown",
+    model: delivery?.model || "none",
+    ms: Math.max(0, Number(delivery?.ms) || 0),
+    refs: Math.max(0, Number(delivery?.refs) || 0),
+    ok: true,
+    ai: true,
+    providerCall: false,
+    answer: true,
+    ...(delivery || {}),
+  }, ctx);
+}
+function hasDeliveredContent(message, refs) {
+  return !!String(message || "").trim() || Math.max(0, Number(refs) || 0) > 0;
 }
 function emitKbQuery(env, ctx, route, cfg, npc, out, base) {
   if (!out?.attempted) return;
@@ -1395,11 +1456,53 @@ function emitKbQuery(env, ctx, route, cfg, npc, out, base) {
     ks: cfg?.ks || "none",
     kb: cfg?.kb || "none",
     npc: npc || "unknown",
+    groundingPath: "grounded_via_kb",
+    pathRole: "primary",
     ms: Math.max(0, Number(out?.totalMs) || 0),
     refs,
     ok: !!out?.ok,
     ...base,
   }, ctx);
+}
+function boundedGroundingReason(out) {
+  const reason = String(out?.reason || "").toLowerCase();
+  if (!out?.attempted || /unconfig|not configured|missing/.test(reason)) return "unconfigured";
+  if (/timeout|abort/.test(reason)) return "timeout";
+  if (out?.ok && !out?.answer && !(out?.data?.references || []).length) return "empty";
+  if (/empty|no (?:docs|documents|references|sources|results)|not found/.test(reason)) return "empty";
+  return "error";
+}
+function emitGroundingOutcome(env, ctx, route, cfg, npc, outcome, base) {
+  const pathRole = outcome?.pathRole === "fallback" ? "fallback" : "primary";
+  const meta = {
+    route,
+    phase: "grounding_outcome",
+    ks: cfg?.ks || "none",
+    kb: cfg?.kb || "none",
+    npc: npc || "unknown",
+    groundingPath: outcome?.groundingPath,
+    pathRole,
+    ms: Math.max(0, Number(outcome?.ms) || 0),
+    refs: Math.max(0, Number(outcome?.refs) || 0),
+    ok: outcome?.ok === true,
+    ...(base || {}),
+  };
+  if (pathRole === "fallback") meta.fallbackReason = outcome?.fallbackReason || "unknown";
+  npcMetric(env, "ai_grounding_outcome", meta, ctx);
+}
+function emitDirectGrounding(env, extra, npc, result) {
+  const telemetry = extra?.groundingTelemetry || {};
+  emitGroundingOutcome(env, extra?.ctx, groundedRoute(npc), {
+    ks: telemetry.ks || MCP_NPCS[npc]?.source || "none",
+    kb: telemetry.kb || "none",
+  }, npc, {
+    groundingPath: "grounded_via_mcp_direct",
+    pathRole: telemetry.pathRole === "fallback" ? "fallback" : "primary",
+    fallbackReason: telemetry.fallbackReason,
+    ok: result?.ok === true,
+    ms: result?.ms,
+    refs: result?.refs,
+  }, extra?.requestMeta);
 }
 // Provider adapter. A caller must hold a Durable Object reservation; aiEnabled is a second hard ceiling.
 async function npcModelCall(env, role, plan, aiEnabled) {
@@ -1442,19 +1545,46 @@ async function npcModelCall(env, role, plan, aiEnabled) {
 }
 // --- Live flag resolver. NPC_LIVE_TOGGLE is the master kill-switch. When it is NOT "true",
 //     behaviour is exactly the env-gated default (KV ignored) — the safe, deploy-only posture.
-//     When "true", the shared NPC_FLAGS KV overrides per key in near real time (owner dashboard
-//     writes it), with the matching env var as the per-key fallback. AI can never be enabled unless
-//     this resolver returns aiEnabled=true, so the hard model-call ceiling is preserved. ---
+//     When "true", the shared NPC_FLAGS KV must explicitly allow each key in near real time (owner
+//     dashboard writes it). Missing/malformed keys fail closed. AI can never be enabled unless this
+//     resolver returns aiEnabled=true, so the hard model-call ceiling is preserved. ---
 async function npcResolveFlags(env) {
   const envAi = env.NPC_AI_ENABLED === "true";
   const envAmb = env.NPC_AMBIENT_ENABLED === "true";
   const envPc = env.NPC_PLAYER_CHAT_ENABLED === "true";
   const liveToggle = env.NPC_LIVE_TOGGLE === "true";
+  const hardCeiling = { ai: envAi, ambient: envAmb, player: envPc };
+  const contract = {
+    hardAiEnabled: envAi,
+    hardAmbientEnabled: envAmb,
+    hardPlayerChatEnabled: envPc,
+    hardCeiling,
+  };
   if (!liveToggle) {
-    return { aiEnabled: envAi, ambientEnabled: envAi && envAmb, playerChatEnabled: envAi && envPc, source: "env", liveToggle: false };
+    const effective = { ai: envAi, ambient: envAi && envAmb, player: envAi && envPc };
+    return {
+      ...contract,
+      aiEnabled: effective.ai,
+      ambientEnabled: effective.ambient,
+      playerChatEnabled: effective.player,
+      requested: effective,
+      effective,
+      source: "env",
+      liveToggle: false,
+    };
   }
   if (!env.NPC_FLAGS || typeof env.NPC_FLAGS.get !== "function") {
-    return { aiEnabled: false, ambientEnabled: false, playerChatEnabled: false, source: "kv-unavailable", liveToggle: true };
+    const effective = { ai: false, ambient: false, player: false };
+    return {
+      ...contract,
+      aiEnabled: false,
+      ambientEnabled: false,
+      playerChatEnabled: false,
+      requested: { ai: null, ambient: null, player: null },
+      effective,
+      source: "kv-unavailable",
+      liveToggle: true,
+    };
   }
   let kAi = null, kAmb = null, kPc = null;
   try {
@@ -1464,15 +1594,41 @@ async function npcResolveFlags(env) {
       env.NPC_FLAGS.get("player_chat_enabled"),
     ]);
   } catch {
-    return { aiEnabled: false, ambientEnabled: false, playerChatEnabled: false, source: "kv-unavailable", liveToggle: true };
+    const effective = { ai: false, ambient: false, player: false };
+    return {
+      ...contract,
+      aiEnabled: false,
+      ambientEnabled: false,
+      playerChatEnabled: false,
+      requested: { ai: null, ambient: null, player: null },
+      effective,
+      source: "kv-unavailable",
+      liveToggle: true,
+    };
   }
-  const allows = (kv) => kv !== "false";
-  const ai = envAi && allows(kAi);
+  // Live mode requires an explicit true. Missing/malformed keys fail closed, so
+  // enabling deployment ceilings can never awaken a latent default state.
+  const allows = (kv) => kv === "true";
+  const requestedAi = allows(kAi);
+  const requested = {
+    ai: requestedAi,
+    ambient: requestedAi && allows(kAmb),
+    player: requestedAi && allows(kPc),
+  };
+  const effective = {
+    ai: envAi && requested.ai,
+    ambient: envAi && envAmb && requested.ambient,
+    player: envAi && envPc && requested.player,
+  };
   return {
-    aiEnabled: ai,
-    ambientEnabled: ai && envAmb && allows(kAmb),
-    playerChatEnabled: ai && envPc && allows(kPc),
-    source: "kv", liveToggle: true,
+    ...contract,
+    aiEnabled: effective.ai,
+    ambientEnabled: effective.ambient,
+    playerChatEnabled: effective.player,
+    requested,
+    effective,
+    source: "kv",
+    liveToggle: true,
   };
 }
 async function npcHandler(body, request, env, ctx) {
@@ -1483,14 +1639,41 @@ async function npcHandler(body, request, env, ctx) {
   const ambientOn = flags.ambientEnabled;
   const playerOn = flags.playerChatEnabled;
   const emitBudgetMetric = (name, meta) => npcMetric(env, name, meta, ctx);
+  const requestMeta = metricContext(body, request);
 
   if (action === "npcConfig") {
     const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
     const budgetReady = budget.available === true;
+    const effective = {
+      ai: aiEnabled && budgetReady,
+      ambient: ambientOn && budgetReady,
+      player: playerOn && budgetReady,
+    };
+    const pending = Object.keys(effective).some((key) =>
+      typeof flags.requested?.[key] === "boolean" && flags.requested[key] !== effective[key]
+    );
+    const canEnable = flags.liveToggle === true
+      && flags.source === "kv"
+      && flags.hardAiEnabled === true
+      && budgetReady;
+    const blockReason = flags.liveToggle !== true ? "live_toggle_off"
+      : flags.source !== "kv" ? "kv_unavailable"
+      : flags.hardAiEnabled !== true ? "npc_hard_ceiling_off"
+      : !budgetReady ? "npc_budget_unavailable"
+      : null;
     return json({ ok: true, config: {
-      aiEnabled: aiEnabled && budgetReady,
-      ambientEnabled: ambientOn && budgetReady,
-      playerChatEnabled: playerOn && budgetReady,
+      aiEnabled: effective.ai,
+      ambientEnabled: effective.ambient,
+      playerChatEnabled: effective.player,
+      requested: flags.requested,
+      effective,
+      pending,
+      canEnable,
+      blockReason,
+      hardAiEnabled: flags.hardAiEnabled,
+      hardAmbientEnabled: flags.hardAmbientEnabled,
+      hardPlayerChatEnabled: flags.hardPlayerChatEnabled,
+      hardCeiling: flags.hardCeiling,
       maxTurns: Number(env.NPC_MAX_TURNS || 6), hardMaxTurns: Number(env.NPC_HARD_MAX_TURNS || 10),
       source: "durable-object", flagSource: flags.source, liveToggle: flags.liveToggle,
     }, budget }, 200, env);
@@ -1501,6 +1684,8 @@ async function npcHandler(body, request, env, ctx) {
 
   if (action === "npcAmbientTurn" || action === "npcPlayerChat") {
     const role = action === "npcAmbientTurn" ? "ambient" : "player";
+    const route = role === "ambient" ? "persona_ambient" : "persona_visitor";
+    const npc = String(body.speaker || "resident").slice(0, 40);
     const featureOn = role === "ambient" ? ambientOn : playerOn;
     if (String(body.speaker || "").toLowerCase() === "auri") {
       const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
@@ -1525,6 +1710,16 @@ async function npcHandler(body, request, env, ctx) {
       providerCall: (plan) => npcModelCall(env, role, plan, aiEnabled),
     });
     if (!turn.ok) {
+      if (turn.usage) {
+        emitProviderUsage(env, ctx, route, "none", npc, {
+          phase: role + "_model",
+          model: turn.model,
+          usage: turn.usage,
+          costUsd: turn.costUsd,
+          ms: 0,
+          ok: false,
+        }, requestMeta);
+      }
       const exhausted = ["day_cap_zero", "day_cap_exhausted", "daily_turn_max", "daily_attempt_max"].includes(turn.reason);
       return json({
         ok: !exhausted,
@@ -1533,9 +1728,23 @@ async function npcHandler(body, request, env, ctx) {
         budget: turn.budget,
       }, 200, env);
     }
+    const line = capLine(turn.value.text, role === "ambient" ? 90 : 180);
+    emitProviderUsage(env, ctx, route, "none", npc, {
+      phase: role + "_model",
+      model: turn.model,
+      usage: turn.usage,
+      costUsd: turn.costUsd,
+      ms: turn.value?.ms,
+    }, requestMeta);
+    emitDeliveredAnswer(env, ctx, route, "none", npc, {
+      model: turn.model,
+      ms: turn.value?.ms,
+      refs: 0,
+      ...requestMeta,
+    });
     return json({
       ok: true,
-      line: capLine(turn.value.text, role === "ambient" ? 90 : 180),
+      line,
       usage: turn.usage,
       model: turn.model,
       budget: turn.budget,
@@ -1594,6 +1803,7 @@ export default {
       const g = await chatLLM(who, history, question, lang, env);
       if (g) {
         emitProviderUsage(env, ctx, "persona_visitor", "none", who, { phase: "persona", model: g.model, usage: g.usage, ms: g.ms }, requestMeta);
+        emitDeliveredAnswer(env, ctx, "persona_visitor", "none", who, { model: g.model, ms: g.ms, refs: 0, ...requestMeta });
         return json({
         repo: null, message: g.text, general: true, usage: g.usage, model: g.model,
         trace: { general: true, model: env.AOAI_DEPLOYMENT || "gpt-5.4-mini" },
@@ -1620,7 +1830,22 @@ export default {
     // KB unreachable / slow / unconfigured / empty. A scholar with its own public MCP falls
     // back to a direct keyless call (clone-friendly); the taxi tells the client to use Local.
     if (out.fallback || (!out.answer && !(out.data?.references || []).length)) {
-      if (MCP_NPCS[who]) return mcpAsk(who, question, env, { repoName, lang, history, ctx, requestMeta });
+      if (MCP_NPCS[who]) {
+        const pathRole = cfg.kb ? "fallback" : "primary";
+        const groundingTelemetry = {
+          ks: cfg.ks || MCP_NPCS[who].source,
+          kb: cfg.kb || "none",
+          pathRole,
+          ...(pathRole === "fallback" ? { fallbackReason: boundedGroundingReason(out) } : {}),
+        };
+        return mcpAsk(who, question, env, { repoName, lang, history, ctx, requestMeta, groundingTelemetry });
+      }
+      if (out.attempted) {
+        emitGroundingOutcome(env, ctx, route, cfg, who, {
+          groundingPath: "grounded_via_kb", pathRole: "primary", ok: false,
+          ms: out.totalMs, refs: 0,
+        }, requestMeta);
+      }
       return json({ fallback: true, reason: out.reason || "empty grounding", detail: out.detail }, 200, env);
     }
 
@@ -1628,6 +1853,16 @@ export default {
       // Taxi driver → pick the best repo so the client can drive there.
       const refs = parseRefs(out.data.references);
       const repo = pickRepo(out.answer, refs);
+      emitGroundingOutcome(env, ctx, route, cfg, who, {
+        groundingPath: "grounded_via_kb", pathRole: "primary", ok: true,
+        ms: out.totalMs, refs: refs.length,
+      }, requestMeta);
+      if (hasDeliveredContent(out.answer, refs.length)) {
+        emitDeliveredAnswer(env, ctx, route, cfg.ks, who, {
+          model: (out.modelActivities || []).at(-1)?.model || "unknown",
+          ms: out.totalMs, refs: refs.length, ...requestMeta,
+        });
+      }
       return json({
         repo,
         message: out.answer,
@@ -1642,14 +1877,41 @@ export default {
     // exist we always surface them as references — even when the synthesized answer hedges —
     // so the user sees the sources they asked for instead of an unsourced "general" reply.
     if (!docs.length) {
+      emitGroundingOutcome(env, ctx, route, cfg, who, {
+        groundingPath: "grounded_via_kb", pathRole: "primary", ok: false,
+        ms: out.totalMs, refs: 0,
+      }, requestMeta);
       if (who === "market") return json({ fallback: true, reason: "market sources unavailable" }, 200, env);
       const g = await chatLLM(who, history, question, lang, env);
       if (g) {
         emitProviderUsage(env, ctx, "persona_visitor", "none", who, { phase: "persona", model: g.model, usage: g.usage, ms: g.ms }, requestMeta);
+        emitDeliveredAnswer(env, ctx, "persona_visitor", "none", who, { model: g.model, ms: g.ms, refs: 0, ...requestMeta });
         return json({
         repo: null, message: g.text, general: true, usage: g.usage, model: g.model,
         trace: { general: true, model: env.AOAI_DEPLOYMENT || "gpt-5.4-mini" },
       }, 200, env); }
+      if (hasDeliveredContent(out.answer, 0)) {
+        emitDeliveredAnswer(env, ctx, "persona_visitor", "none", who, {
+          model: (out.modelActivities || []).at(-1)?.model || "unknown",
+          ms: out.totalMs, refs: 0, ...requestMeta,
+        });
+      }
+      return json({
+        repo: null,
+        message: out.answer,
+        usage,
+        trace: { ks: cfg.ks, tools: out.tools, refs: [], docs: true, mcpMs: out.mcpMs, totalMs: out.totalMs, partial: out.status === 206 },
+      }, 200, env);
+    }
+    emitGroundingOutcome(env, ctx, route, cfg, who, {
+      groundingPath: "grounded_via_kb", pathRole: "primary", ok: true,
+      ms: out.totalMs, refs: docs.length,
+    }, requestMeta);
+    if (hasDeliveredContent(out.answer, docs.length)) {
+      emitDeliveredAnswer(env, ctx, route, cfg.ks, who, {
+        model: (out.modelActivities || []).at(-1)?.model || "unknown",
+        ms: out.totalMs, refs: docs.length, ...requestMeta,
+      });
     }
     return json({
       repo: null,

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -66,6 +66,8 @@ AOAI_API_VERSION = "2025-04-01-preview"
 # Private aggregate telemetry target and model-cost attribution assumptions.
 # The prices match the observed Foundry Models input/cached-input/output meters
 # and are shown verbatim in the private Observatory methodology panel.
+# Set the same random secret on this Worker and repolis-metrics; never commit it:
+#   wrangler secret put METRICS_INGEST_TOKEN
 METRICS_URL = "https://repolis-metrics.wingnut0310.workers.dev/event"
 MODEL_PRICE_IN_PER_1M_USD = "0.75"
 MODEL_PRICE_CACHED_IN_PER_1M_USD = "0.075"
@@ -78,6 +80,13 @@ NPC_MAX_COMPLETION_TOKENS = "120"
 NPC_BUDGET_TIMEOUT_MS = "1500"
 NPC_DAILY_ATTEMPT_MAX = "5000"
 NPC_RESERVATION_LEASE_MS = "60000"
+# Deployment ceilings permit the owner-only KV switches to turn resident AI on.
+# Live mode still requires explicit KV "true" values; missing keys fail closed.
+NPC_AI_ENABLED = "true"
+NPC_AMBIENT_ENABLED = "true"
+NPC_PLAYER_CHAT_ENABLED = "true"
+# 31-day worst case = $4.65 for resident Azure model calls.
+NPC_DAY_CAP_USD = "0.15"
 
 # Set your Azure AI Search endpoint (not secret, but account-specific). Either
 # uncomment + edit here, or keep it out of git with `wrangler secret put SEARCH_ENDPOINT`:

--- a/index.html
+++ b/index.html
@@ -6870,7 +6870,7 @@ function _advanceAmb(){ const C=_ambConv; if(!C||C.pending) return; const now=cl
   function done(line,ai,fb){ if(_ambConv!==C){ C.pending=false; return; } line=_capBub(line); speaker.bub.say(line,_hex(speaker.res.color)); speaker._gt=2.2;
     const turn={ t:Math.round(clock.elapsedTime), a:C.a.res.id, b:C.b.res.id, who:speaker.res.id, text:line, ai:!!ai, fb:!!fb };
     C.turns.push(turn); _pushTranscript(turn); if(fb) _npcBudget.fallbackTurns++; if(ai) _npcBudget.aiTurns++;
-    _emitMetric('npc_ambient_turn',{who:speaker.res.id,ai:!!ai,fb:!!fb,len:line.length});
+    _emitMetric('npc_ambient_turn',{route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false,who:speaker.res.id,ai:!!ai,fb:!!fb,len:line.length});
     C.i++; C.prevWho=speaker; C.si=(C.si+1)%C.members.length; C.nextAt=now + NPC_CFG.gapMin + Math.random()*(NPC_CFG.gapMax-NPC_CFG.gapMin); if(C.i>=C.max) _endAmb('done'); }   // the speaking turn round-robins through every circle member so all of them talk, not just two
   if(useAI){ C.pending=true; C.nextAt=now+9.5; _aiAmbientTurn(C,speaker,listener).then(line=>{ C.pending=false; if(line) done(line,true,false); else done(_scriptLine(speaker),false,true); }).catch(()=>{ C.pending=false; done(_scriptLine(speaker),false,true); }); }
   else done(_scriptLine(speaker),false,false); }
@@ -7097,9 +7097,9 @@ async function _npcFetch(payload){ const url=NPC_CFG.worker; if(!url) return nul
     if(!res.ok) return null; const data=await res.json(); if(data&&data.budget) _applyBudget(data.budget); return data; }
   catch(e){ clearTimeout(to); return null; } }
 async function _aiAmbientTurn(C,speaker,listener){ const data=await _npcFetch({ npc_action:'npcAmbientTurn', speaker:speaker.res.id, listener:listener.res.id, zone:speaker.res.zone, topic:C.topic, lang:LANG, last:C.turns.slice(-4).map(t=>({who:t.who,text:t.text})) });
-  if(!data){ _emitMetric('npc_fallback_used',{where:'ambient',reason:'fetch_fail'}); return null; }
-  if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{where:'ambient'}); } _emitMetric('npc_fallback_used',{where:'ambient',reason:data.reason||'no_line'}); return null; }
-  _emitMetric('npc_budget_spend',{where:'ambient',spent:_npcBudget.spentUsd}); return String(data.line); }
+  if(!data){ _emitMetric('npc_fallback_used',{route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'ambient',reason:'fetch_fail'}); return null; }
+  if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'ambient'}); } _emitMetric('npc_fallback_used',{route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'ambient',reason:data.reason||'no_line'}); return null; }
+  _emitMetric('npc_budget_spend',{route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'ambient',spent:_npcBudget.spentUsd}); return String(data.line); }
 // ---- shared resident/group chat transcript: every speaker answers on top of the thread (and a chime-in reacts in context) ----
 let _resHist=[], _marketThread=false, _marketRequestSeq=0, _marketAbort=null;   // resident thread + cancellable AURI request generation
 function _plain(s){ return String(s==null?'':s).replace(/<[^>]*>/g,' ').replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/\s+/g,' ').trim(); }
@@ -7108,9 +7108,9 @@ function _resHistWindow(){ return _resHist.slice(-10); }             // recent w
 async function _aiPlayerChat(res,q,opts){ opts=opts||{}; const payload={ npc_action:'npcPlayerChat', speaker:res.id, zone:res.zone, question:q, lang:LANG };
   if(opts.last&&opts.last.length) payload.last=opts.last; if(opts.chime){ payload.chime=true; if(opts.prev) payload.prev=opts.prev; }   // last=prior thread; chime/prev → react to the previous speaker
   const data=await _npcFetch(payload);
-  if(!data){ _emitMetric('npc_fallback_used',{where:'player',reason:'fetch_fail'}); return null; }
-  if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{where:'player'}); } _emitMetric('npc_fallback_used',{where:'player',reason:data.reason||'no_line'}); return null; }
-  _emitMetric('npc_budget_spend',{where:'player',spent:_npcBudget.spentUsd}); return String(data.line); }
+  if(!data){ _emitMetric('npc_fallback_used',{route:'persona_visitor',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'player',reason:'fetch_fail'}); return null; }
+  if(data.fallback||!data.line){ if(data.reason==='npc_budget_exhausted'){ _npcBudget.blocked=true; _emitMetric('npc_budget_blocked',{route:'persona_visitor',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'player'}); } _emitMetric('npc_fallback_used',{route:'persona_visitor',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'player',reason:data.reason||'no_line'}); return null; }
+  _emitMetric('npc_budget_spend',{route:'persona_visitor',npc:'resident',phase:'client_observation',answer:false,providerCall:false,where:'player',spent:_npcBudget.spentUsd}); return String(data.line); }
 
 // ---- deterministic scripted player-chat reply (grounded in the resident's district/repos; good-topics only) ----
 function _zoneNames(n){ return ZONES.slice(0,n||3).map(z=>LANG==='ko'?z.ko:z.en).join(', '); }
@@ -7340,7 +7340,7 @@ async function npcBootConfig(){ NPC_CFG.worker=(typeof groundedUrl==='function'?
   if(data.config){ const c=data.config; NPC_CFG.aiEnabled=!!c.aiEnabled; NPC_CFG.ambientAiEnabled=!!c.aiEnabled&&!!c.ambientEnabled; NPC_CFG.playerChatAiEnabled=!!c.aiEnabled&&!!c.playerChatEnabled;
     if(c.maxTurns){ const cap=Math.min(NPC_CFG.hardMaxTurns,c.maxTurns); NPC_CFG.maxTurns=LOW_END?Math.min(NPC_CFG.maxTurns,cap):cap; } }   // LOW_END: worker may tighten turns, never loosen past the low-end cap
   if(data.budget) _applyBudget(data.budget);
-  _emitMetric('npc_mode_changed',{aiEnabled:NPC_CFG.aiEnabled,ambient:NPC_CFG.ambientAiEnabled,player:NPC_CFG.playerChatAiEnabled,source:'worker'}); }
+  _emitMetric('npc_mode_changed',{route:'persona_ambient',npc:'system',phase:'client_observation',answer:false,providerCall:false,aiEnabled:NPC_CFG.aiEnabled,ambient:NPC_CFG.ambientAiEnabled,player:NPC_CFG.playerChatAiEnabled,source:'worker'}); }
 setTimeout(()=>{ try{ npcBootConfig(); }catch(e){} }, 2600);
 
 /* ---- character (chibi, cute — soft rounded forms, no hard boxes) ---- */
@@ -8788,12 +8788,13 @@ function traceRefCount(tr){ return tr&&Array.isArray(tr.refs) ? tr.refs.length :
 function trackChatEvent(name, extra){ track(name, chatMeta(extra)); }
 function canonicalAiRoute(route,npc){ const who=npcKindOf(npc);
   if(route==='grounded') return 'grounded_kb_taxi';
-  if(route==='scholar_grounded') return who==='msdocs'?'grounded_mcp_mslearn':who==='deepwiki'?'grounded_mcp_deepwiki':'persona_visitor';
+  if(route==='market_grounded') return 'grounded_kb_market';
+  if(route==='scholar_grounded') return who==='msdocs'?'grounded_mcp_mslearn':who==='deepwiki'?'grounded_mcp_deepwiki':who==='context7'?'grounded_mcp_context7':who==='huggingface'?'grounded_mcp_huggingface':'persona_visitor';
   if(route==='general_chat'||route==='scholar') return 'persona_visitor';
   return route; }
 function aiRequestPayload(payload){ return Object.assign({},payload,analyticsIdentity()); }
 function trackAiTurn(route, npc, q, start, outcome){ const canonical=canonicalAiRoute(route,npc); trackChatEvent('ai_chat_turn', Object.assign({
-  route:canonical, legacyRoute:canonical===route?undefined:route, phase:'answer', answer:true, providerCall:false,
+  route:canonical, legacyRoute:canonical===route?undefined:route, phase:'client_observation', answer:false, providerCall:false,
   npc:npcKindOf(npc), qLen:qLenBucket(q), ms:elapsedMs(start)
 }, outcome||{})); }
 function stripHtml(h){ const d=document.createElement('div'); d.innerHTML=String(h||''); return (d.textContent||d.innerText||'').replace(/\s+/g,' ').trim().slice(0,600); }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1142,17 +1142,160 @@ ok(/if \(body && body\.npc_action\) return npcHandler\(body, request, env, ctx\)
 ok(/async function npcHandler\(/.test(WORKER), 'npcHandler() exists');
 ok(/grounded_mcp_mslearn/.test(WORKER) && /grounded_mcp_deepwiki/.test(WORKER) && /grounded_kb_taxi/.test(WORKER), 'grounded AI routes use the report taxonomy');
 ok(/tokensIn: u\.prompt_tokens/.test(WORKER) && /cachedTokens: u\.cached_tokens/.test(WORKER) && /tokensOut: u\.completion_tokens/.test(WORKER), 'provider usage emits input, cached-input, and output tokens');
+ok(/headers\["X-Repolis-Metrics-Key"\] = ingestToken/.test(WORKER)
+  && /env\.METRICS_INGEST_TOKEN/.test(WORKER),
+  'server telemetry authenticates to Observatory with the shared ingest secret');
+ok((WORKER.match(/npcMetric\(env, "ai_kb_query"/g) || []).length === 1
+  && /groundingPath: "grounded_via_kb"/.test(WORKER)
+  && /pathRole: "primary"/.test(WORKER),
+  'ai_kb_query is emitted only by the real Azure KB retrieve-attempt helper');
+ok(/function emitGroundingOutcome\(/.test(WORKER)
+  && /npcMetric\(env, "ai_grounding_outcome"/.test(WORKER)
+  && /groundingPath: "grounded_via_mcp_direct"/.test(WORKER)
+  && /pathRole === "fallback"/.test(WORKER)
+  && /boundedGroundingReason\(out\)/.test(WORKER),
+  'final grounding telemetry separates KB from direct MCP and labels only true fallbacks');
+const reasonSource = (WORKER.match(/function boundedGroundingReason\([\s\S]*?(?=\nfunction emitGroundingOutcome)/) || [''])[0];
+const outcomeSource = (WORKER.match(/function emitGroundingOutcome\([\s\S]*?(?=\nfunction emitDirectGrounding)/) || [''])[0];
+if (reasonSource && outcomeSource) {
+  const boundedReason = new Function(`${reasonSource}; return boundedGroundingReason;`)();
+  ok(boundedReason({ attempted: false, reason: 'grounding not configured' }) === 'unconfigured'
+    && boundedReason({ attempted: true, reason: 'timeout 25000ms' }) === 'timeout'
+    && boundedReason({ attempted: true, ok: true, answer: '', data: { references: [] } }) === 'empty'
+    && boundedReason({ attempted: true, reason: 'kb 500' }) === 'error',
+    'fallback reasons collapse to the four metrics-safe categories');
+  const outcomes = [];
+  const emitOutcome = new Function('npcMetric', `${outcomeSource}; return emitGroundingOutcome;`)(
+    (_env, event, meta) => outcomes.push({ event, meta })
+  );
+  emitOutcome({}, null, 'grounded_mcp_context7', { ks: 'context7-direct', kb: 'none' }, 'context7', {
+    groundingPath: 'grounded_via_mcp_direct', pathRole: 'primary', fallbackReason: 'timeout', ok: true,
+  });
+  emitOutcome({}, null, 'grounded_mcp_mslearn', { ks: 'microsoft-learn-mcp-ks', kb: 'repolis-mslearn-kb' }, 'msdocs', {
+    groundingPath: 'grounded_via_mcp_direct', pathRole: 'fallback', fallbackReason: 'timeout', ok: true,
+  });
+  ok(outcomes[0].event === 'ai_grounding_outcome' && outcomes[0].meta.pathRole === 'primary'
+    && outcomes[0].meta.fallbackReason === undefined
+    && outcomes[1].meta.pathRole === 'fallback' && outcomes[1].meta.fallbackReason === 'timeout',
+    'direct-primary has no fallback reason while KB-to-direct fallback retains its bounded cause');
+}
+const providerTelemetry = (WORKER.match(/function emitProviderUsage\([\s\S]*?(?=\nfunction emitDeliveredAnswer)/) || [''])[0];
+const answerTelemetry = (WORKER.match(/function emitDeliveredAnswer\([\s\S]*?(?=\nfunction hasDeliveredContent)/) || [''])[0];
+ok(/providerCall: true/.test(providerTelemetry) && /answer: false/.test(providerTelemetry)
+  && /providerCall: false/.test(answerTelemetry) && /answer: true/.test(answerTelemetry)
+  && /phase: "delivered_answer"/.test(answerTelemetry),
+  'provider usage is additive and distinct from the exactly-one delivered-answer contract');
+const deliveredContentSource = (WORKER.match(/function hasDeliveredContent\([\s\S]*?(?=\nfunction emitKbQuery)/) || [''])[0];
+if (deliveredContentSource) {
+  const hasDeliveredContent = new Function(`${deliveredContentSource}; return hasDeliveredContent;`)();
+  ok(!hasDeliveredContent('', 0) && !hasDeliveredContent('   ', 0)
+    && hasDeliveredContent('answer', 0) && hasDeliveredContent('', 2),
+    'delivered-answer denominator requires visible text or visible result references');
+}
+ok(/if \(hasDeliveredContent\(out\.answer, 0\)\) \{[\s\S]{0,160}emitDeliveredAnswer\(env, ctx, "persona_visitor", "none"/.test(WORKER),
+  'a no-doc KB response is never mislabeled as a successful grounded delivered answer');
+const metricTransportSource = (WORKER.match(/function npcRedact\([\s\S]*?(?=\nfunction metricContext)/) || [''])[0];
+ok(!!metricTransportSource, 'trusted telemetry transport is extractable for behavioral checks');
+if (metricTransportSource) {
+  const originalFetch = globalThis.fetch;
+  const metricRequests = [];
+  globalThis.fetch = async (url, init) => {
+    metricRequests.push({ url, init });
+    return new Response(null, { status: 204 });
+  };
+  try {
+    const metric = new Function(`${metricTransportSource}; return npcMetric;`)();
+    await metric({ METRICS_URL: 'https://metrics.example/event', METRICS_INGEST_TOKEN: 'shared-secret' },
+      'ai_chat_turn', { answer: true, providerCall: false, question: 'private' });
+    const sent = metricRequests[0];
+    const sentBody = JSON.parse(sent.init.body);
+    ok(new Headers(sent.init.headers).get('X-Repolis-Metrics-Key') === 'shared-secret'
+      && sentBody.answer === true && sentBody.providerCall === false
+      && sentBody.question === undefined && sentBody.question_len === 7,
+      'trusted telemetry sends the secret header while redacting prompt text');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+ok(/route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false/.test(HTML),
+  'browser ambient observations are explicitly non-authoritative and never leak into the none route');
+ok(/function trackAiTurn\([\s\S]{0,260}phase:'client_observation', answer:false, providerCall:false/.test(HTML),
+  'browser scholar/taxi observations cannot duplicate the Worker delivered-answer denominator');
+ok(/who==='context7'\?'grounded_mcp_context7':who==='huggingface'\?'grounded_mcp_huggingface'/.test(HTML)
+  && /route==='market_grounded'\) return 'grounded_kb_market'/.test(HTML),
+  'client route aliases match the Worker taxonomy for Context7, Hugging Face, and market grounding');
 ok(/action === "npcConfig"/.test(WORKER) && /action === "npcBudget"/.test(WORKER) && /"npcAmbientTurn"/.test(WORKER) && /"npcPlayerChat"/.test(WORKER), 'all four npc actions (config/budget/ambientTurn/playerChat) handled');
 ok(/if \(!aiEnabled\) return \{ ok: false, reason: "npc_ai_disabled" \}/.test(WORKER), 'hard ceiling: npcModelCall refuses unless the resolved aiEnabled is true');
 ok(/async function npcResolveFlags\(/.test(WORKER), 'npcResolveFlags() resolves the effective NPC flags (env vs live KV)');
 ok(/env\.NPC_LIVE_TOGGLE === "true"/.test(WORKER), 'NPC_LIVE_TOGGLE is the master kill-switch for the live toggle');
-ok(/source: "env", liveToggle: false/.test(WORKER), 'live toggle OFF → resolver ignores KV and stays env-gated (safe deploy-only default)');
+ok(/source: "env"[\s\S]{0,80}liveToggle: false/.test(WORKER), 'live toggle OFF → resolver ignores KV and stays env-gated (safe deploy-only default)');
 ok(/env\.NPC_FLAGS\.get\(/.test(WORKER), 'live mode reads on/off from the shared NPC_FLAGS KV');
-ok(/const ai = envAi && allows\(kAi\)/.test(WORKER)
-  && /ambientEnabled: ai && envAmb && allows\(kAmb\)/.test(WORKER)
-  && /playerChatEnabled: ai && envPc && allows\(kPc\)/.test(WORKER)
+ok(/const allows = \(kv\) => kv === "true"/.test(WORKER)
+  && /ai: envAi && requested\.ai/.test(WORKER)
+  && /ambient: envAi && envAmb && requested\.ambient/.test(WORKER)
+  && /player: envAi && envPc && requested\.player/.test(WORKER)
   && /source: "kv-unavailable"/.test(WORKER),
-  'KV live flags can kill resident AI, never bypass env ceilings, and fail closed on read errors');
+  'KV live flags require explicit true, never bypass env ceilings, and fail closed on missing/read errors');
+const npcResolverSource = (WORKER.match(/async function npcResolveFlags\(env\) \{[\s\S]*?(?=\nasync function npcHandler)/) || [''])[0];
+ok(!!npcResolverSource, 'npcResolveFlags is extractable for behavioral contract tests');
+if (npcResolverSource) {
+  const resolveNpcFlags = new Function(`${npcResolverSource}; return npcResolveFlags;`)();
+  const liveKv = (values) => ({ get: async (key) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : null });
+  const hardOff = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'true',
+    NPC_AI_ENABLED: 'false', NPC_AMBIENT_ENABLED: 'false', NPC_PLAYER_CHAT_ENABLED: 'false',
+    NPC_FLAGS: liveKv({ ai_enabled: 'true', ambient_enabled: 'true', player_chat_enabled: 'true' }),
+  });
+  ok(hardOff.requested.ai === true && hardOff.effective.ai === false
+    && hardOff.hardAiEnabled === false,
+  'KV true cannot bypass an OFF deployment ceiling and both states remain observable');
+  const requestedOff = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'true',
+    NPC_AI_ENABLED: 'true', NPC_AMBIENT_ENABLED: 'true', NPC_PLAYER_CHAT_ENABLED: 'true',
+    NPC_FLAGS: liveKv({ ai_enabled: 'false', ambient_enabled: 'false', player_chat_enabled: 'false' }),
+  });
+  ok(requestedOff.requested.ai === false && requestedOff.effective.ai === false,
+    'explicit KV false keeps an enabled deployment ceiling effectively OFF');
+  const requestedOn = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'true',
+    NPC_AI_ENABLED: 'true', NPC_AMBIENT_ENABLED: 'true', NPC_PLAYER_CHAT_ENABLED: 'true',
+    NPC_FLAGS: liveKv({ ai_enabled: 'true', ambient_enabled: 'true', player_chat_enabled: 'true' }),
+  });
+  ok(requestedOn.requested.ai === true && requestedOn.effective.ai === true
+    && requestedOn.effective.ambient === true && requestedOn.effective.player === true,
+  'explicit KV true activates only features with ON deployment ceilings');
+  const missingKeys = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'true',
+    NPC_AI_ENABLED: 'true', NPC_AMBIENT_ENABLED: 'true', NPC_PLAYER_CHAT_ENABLED: 'true',
+    NPC_FLAGS: liveKv({}),
+  });
+  ok(missingKeys.requested.ai === false && missingKeys.effective.ai === false,
+    'missing KV keys fail closed instead of inheriting an enabled deployment default');
+  const readFailure = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'true',
+    NPC_AI_ENABLED: 'true', NPC_AMBIENT_ENABLED: 'true', NPC_PLAYER_CHAT_ENABLED: 'true',
+    NPC_FLAGS: { get: async () => { throw new Error('kv unavailable'); } },
+  });
+  ok(readFailure.requested.ai === null && readFailure.effective.ai === false
+    && readFailure.source === 'kv-unavailable',
+  'KV read failures expose unknown request state and fail effective flags closed');
+  let ignoredReads = 0;
+  const deployOnly = await resolveNpcFlags({
+    NPC_LIVE_TOGGLE: 'false',
+    NPC_AI_ENABLED: 'true', NPC_AMBIENT_ENABLED: 'true', NPC_PLAYER_CHAT_ENABLED: 'false',
+    NPC_FLAGS: { get: async () => { ignoredReads += 1; return 'false'; } },
+  });
+  ok(ignoredReads === 0 && deployOnly.source === 'env' && deployOnly.effective.ai === true
+    && deployOnly.effective.player === false,
+  'live toggle OFF ignores KV and reports the env-gated effective state');
+}
+ok(/requested: flags\.requested/.test(WORKER)
+  && /hardAiEnabled: flags\.hardAiEnabled/.test(WORKER)
+  && /hardAmbientEnabled: flags\.hardAmbientEnabled/.test(WORKER)
+  && /hardPlayerChatEnabled: flags\.hardPlayerChatEnabled/.test(WORKER)
+  && /pending,/.test(WORKER)
+  && /canEnable,/.test(WORKER),
+  'npcConfig exposes requested/effective/pending and per-feature deployment ceilings');
 ok(/runBudgetedNpcCall\(\{[\s\S]*?providerCall: \(plan\) => npcModelCall\(env, role, plan, aiEnabled\)/.test(WORKER),
   'model call is reachable only through the durable reserve/settle lifecycle');
 ok(/"npc_budget_exhausted"/.test(WORKER), 'over-budget returns npc_budget_exhausted (client falls back to scripted)');


### PR DESCRIPTION
## What changed

- Preserves the existing Dashboard → shared KV → Taxi per-request read async toggle architecture.
- Exposes immutable deployment ceilings plus requested/effective/pending NPC state.
- Fails closed on missing KV keys and caps resident Azure model spend at $0.15/day (at most $4.65 in a 31-day month).
- Adds signed server telemetry for provider usage, delivered answers, real KB attempts, and KB-vs-direct-MCP grounding outcomes.
- Removes browser-side authoritative answer claims and fixes Context7, Hugging Face, and market route aliases.

## Why

Production had the three KV flags settable but the Taxi deployment ceilings were absent, so Turn all on wrote successfully while effective state remained off. Unsigned and ambiguous telemetry also prevented trustworthy P3/S1 attribution.

## Validation

- Repolis smoke — 905/905 passing
- Council core — 130/130 passing
- Council live — 56/56 passing
- Durable NPC budget governor tests passing
- Wrangler 4.123 dry-run — 229.55 KiB / 60.15 KiB gzip
- Worker/JavaScript syntax checks and `git diff --check`
- Live NPC KV verified all OFF before rollout
