### PR TITLE
fix: route telemetry through service binding

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -65,6 +65,12 @@ same random value configured on `repolis-metrics`. The Worker sends it only as
 KB attempts, and final grounding paths out of the untrusted browser lane; prompt and answer text
 are never included.
 
+The committed `REPOLIS_METRICS` Service Binding is the primary transport. Cloudflare does not
+support an ordinary same-zone Worker-to-Worker `fetch()` to a `workers.dev` route without special
+routing, which can surface as error 1042. The binding forwards the same signed HTTP `Request`
+directly to `repolis-metrics`; global `fetch()` remains only an optional fallback for deployments
+that do not expose the binding. Deploy `repolis-metrics` before deploying this caller.
+
 Deterministic navigation ("take me to the most popular repo") is handled in the client
 and never reaches here. If the KB is unreachable / slow / unconfigured, the Worker returns
 `{ fallback:true }` and the client silently uses Local search. If the KB has nothing but
@@ -317,9 +323,11 @@ possibly billable dollars.
 //                  aiEnabled, ambientEnabled, playerChatEnabled,
 //                  hardAiEnabled, hardAmbientEnabled, hardPlayerChatEnabled,
 //                  maxTurns, hardMaxTurns, source:"durable-object", flagSource, liveToggle },
-//      budget:{ source:"durable-object", available, ... } }
+//      budget:{ source:"durable-object", durable:true, enforcement:"atomic_reservation",
+//               available, ... } }
 { "npc_action": "npcBudget" }
-// → { ok, budget:{ enabled, available, source:"durable-object", day, dayCapUsd,
+// → { ok, budget:{ enabled, available, source:"durable-object", durable:true,
+//                  enforcement:"atomic_reservation", day, dayCapUsd,
 //                  spentUsd, reservedUsd, remainingUsd, turnsToday, reservedTurns,
 //                  dailyTurnMax, attemptsToday, dailyAttemptMax, blocked } }
 { "npc_action": "npcAmbientTurn", "speaker":"sol", "listener":"jun", "topic":"model", "lang":"ko",
@@ -329,9 +337,12 @@ possibly billable dollars.
 // → { ok, line:"…", budget } | { ok:false, fallback:true, reason:"npc_budget_exhausted", budget }
 ```
 
-`npcConfig` and `npcBudget` only read flags/Governor state; they never invoke a model. When the binding is
-unavailable, they return `available:false`, `blocked:true`, and `source:"durable-object"` rather than an
-isolate-local estimate.
+`npcConfig` and `npcBudget` only read flags/Governor state; they never invoke a model. Every budget view,
+including a fail-closed unavailable response, declares `source:"durable-object"`, `durable:true`, and
+`enforcement:"atomic_reservation"`. These fields mean the configured enforcement mechanism is the single
+SQLite-backed Durable Object reservation ledger, never an isolate-local estimate. When that binding or its
+storage cannot be reached, `available:false` and `blocked:true` prevent a provider call; they do not downgrade
+to best-effort accounting.
 
 ### Env (all optional — defaults keep AI **off**)
 

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -29,6 +29,7 @@
 //   GROUNDED_MAX_RUNTIME_S optional KB runtime budget seconds (default 30; KB requires 11–599)
 //   ALLOW_ORIGIN           optional, e.g. https://<you>.github.io (default *)
 //   METRICS_INGEST_TOKEN   shared Observatory secret (X-Repolis-Metrics-Key; never commit)
+//   REPOLIS_METRICS        optional Service Binding to repolis-metrics (preferred over global fetch)
 //
 // Chronopolis Kronos Council (POST {action:"council"}) — see councilHandler near the bottom.
 //   COUNCIL_LIVE_ENABLED   "true" turns on the money-spending Live debate. DEFAULT OFF: every
@@ -1349,7 +1350,15 @@ function npcMetric(env, name, meta, ctx) {
     const headers = { "Content-Type": "application/json" };
     const ingestToken = String(env.METRICS_INGEST_TOKEN || "").trim();
     if (ingestToken && !/[\r\n]/.test(ingestToken)) headers["X-Repolis-Metrics-Key"] = ingestToken;
-    const task = fetch(url, { method: "POST", headers, body: JSON.stringify({ ev: name, ts: Date.now(), ...npcRedact(meta) }) }).catch(() => {});
+    const request = new Request(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ ev: name, ts: Date.now(), ...npcRedact(meta) }),
+    });
+    const transport = env.REPOLIS_METRICS && typeof env.REPOLIS_METRICS.fetch === "function"
+      ? env.REPOLIS_METRICS
+      : { fetch: (input) => fetch(input) };
+    const task = transport.fetch(request).catch(() => {});
     if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(task);
     return task;
   } catch { /* metrics never break a turn */ }

--- a/cloudflare-taxi/src/npc-budget-governor.js
+++ b/cloudflare-taxi/src/npc-budget-governor.js
@@ -1,4 +1,9 @@
 const NPC_BUDGET_SOURCE = "durable-object";
+const NPC_BUDGET_VIEW_CONTRACT = Object.freeze({
+  source: NPC_BUDGET_SOURCE,
+  durable: true,
+  enforcement: "atomic_reservation",
+});
 const NPC_BUDGET_OBJECT_NAME = "npc-budget-canonical-v1";
 const NPC_LEDGER_KEY = "ledger";
 const NPC_ARCHIVED_LEDGER_PREFIX = "ledger:";
@@ -152,8 +157,8 @@ function publicBudget(ledger) {
   const turnBlocked = dailyTurnMax > 0 && ledger.turns + ledger.reservedTurns >= dailyTurnMax;
   const attemptBlocked = ledger.attempts >= ledger.dailyAttemptMax;
   return {
+    ...NPC_BUDGET_VIEW_CONTRACT,
     available: true,
-    source: NPC_BUDGET_SOURCE,
     day: ledger.day,
     dayCapUsd: nanosToUsd(capNanos),
     spentUsd: nanosToUsd(ledger.spentNanos),
@@ -170,9 +175,9 @@ function publicBudget(ledger) {
 
 function unavailableBudget(reason, policy) {
   return {
+    ...NPC_BUDGET_VIEW_CONTRACT,
     available: false,
     enabled: false,
-    source: NPC_BUDGET_SOURCE,
     day: null,
     dayCapUsd: policy?.ok ? nanosToUsd(policy.capNanos) : null,
     spentUsd: null,
@@ -215,7 +220,7 @@ function validReservationRecord(record) {
 function operationMeta(result, extra = {}) {
   const budget = result?.budget;
   return {
-    source: NPC_BUDGET_SOURCE,
+    ...NPC_BUDGET_VIEW_CONTRACT,
     ...extra,
     ...(budget?.day ? {
       day: budget.day,

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -28,6 +28,12 @@ new_sqlite_classes = ["NpcBudgetGovernor"]
 binding = "NPC_FLAGS"
 id = "0cad99a719a84c919839aa9e0616db53"
 
+# Same-account Worker-to-Worker telemetry must use a Service Binding. A global
+# fetch to the repolis-metrics workers.dev route can fail with Cloudflare 1042.
+[[services]]
+binding = "REPOLIS_METRICS"
+service = "repolis-metrics"
+
 # Non-secret config. The Search key is a SECRET — never put it here:
 #   wrangler secret put SEARCH_API_KEY
 [vars]

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1199,8 +1199,9 @@ ok(!!metricTransportSource, 'trusted telemetry transport is extractable for beha
 if (metricTransportSource) {
   const originalFetch = globalThis.fetch;
   const metricRequests = [];
-  globalThis.fetch = async (url, init) => {
-    metricRequests.push({ url, init });
+  const serviceRequests = [];
+  globalThis.fetch = async (request) => {
+    metricRequests.push(request);
     return new Response(null, { status: 204 });
   };
   try {
@@ -1208,15 +1209,36 @@ if (metricTransportSource) {
     await metric({ METRICS_URL: 'https://metrics.example/event', METRICS_INGEST_TOKEN: 'shared-secret' },
       'ai_chat_turn', { answer: true, providerCall: false, question: 'private' });
     const sent = metricRequests[0];
-    const sentBody = JSON.parse(sent.init.body);
-    ok(new Headers(sent.init.headers).get('X-Repolis-Metrics-Key') === 'shared-secret'
+    const sentBody = await sent.clone().json();
+    ok(sent instanceof Request
+      && sent.headers.get('X-Repolis-Metrics-Key') === 'shared-secret'
       && sentBody.answer === true && sentBody.providerCall === false
       && sentBody.question === undefined && sentBody.question_len === 7,
-      'trusted telemetry sends the secret header while redacting prompt text');
+      'trusted global-fetch fallback sends the secret header while redacting prompt text');
+    await metric({
+      METRICS_URL: 'https://metrics.example/event',
+      METRICS_INGEST_TOKEN: 'shared-secret',
+      REPOLIS_METRICS: {
+        async fetch(request) {
+          serviceRequests.push(request);
+          return new Response(null, { status: 204 });
+        },
+      },
+    }, 'ai_grounding_outcome', { groundingPath: 'grounded_via_kb', ok: true });
+    const serviceSent = serviceRequests[0];
+    const serviceBody = await serviceSent.clone().json();
+    ok(serviceSent instanceof Request && serviceSent.url === 'https://metrics.example/event'
+      && serviceSent.headers.get('X-Repolis-Metrics-Key') === 'shared-secret'
+      && serviceBody.ev === 'ai_grounding_outcome'
+      && serviceBody.groundingPath === 'grounded_via_kb'
+      && metricRequests.length === 1,
+      'same-account telemetry prefers the signed REPOLIS_METRICS Service Binding and never hairpins through global fetch');
   } finally {
     globalThis.fetch = originalFetch;
   }
 }
+ok(/\[\[services\]\][\s\S]*?binding = "REPOLIS_METRICS"[\s\S]*?service = "repolis-metrics"/.test(TAXI_WRANGLER),
+  'Taxi deployment binds repolis-metrics for same-account Worker telemetry');
 ok(/route:'persona_ambient',npc:'resident',phase:'client_observation',answer:false,providerCall:false/.test(HTML),
   'browser ambient observations are explicitly non-authoritative and never leak into the none route');
 ok(/function trackAiTurn\([\s\S]{0,260}phase:'client_observation', answer:false, providerCall:false/.test(HTML),

--- a/scripts/test-npc-budget-governor.mjs
+++ b/scripts/test-npc-budget-governor.mjs
@@ -135,8 +135,11 @@ export async function runNpcBudgetGovernorTests(check) {
     const status = await operation(governor, { op: 'status', ...policy });
     check(reservations.filter((result) => result.accepted).length === 1
       && status.budget.reservedUsd === 0.0006
+      && status.budget.source === 'durable-object'
+      && status.budget.durable === true
+      && status.budget.enforcement === 'atomic_reservation'
       && status.budget.reservedUsd + status.budget.spentUsd <= status.budget.dayCapUsd,
-    'Durable governor serializes simultaneous reservations without cap overshoot');
+    'Durable governor advertises atomic reservation enforcement and serializes simultaneous reservations without cap overshoot');
   }
 
   {
@@ -402,7 +405,9 @@ export async function runNpcBudgetGovernorTests(check) {
       && success.budget.reservedUsd === 0
       && success.budget.remainingUsd === 0.9997135
       && success.budget.turnsToday === 1
-      && success.budget.source === 'durable-object',
+      && success.budget.source === 'durable-object'
+      && success.budget.durable === true
+      && success.budget.enforcement === 'atomic_reservation',
     'npcBudget reports authoritative spent, reserved, remaining, and turn values');
     check(!serializedState.includes('unique hermetic visitor')
       && !serializedEvents.includes('unique hermetic visitor')
@@ -446,6 +451,44 @@ export async function runNpcBudgetGovernorTests(check) {
     check(Math.abs(partialUsage.budget.spentUsd - billableEmpty.costUsd - partialUsage.costUsd) < 1e-12
       && partialUsage.budget.reservedUsd === 0,
     'billable fallback and partial usage remain reflected in authoritative budget totals');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const env = baseEnv(governor);
+    const plan = createNpcCallPlan(env, 'player', MESSAGES);
+    env.NPC_DAY_CAP_USD = String(plan.reservationNanos / 1_000_000_000);
+    let providerCalls = 0;
+    const attempted = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: false, billable: true, reason: 'provider_http_error', usage: null };
+      },
+    });
+    const blocked = await runBudgetedNpcCall({
+      env,
+      role: 'player',
+      messages: MESSAGES,
+      enabled: true,
+      providerCall: async () => {
+        providerCalls += 1;
+        return { ok: true, text: 'must not run', usage: null };
+      },
+    });
+    const status = await npcBudgetStatus(env, true);
+    check(!attempted.ok && attempted.reason === 'provider_http_error'
+      && attempted.costUsd === plan.reservationNanos / 1_000_000_000
+      && !blocked.ok && blocked.reason === 'day_cap_exhausted'
+      && providerCalls === 1
+      && status.spentUsd === status.dayCapUsd && status.reservedUsd === 0
+      && status.turnsToday === 1 && status.attemptsToday === 1
+      && status.blocked && status.durable === true
+      && status.enforcement === 'atomic_reservation',
+    'a dispatched attempt with missing usage full-settles its conservative reservation and cannot overshoot or reopen the hard daily cap');
   }
 
   {
@@ -659,7 +702,10 @@ export async function runNpcBudgetGovernorTests(check) {
     });
     check(!unavailable.ok && unavailable.reason === 'npc_budget_governor_unavailable'
       && unavailable.budget.available === false && unavailable.budget.blocked
-      && unavailable.budget.source === 'durable-object' && providerCalls === 0,
-    'missing Durable Object binding fails closed before any provider call');
+      && unavailable.budget.source === 'durable-object'
+      && unavailable.budget.durable === true
+      && unavailable.budget.enforcement === 'atomic_reservation'
+      && providerCalls === 0,
+    'missing Durable Object binding retains the durable atomic contract and fails closed before any provider call');
   }
 }


### PR DESCRIPTION
Route signed Taxi telemetry to repolis-metrics through a same-account Service Binding, avoiding the Workers same-zone global-fetch failure. Also publish the Durable Object atomic-reservation budget contract and add conservative hard-cap regression coverage. Validation: smoke 908/908, governor tests, syntax, diff check, and Wrangler dry-run.