### PR TITLE
Separate NPC switch state from runtime health

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -319,7 +319,8 @@ possibly billable dollars.
 
 ```jsonc
 { "npc_action": "npcConfig", "lang": "ko" }
-// → { ok, config:{ requested, effective, pending, canEnable, blockReason,
+// → { ok, config:{ requested, controlEffective, effective, runtimeAvailable,
+//                  budgetReason, pending, canEnable, blockReason,
 //                  aiEnabled, ambientEnabled, playerChatEnabled,
 //                  hardAiEnabled, hardAmbientEnabled, hardPlayerChatEnabled,
 //                  maxTurns, hardMaxTurns, source:"durable-object", flagSource, liveToggle },
@@ -337,7 +338,10 @@ possibly billable dollars.
 // → { ok, line:"…", budget } | { ok:false, fallback:true, reason:"npc_budget_exhausted", budget }
 ```
 
-`npcConfig` and `npcBudget` only read flags/Governor state; they never invoke a model. Every budget view,
+`npcConfig` and `npcBudget` only read flags/Governor state; they never invoke a model. `controlEffective`
+reports the env∧KV control plane independently, while the backward-compatible `effective` remains the
+fail-closed runtime view. A transient Governor probe failure therefore reports `runtimeAvailable:false`
+and a bounded `budgetReason` without being mislabeled as KV propagation. Every budget view,
 including a fail-closed unavailable response, declares `source:"durable-object"`, `durable:true`, and
 `enforcement:"atomic_reservation"`. These fields mean the configured enforcement mechanism is the single
 SQLite-backed Durable Object reservation ledger, never an isolate-local estimate. When that binding or its
@@ -359,7 +363,7 @@ to best-effort accounting.
 | `NPC_DAY_CAP_USD` | `0.15` in this deployment (`10` code default) | Durable UTC-day hard cap. The committed value bounds a 31-day month to `$4.65` of resident Azure model calls. `0` disables calls; invalid values fail closed. |
 | `NPC_DAILY_TURN_MAX` | `0` (off) | Optional durable daily turn cap; in-flight reservations consume slots. |
 | `NPC_DAILY_ATTEMPT_MAX` | `5000` | Hard abuse/storage ceiling for accepted reservations, including provider failures. Must be positive. |
-| `NPC_BUDGET_TIMEOUT_MS` | `1500` | Internal Governor response deadline (100–10000 ms); timeout fails closed. |
+| `NPC_BUDGET_TIMEOUT_MS` | `3000` | Internal Governor response deadline (100–10000 ms); timeout fails closed. Retryable failures wait 100–250 ms before one idempotent retry; overload is not retried. |
 | `NPC_RESERVATION_LEASE_MS` | `60000` | Orphan lease; must exceed `NPC_TIMEOUT_MS + 2×NPC_BUDGET_TIMEOUT_MS + 10000` and be ≤300000. Expiry full-settles. |
 | `NPC_TIMEOUT_MS` | `12000` | Entra token + model request deadline; timeout aborts the request and releases its reservation. |
 | `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient conversation caps. |

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -49,6 +49,7 @@ import CouncilFixtures from "../../council/fixtures.js";
 import COUNCIL_CFG from "../../council/council.config.json";
 import {
   NpcBudgetGovernor,
+  npcControlStatus,
   npcBudgetStatus,
   runBudgetedNpcCall,
 } from "./npc-budget-governor.js";
@@ -1652,15 +1653,9 @@ async function npcHandler(body, request, env, ctx) {
 
   if (action === "npcConfig") {
     const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
-    const budgetReady = budget.available === true;
-    const effective = {
-      ai: aiEnabled && budgetReady,
-      ambient: ambientOn && budgetReady,
-      player: playerOn && budgetReady,
-    };
-    const pending = Object.keys(effective).some((key) =>
-      typeof flags.requested?.[key] === "boolean" && flags.requested[key] !== effective[key]
-    );
+    const status = npcControlStatus(flags, budget);
+    const budgetReady = status.runtimeAvailable;
+    const effective = status.effective;
     const canEnable = flags.liveToggle === true
       && flags.source === "kv"
       && flags.hardAiEnabled === true
@@ -1668,7 +1663,7 @@ async function npcHandler(body, request, env, ctx) {
     const blockReason = flags.liveToggle !== true ? "live_toggle_off"
       : flags.source !== "kv" ? "kv_unavailable"
       : flags.hardAiEnabled !== true ? "npc_hard_ceiling_off"
-      : !budgetReady ? "npc_budget_unavailable"
+      : !budgetReady ? status.budgetReason
       : null;
     return json({ ok: true, config: {
       aiEnabled: effective.ai,
@@ -1676,7 +1671,10 @@ async function npcHandler(body, request, env, ctx) {
       playerChatEnabled: effective.player,
       requested: flags.requested,
       effective,
-      pending,
+      controlEffective: status.controlEffective,
+      runtimeAvailable: status.runtimeAvailable,
+      budgetReason: status.budgetReason,
+      pending: status.pending,
       canEnable,
       blockReason,
       hardAiEnabled: flags.hardAiEnabled,

--- a/cloudflare-taxi/src/npc-budget-governor.js
+++ b/cloudflare-taxi/src/npc-budget-governor.js
@@ -111,7 +111,7 @@ function budgetPolicy(env) {
   const dailyTurnMax = parseNonNegativeInteger(env?.NPC_DAILY_TURN_MAX, 0);
   const dailyAttemptMax = parseNonNegativeInteger(env?.NPC_DAILY_ATTEMPT_MAX, 5000);
   const providerTimeoutMs = parseNonNegativeInteger(env?.NPC_TIMEOUT_MS, 12_000);
-  const governorTimeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 1500);
+  const governorTimeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 3000);
   const hasConfiguredLease = env?.NPC_RESERVATION_LEASE_MS !== undefined
     && env?.NPC_RESERVATION_LEASE_MS !== null
     && env?.NPC_RESERVATION_LEASE_MS !== "";
@@ -190,6 +190,36 @@ function unavailableBudget(reason, policy) {
     dailyAttemptMax: policy?.ok ? policy.dailyAttemptMax : null,
     blocked: true,
     reason,
+  };
+}
+
+// Keep the asynchronous flag-control plane distinct from a point-in-time
+// Governor health probe. A transient Durable Object failure must still fail the
+// runtime closed, but it is not KV propagation and must not be reported as such.
+export function npcControlStatus(flags, budget) {
+  const controlEffective = {
+    ai: flags?.effective?.ai === true,
+    ambient: flags?.effective?.ambient === true,
+    player: flags?.effective?.player === true,
+  };
+  const runtimeAvailable = budget?.available === true;
+  const effective = {
+    ai: controlEffective.ai && runtimeAvailable,
+    ambient: controlEffective.ambient && runtimeAvailable,
+    player: controlEffective.player && runtimeAvailable,
+  };
+  const pending = Object.keys(controlEffective).some((key) =>
+    typeof flags?.requested?.[key] === "boolean"
+      && flags.requested[key] !== controlEffective[key]
+  );
+  return {
+    controlEffective,
+    effective,
+    pending,
+    runtimeAvailable,
+    budgetReason: runtimeAvailable
+      ? null
+      : String(budget?.reason || "npc_budget_unavailable").slice(0, 64),
   };
 }
 
@@ -779,7 +809,7 @@ function governorStub(env) {
 }
 
 async function governorCall(env, payload) {
-  const timeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 1500);
+  const timeoutMs = parseNonNegativeInteger(env?.NPC_BUDGET_TIMEOUT_MS, 3000);
   if (timeoutMs === null || timeoutMs < 100 || timeoutMs > 10_000) {
     return { ok: false, reason: "npc_budget_timeout_invalid" };
   }
@@ -799,9 +829,19 @@ async function governorCall(env, payload) {
     const body = await response.json();
     return body?.ok ? body : { ok: false, reason: body?.reason || "npc_budget_governor_error" };
   } catch (error) {
+    const overloaded = error?.overloaded === true;
+    const bindingMisconfigured = ["npc_budget_binding_missing", "npc_budget_binding_invalid"]
+      .includes(error?.message);
     return {
       ok: false,
-      reason: error?.name === "AbortError" ? "npc_budget_governor_timeout" : "npc_budget_governor_unavailable",
+      reason: overloaded
+        ? "npc_budget_governor_overloaded"
+        : error?.name === "AbortError"
+          ? "npc_budget_governor_timeout"
+          : "npc_budget_governor_unavailable",
+      overloaded,
+      retryable: !overloaded && !bindingMisconfigured
+        && (error?.name === "AbortError" || error?.retryable !== false),
     };
   } finally {
     clearTimeout(timer);
@@ -809,6 +849,9 @@ async function governorCall(env, payload) {
 }
 
 function retryableGovernorFailure(result) {
+  if (result?.overloaded === true || result?.retryable === false
+    || result?.reason === "npc_budget_governor_overloaded") return false;
+  if (result?.retryable === true) return true;
   return [
     "npc_budget_governor_timeout",
     "npc_budget_governor_unavailable",
@@ -817,9 +860,28 @@ function retryableGovernorFailure(result) {
   ].includes(result?.reason);
 }
 
+function governorRetryDelayMs(env) {
+  const sampled = typeof env?.__npcBudgetRandom === "function"
+    ? Number(env.__npcBudgetRandom())
+    : Math.random();
+  const unit = Number.isFinite(sampled) ? Math.max(0, Math.min(1, sampled)) : 0;
+  return 100 + Math.floor(unit * 150);
+}
+
+async function waitBeforeGovernorRetry(env) {
+  const delayMs = governorRetryDelayMs(env);
+  if (typeof env?.__npcBudgetSleep === "function") {
+    await env.__npcBudgetSleep(delayMs);
+    return;
+  }
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 async function reliableGovernorCall(env, payload) {
   const first = await governorCall(env, payload);
-  return retryableGovernorFailure(first) ? governorCall(env, payload) : first;
+  if (!retryableGovernorFailure(first)) return first;
+  await waitBeforeGovernorRetry(env);
+  return governorCall(env, payload);
 }
 
 function withEnabled(budget, enabled) {

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -83,7 +83,7 @@ MODEL_PRICE_OUT_PER_1M_USD = "4.5"
 # Unknown deployments or malformed tables fail closed. max_completion_tokens uses the same bound.
 NPC_MODEL_PRICING_JSON = '{"gpt-5.4-mini":{"inputPer1MUsd":0.75,"cachedInputPer1MUsd":0.075,"outputPer1MUsd":4.5,"maxInputTokens":272000,"maxOutputTokens":128000}}'
 NPC_MAX_COMPLETION_TOKENS = "120"
-NPC_BUDGET_TIMEOUT_MS = "1500"
+NPC_BUDGET_TIMEOUT_MS = "3000"
 NPC_DAILY_ATTEMPT_MAX = "5000"
 NPC_RESERVATION_LEASE_MS = "60000"
 # Deployment ceilings permit the owner-only KV switches to turn resident AI on.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1526,12 +1526,19 @@ if (npcResolverSource) {
   'live toggle OFF ignores KV and reports the env-gated effective state');
 }
 ok(/requested: flags\.requested/.test(WORKER)
+  && /controlEffective: status\.controlEffective/.test(WORKER)
+  && /runtimeAvailable: status\.runtimeAvailable/.test(WORKER)
+  && /budgetReason: status\.budgetReason/.test(WORKER)
   && /hardAiEnabled: flags\.hardAiEnabled/.test(WORKER)
   && /hardAmbientEnabled: flags\.hardAmbientEnabled/.test(WORKER)
   && /hardPlayerChatEnabled: flags\.hardPlayerChatEnabled/.test(WORKER)
   && /pending,/.test(WORKER)
   && /canEnable,/.test(WORKER),
   'npcConfig exposes requested/effective/pending and per-feature deployment ceilings');
+ok(/NPC_BUDGET_TIMEOUT_MS = "3000"/.test(TAXI_WRANGLER)
+  && /npc_budget_governor_overloaded/.test(NPC_GOVERNOR)
+  && /waitBeforeGovernorRetry/.test(NPC_GOVERNOR),
+  'Governor uses a 3-second deadline, bounded retry backoff, and an overload no-retry lane');
 ok(/runBudgetedNpcCall\(\{[\s\S]*?providerCall: \(plan\) => npcModelCall\(env, role, plan, aiEnabled\)/.test(WORKER),
   'model call is reachable only through the durable reserve/settle lifecycle');
 ok(/"npc_budget_exhausted"/.test(WORKER), 'over-budget returns npc_budget_exhausted (client falls back to scripted)');

--- a/scripts/test-npc-budget-governor.mjs
+++ b/scripts/test-npc-budget-governor.mjs
@@ -1,6 +1,7 @@
 import {
   NpcBudgetGovernor,
   createNpcCallPlan,
+  npcControlStatus,
   npcBudgetStatus,
   runBudgetedNpcCall,
 } from '../cloudflare-taxi/src/npc-budget-governor.js';
@@ -125,6 +126,27 @@ const MESSAGES = [
 ];
 
 export async function runNpcBudgetGovernorTests(check) {
+  {
+    const flags = {
+      requested: { ai: true, ambient: true, player: true },
+      effective: { ai: true, ambient: true, player: true },
+    };
+    const unavailable = npcControlStatus(flags, {
+      available: false,
+      reason: 'npc_budget_governor_timeout',
+    });
+    const available = npcControlStatus(flags, { available: true });
+    check(unavailable.controlEffective.ai === true
+      && unavailable.effective.ai === false
+      && unavailable.runtimeAvailable === false
+      && unavailable.pending === false
+      && unavailable.budgetReason === 'npc_budget_governor_timeout'
+      && available.effective.ai === true
+      && available.runtimeAvailable === true
+      && available.budgetReason === null,
+    'control-plane state remains ON while an unavailable Governor independently fails runtime effective state closed');
+  }
+
   {
     const { governor } = makeGovernor();
     const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
@@ -707,5 +729,63 @@ export async function runNpcBudgetGovernorTests(check) {
       && unavailable.budget.enforcement === 'atomic_reservation'
       && providerCalls === 0,
     'missing Durable Object binding retains the durable atomic contract and fails closed before any provider call');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const delays = [];
+    let calls = 0;
+    const env = {
+      ...baseEnv(governor),
+      __npcBudgetRandom: () => 0,
+      __npcBudgetSleep: async (ms) => { delays.push(ms); },
+      NPC_BUDGET_GOVERNOR: {
+        getByName() {
+          return {
+            async fetch(input, init) {
+              calls += 1;
+              if (calls === 1) {
+                const error = new Error('transient infrastructure failure');
+                error.retryable = true;
+                throw error;
+              }
+              return governor.fetch(new Request(input, init));
+            },
+          };
+        },
+      },
+    };
+    const status = await npcBudgetStatus(env, true);
+    check(status.available === true && calls === 2
+      && delays.length === 1 && delays[0] === 100,
+    'retryable Governor failures wait for bounded jittered backoff before one idempotent retry');
+  }
+
+  {
+    const { governor } = makeGovernor();
+    const delays = [];
+    let calls = 0;
+    const env = {
+      ...baseEnv(governor),
+      __npcBudgetSleep: async (ms) => { delays.push(ms); },
+      NPC_BUDGET_GOVERNOR: {
+        getByName() {
+          return {
+            async fetch() {
+              calls += 1;
+              const error = new Error('object overloaded');
+              error.overloaded = true;
+              error.retryable = true;
+              throw error;
+            },
+          };
+        },
+      },
+    };
+    const status = await npcBudgetStatus(env, true);
+    check(status.available === false
+      && status.reason === 'npc_budget_governor_overloaded'
+      && calls === 1 && delays.length === 0,
+    'an overloaded Governor fails closed without a retry that would amplify the overload');
   }
 }


### PR DESCRIPTION
## What changed

- adds controlEffective, runtimeAvailable, and budgetReason to the resident control contract
- computes KV pending independently from the budget Governor health probe
- increases the Governor timeout to 3 seconds with one bounded retry for retryable failures
- fails closed immediately on overload and retains the atomic daily cap

## Root cause

A transient Durable Object status failure correctly paused model execution, but the response incorrectly looked like an unpropagated ON request. The dashboard then hid the recovery path.

## Validation

- Governor checks: 27 passing
- Repolis smoke: 995 passing
- Wrangler dry run succeeds
- git diff --check passes