### PR TITLE
feat: add repository-first Repo Portal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`repos.json`** | Generated array of repo objects that build the current owner city. **Do not hand-edit.** | Never directly; regenerate (see below). |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
+| **`assets/repo-portal.js`** | Pure username/repository parser, route precedence, public projection, canonical Portal URL, and owner-town expansion link. | Changing `?repo=`, accepted GitHub inputs, public traffic truth, or target share links. |
 | **`assets/town-growth.js`** | Pure repo-creation timeline, year snapshot, and Growth Replay share-link logic. | Changing historical cutoffs, unknown-date policy, or `?growth=` links. |
 | **`assets/town-creator.js`** | Pure allowlisted public-profile + town-repo summary for Creator Hall. | Changing creator facts, badges, signature-repo ranking, or avatar safety. |
 | **`assets/twin-towns.js`** | Pure public-repo comparison and reversible Twin Towns link builder. | Changing the two-person referral bridge or its URL contract. |
@@ -141,9 +142,11 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 | You want to… | Start here |
 |---|---|
 | Change how a repo becomes a building (height/size/ornaments) | `index.html` (city-build section) + score/rank in `scripts/build_repos.py`; model in [`docs/domain-model.md`](docs/domain-model.md). |
+| Change Repo Portal parsing, target-first loading, cache, expansion, or privacy events | `assets/repo-portal.js` + the repo data/intro/Station/Atelier blocks in `index.html` + `scripts/smoke.mjs`; preserve one repo request before Aha, `trafficKnown:false` for public API data, 15-minute/512 KiB LRU bounds, canonical `?repo=owner/repo&ref=repo-portal`, and [`docs/repo-portal-change-guide.md`](docs/repo-portal-change-guide.md). |
 | Change districts, Village Chronicle, passport, or exploration loops | `index.html` + the matching behavioral groups in `scripts/smoke.mjs`. |
 | Change Creator Hall profile facts, caching, or upstream Star handoff | `assets/town-creator.js` + the Creator Hall landmark/panel blocks in `index.html` + `scripts/smoke.mjs`; keep profile loading explicit-read and allowlisted. |
 | Change Town Growth Replay years, camera, reveal, share links, or era postcards | `assets/town-growth.js` + `/*TOWN_GROWTH_REPLAY*/` in `index.html` + the Growth Replay group in `scripts/smoke.mjs`; creation dates are historical, building metrics are current, and replay must restore camera/fog/sky/LOD exactly. |
+| Change Repository Atelier room, avatar, data walls, or action terminals | `/*REPOSITORY_ATELIER*/` in `index.html` + the Atelier group in `scripts/smoke.mjs`; preserve one lazy reusable room, three bounded canvas atlases, exact exterior restore, zero exterior renders inside, in-room Ask/Why ownership, and explicit-only exit/GitHub navigation. |
 | Change Twin Towns matching or two-person share links | `assets/twin-towns.js` + the Twin Towns block in `index.html` + `scripts/smoke.mjs`. |
 | Change Town Gazette / return-visit freshness | `/*FRESHNESS*/` + Passport render/start flow in `index.html`; keep snapshots local, bounded, per-town, and explicit-read only. |
 | Change resident homes, styles, gardens, routines, moods, friendships, haunts, or Shared Joy | The resident social layer + Starlight Row blocks in `index.html`; preserve the resident style map, 3 roof batches, 10/6 desktop/LOW_END detail-batch cap, 42-unit reserve, entrance gap, quarter colliders, home/work truth, owned porch seats, and social ownership guards. |
@@ -161,7 +164,7 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 A daily Action turns the owner's **public repos + committed traffic logs** into `repos.json`. `index.html`
 turns that array into metric-shaped buildings, topic districts, routes, maps, and exploration progress.
 Residents add named homes, home/work commutes, moods, friendships, haunts, Shared Joy excursions, gatherings, and festivals; landmarks include the
-Contribution Library, Chronopolis, Observatory, and imported procedural World Tree. Town Growth Replay turns public repo creation dates into a reversible, shareable city history without inventing historical metrics. Gitber/POLARIS and the
+Contribution Library, Chronopolis, Observatory, and imported procedural World Tree. Repo Portal lets one public `owner/repo` arrive before its owner catalog, then reuses the same building and Repository Atelier with truthful public-metadata boundaries. Every repo also rebinds one reusable Atelier where its data, impact signals, current avatar, and in-room Gitber stay inside the exhibition. Town Growth Replay turns public repo creation dates into a reversible, shareable city history without inventing historical metrics. Gitber/POLARIS and the
 scholars (VEGA · MS Learn, RIGEL · DeepWiki, MIRA · Context7, LYRA · Hugging Face) add natural-language
 navigation and grounded answers. Residents hand specialist questions to the right scholar instead of gaining
 their own MCP access. The Passport's local Town Gazette makes daily public-repo changes visible on return. Everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [1.87.0] — 2026-08-20
+
+### 🏛️ Repo Portal — let one repository bring visitors into the city
+
+Repo Portal is the most direct Star-growth change because it attaches Repolis to work developers already
+share. A recipient no longer has to understand the whole city before finding personal relevance: one
+`owner/repo` link loads that project, proves its public facts, and opens its Repository Atelier. GitHub and a
+copyable Portal remain one action away, while the owner catalog waits for an explicit expansion. The result
+is a useful repository artifact first and a Repolis discovery path second.
+
+- The intro and GitHub Station now share one strict resolver for usernames, `owner/repo`, and GitHub
+  repository root URLs. Canonical links use `?repo=owner/repo&ref=repo-portal`; repository ownership wins
+  over conflicting town, Twin Towns, Growth Replay, or card-hash state.
+- Arbitrary targets check the generated owner snapshot, a fresh bounded cache, then one exact public GitHub
+  repository request. A stale entry is labelled when it rescues 404/rate/network failure; otherwise the
+  existing owner town remains usable. The cache is limited to 15 minutes, 30 entries, and 512 KiB.
+- Public API projections no longer manufacture visitors, views, or clones. `trafficKnown:false` keeps those
+  fields `null`; public buildings use stars, forks, and update recency, and cards, search, and Atelier walls
+  explain the boundary. Exact owner-snapshot matches retain known cumulative traffic.
+- The first screen confirms target stars, forks, language, description, and source before one click enters
+  the Atelier. Its new actions copy the canonical Portal, open GitHub, or explicitly expand into the
+  existing owner-town loader while retaining the target focus.
+- Six coarse funnel events remove owner, repository, URL, input, query, `cityUser`, and persistent instance
+  identifiers. The existing earned Star invitation becomes eligible only after the target room reaches Aha
+  or a Portal is copied, then waits until the visitor returns outside.
+- The change adds one small pure module and no model, binary asset, texture, light, shadow, backend,
+  dependency, or build step. Hermetic guards cover parsing, hostile inputs, URL precedence, cache bounds,
+  stale/offline fallback, traffic truth, KO/EN, accessibility, telemetry privacy, and the 5 MiB runtime cap.
+
+## [1.86.1] — 2026-08-19
+
+### 🏛️ Repository Atelier completion — actions and identity stay inside
+
+- **Ask Gitber** and **Why this district?** no longer exit to the town. Both open a dark in-room conversation;
+  the former uses the existing selected Gitber mode and the latter gives the deterministic classifier reason.
+- Exterior taxi rides, scholar handoffs, and recommendation ride buttons are blocked while the room owns
+  interaction. GitHub remains an explicit safe new-tab terminal and the exit remains the only town return.
+- The primitive capsule avatar is replaced by the current Repolis chibi hierarchy with shared GPU resources
+  and mapped walk animation.
+- A new Impact/Signals Wall, three metric artifacts, ceiling architecture, framed side gallery, curved data
+  path, cleaner core shell, and ordered data spires complete the sparse room. Stars, forks, activity, score,
+  language, topics, creation, push, release, traffic, and district colors all rebind per repo.
+- The room remains lazy-created and reusable with three bounded canvas textures, zero exterior renders while
+  active, exact camera/UI/tour restoration, and no network or model call until the visitor asks.
+
 ## [1.86.0] — 2026-08-18
 
 ### ⏳ Town Growth Replay — watch an open-source history become a city

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@
 
 <sub>🎬 <strong>15초 데모:</strong> 트래픽 → 건물 · 깃버에게 질문 → 택시 이동 → 실제 레포 카드</sub><br>
 <sub><code>WASD</code> / 터치로 걷기 · 깃버에게 묻기 · <code>Enter</code> / 탭으로 열기 · 가입이나 빌드 없음 · <strong><a href="#60초-로컬-실행">로컬 실행</a></strong> · ⭐ <strong><a href="https://github.com/hyeonsangjeon/Repolis">Star 남기기</a></strong></sub><br>
-<sub>첫 화면에 GitHub username을 입력하세요. 공개 메타데이터만 사용합니다.</sub>
+<sub>첫 화면에 GitHub username, <code>owner/repo</code>, 또는 레포 URL을 입력하세요. 공개 메타데이터만 사용합니다.</sub>
 
 [![매일 갱신](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=flat-square&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=flat-square&logo=three.js&logoColor=white)](https://threejs.org)
@@ -33,7 +33,7 @@
 | 깃버가 자연어로 찾고 실제 결과까지 운전합니다 | 저장소 탐색이 또 하나의 목록이 아니라 상호작용이 됩니다 |
 | `?user=<login>`이 어떤 공개 GitHub 계정이든 마을로 다시 짓습니다 | 클론이나 설정 전에 같은 엔진을 내 작업으로 검증할 수 있습니다 |
 
-**가장 빠른 확인:** **[내 GitHub로 보기](https://hyeonsangjeon.github.io/Repolis/?launch=1)**를 열고 username을 입력한 뒤 내 공개 레포 사이를 걸어보세요. 토큰·계정 연결·포크가 필요 없습니다.
+**가장 빠른 확인:** **[내 GitHub로 보기](https://hyeonsangjeon.github.io/Repolis/?launch=1)**를 열고 username이나 `owner/repo` 하나를 입력하세요. username은 공개 마을을 만들고, 레포 주소는 그 프로젝트부터 엽니다. 토큰·계정 연결·포크가 필요 없습니다.
 
 <div align="center">
 
@@ -50,6 +50,7 @@
 | 목표 | 할 일 | 결과 |
 |---|---|---|
 | 내 공개 레포 미리보기 | 라이브 첫 화면에 username 입력 | 몇 초 안에 공유 가능한 메타데이터 마을 생성 |
+| 레포 하나를 경험으로 공유 | `owner/repo` 또는 GitHub 레포 URL을 입력하고 전시실에서 **Repo Portal 복사** | 소유자 목록보다 대상 하나를 먼저 불러오는 `?repo=owner/repo&ref=repo-portal` 정식 링크 |
 | 마을을 만든 사람 소개 | **마을 창작자 회관** 방문 또는 도시 메뉴의 **마을 만든 사람** 열기 | 현재 마을 주인의 공개 bio·팔로워·GitHub 활동 기간·주요 언어·배지·대표 프로젝트 표시 |
 | 내 오픈소스 역사가 펼쳐지는 장면 보기 | 길찾기·여권·완성된 공개 마을 미리보기에서 **도시 성장 리플레이** 열기 | 레포 집이 생성 연도별로 솟아나는 타임라인, 연도 공유 링크, 시대 엽서 |
 | 다른 개발자와 마을 연결 | 미리보기 후 **친구 마을과 연결하기** 클릭, 또는 도시 메뉴에서 **Twin Towns** 열기 | 두 마을과 공통 언어·토픽을 바로 여는 2인 링크 생성 |
@@ -72,7 +73,7 @@ Repolis는 공개 GitHub 메타데이터와 누적 트래픽을 또 하나의 �
 | 스타 | 지붕 장식 |
 | 최근 활동 | 밤에 빛나는 창문 |
 
-레포는 주제별 구역으로 나뉘고 도로, 표지판, 구역 허브, 세계 지도로 연결됩니다. 주인 마을은 누적 트래픽 기록과 GitHub API로 매일 갱신되며, `?user=<login>`을 붙이면 누구의 공개 레포든 가벼운 마을로 만들 수 있습니다.
+레포는 주제별 구역으로 나뉘고 도로, 표지판, 구역 허브, 세계 지도로 연결됩니다. 주인 마을은 누적 트래픽 기록과 GitHub API로 매일 갱신됩니다. `?user=<login>`은 가벼운 공개 마을을 만들고, `?repo=<owner>/<repo>`는 프로젝트 하나를 먼저 불러옵니다. GitHub는 이 공개 API 모드에 방문자·조회·클론 트래픽을 제공하지 않으므로, 건물은 가짜 트래픽 없이 스타·포크·최근 업데이트로 지어집니다.
 일반적인 보행 거리에서도 한 번에 그리는 건축 LOD가 레포 집의 텍스처 벽과 지붕뿐 아니라 대지, 생울타리, 진입로, 실제 창유리, 셔터, 창턱, 화분, 배수관, 집 등급별 현관·발코니·포티코를 유지합니다.
 
 ## 실제로 살아가는 마을
@@ -80,7 +81,8 @@ Repolis는 공개 GitHub 메타데이터와 누적 트래픽을 또 하나의 �
 - **주민은 제자리 반복 동작만 하지 않습니다.** 이름 있는 주민들이 자기 구역을 거닐고, 시간대에 맞춰 생활하며, 기분이 바뀌고, 아끼는 아지트를 찾습니다. 북동쪽 **별빛 주거구역**에는 이름표가 달린 집과 주민색 앞마당이 있습니다. 집마다 3종 지붕 실루엣, 셔터, 트랜섬 창, 선택형 창가 화분·캐노피·굴뚝·지붕 장식이 다르게 조합되고, 공동 꽃정원·랜턴·생울타리·활엽수·사이프러스가 마을을 감쌉니다. 밤이면 따뜻한 창과 현관으로 귀가하고, 아침이면 각자 구역으로 출근합니다. 친구를 알아보고 함께 산책하거나 나란히 쉬며, 모닥불에 모이고, 때로는 새 릴리스 축제를 엽니다. 두 주민은 플레이어 지시나 AI 호출 없이 실제 꽃밭·별이 보이는 밤하늘·실제 레포 집으로 짧은 **함께하는 기쁨** 나들이도 스스로 떠납니다. 전문 질문을 받으면 아는 척하지 않고 맞는 현자를 소개합니다. 나침반을 따라 마을 안에서 그 현자를 직접 찾아가세요.
 - **탐험에는 흐름이 남습니다.** 탐험 여권이 집과 명소 방문을 기록하고, 구역 진행률이 남은 곳을 보여주며, 매일 열리는 **마을 이야기**가 한 주민과 그 아지트, 실제로 이어진 레포 또는 구역을 연결합니다.
 - **레포 역사가 움직이는 도시 이야기가 됩니다.** **도시 성장 리플레이**는 모든 레포 집에 이미 있는 공개 생성일을 읽어 첫 집부터 현재까지 실제 레포 탄생 연도 순으로 마을을 키웁니다. 슬라이더·재생/일시정지·연도 딥링크·시대 엽서는 주인 마을과 모든 `?user=` 공개 마을에서 동작합니다. 현재도 공개된 레포만 시간축에 들어가며, 집의 모습과 언어 표시는 현재 메타데이터라는 경계도 화면에 명시합니다. 새 메시·텍스처·조명·백엔드·계정·이력 저장은 없습니다.
-- **모든 레포 집에는 실제로 걸어 들어가는 방이 있습니다.** 카드에서 재사용 가능한 **Repository Atelier**로 입장하면 Repository Core, 역사·데이터 벽, 액션 터미널이 선택한 레포에 맞춰 결정적으로 바뀝니다. 입장만으로 네트워크나 AI를 호출하지 않으며, GitHub와 깃버는 터미널을 직접 선택할 때만 작동합니다.
+- **레포 하나가 입구가 됩니다.** **Repo Portal**에 `owner/repo`나 GitHub URL을 넣으면 소유자 목록보다 공개 대상 하나를 먼저 불러오고, 한 번의 입장 클릭 뒤 Repository Atelier로 안내합니다. 전시실에서 정식 주소를 복사하거나 GitHub를 열 수 있고, 원할 때만 소유자의 마을 전체로 넓힙니다. 15분·512 KiB 로컬 캐시와 오래된 캐시 복구로 범위를 묶으며, 알 수 없는 트래픽은 그대로 비공개로 표시합니다.
+- **모든 레포 집에는 완성된 전시실이 있습니다.** 카드에서 재사용 가능한 **Repository Atelier**로 입장하면 현재 Repolis 치비 캐릭터, 역사·데이터 벽, 영향·신호 벽, 지표 아티팩트, 곡선 데이터 경로, Repository Core, 액션 터미널이 선택한 레포에 맞춰 결정적으로 바뀝니다. **깃버에게 이 레포 질문**과 **왜 이 구역인가**는 방문자를 밖으로 내보내지 않고 실내 대화로 열리며, 출구만 마을로 돌아갑니다. GitHub는 명시적인 외부 액션이고, 입장 자체에는 네트워크나 AI 호출이 없습니다.
 - **매일 갱신되는 이유가 재방문에서 보입니다.** 여권의 **마을 소식**은 이 브라우저가 마지막으로 읽은 공개 레포 스냅샷과 현재를 비교해 새 레포·제공되는 경우의 릴리스 태그·푸시·양의 지표 성장을 보여줍니다. 전부 로컬에서 계산되어 비용이 없습니다.
 - **레포끼리의 관계도 보입니다.** 별빛 전망대는 공통 주제나 언어를 바탕으로 실제 세 레포의 연결을 찾고, 밤하늘 저장소 별자리 탐사로 펼칩니다.
 - **모든 마을은 만든 사람을 소개합니다.** **마을 창작자 회관**은 본진·포크·`?user=` 방문 마을의 현재 소유자에게 귀속됩니다. 명시적으로 불러온 공개 GitHub 프로필과 이미 렌더링된 레포를 합쳐 사실 기반 통계·주요 언어·획득 배지·대표 프로젝트 세 개를 보여준 뒤 원본 Repolis 엔진을 분명히 표시합니다.
@@ -124,7 +126,7 @@ GTM_DIR=data python3 scripts/build_repos.py
 
 ## 내 도시로 만들기
 
-가장 빠른 미리보기에는 포크도 필요 없습니다. **[내 GitHub로 보기](https://hyeonsangjeon.github.io/Repolis/?launch=1)**를 열거나 `https://hyeonsangjeon.github.io/Repolis/?user=<login>`을 공유하세요.
+가장 빠른 미리보기에는 포크도 필요 없습니다. **[내 GitHub로 보기](https://hyeonsangjeon.github.io/Repolis/?launch=1)**를 열거나 `https://hyeonsangjeon.github.io/Repolis/?user=<login>`을 공유하세요. 프로젝트 하나는 `https://hyeonsangjeon.github.io/Repolis/?repo=<owner>/<repo>&ref=repo-portal`로 바로 열 수 있습니다.
 
 영구적인 메타데이터 도시를 운영하려면:
 
@@ -159,6 +161,7 @@ Repolis는 **빌드 없는 정적 웹 앱**을 유지합니다. 주 런타임은
 | [`repolis.config.js`](repolis.config.js) | 포크 소유자 자동 인식과 선택형 서비스 안전 기본값 |
 | [`repos.json`](repos.json) | 생성된 레포 및 트래픽 데이터 |
 | [`scholars.js`](scholars.js) | 현자 명단 |
+| [`assets/repo-portal.js`](assets/repo-portal.js) | 엄격한 대상 해석·공개 데이터 투영·정식 레포 링크 |
 | [`assets/town-growth.js`](assets/town-growth.js) | 결정적 레포 탄생 타임라인·연도 스냅샷·공유 링크 |
 | [`assets/world-tree/`](assets/world-tree/) | 절차적 월드 트리 팩토리 |
 | [`cloudflare-taxi/`](cloudflare-taxi/) | 근거 검색 AI와 선택형 주민 대화 Worker |
@@ -191,6 +194,7 @@ Repolis는 **빌드 없는 정적 웹 앱**을 유지합니다. 주 런타임은
 
 - [`AGENTS.md`](AGENTS.md) — 기여자와 에이전트 운영 계약
 - [`docs/domain-model.md`](docs/domain-model.md) — 레포 데이터와 기능 모델
+- [`docs/repo-portal-change-guide.md`](docs/repo-portal-change-guide.md) — Repo Portal URL·데이터·캐시·프라이버시·유지보수 계약
 - [`docs/known-limitations.md`](docs/known-limitations.md) — 의도된 제약
 - [`SCHOLARS.md`](SCHOLARS.md) — 현자 명단과 근거 검색 역할
 - [`COUNCIL_PATTERN.ko.md`](COUNCIL_PATTERN.ko.md) — 토론에서 판정으로 가는 패턴

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <sub>🎬 <strong>15-second demo:</strong> traffic → buildings · ask Gitber → taxi ride → real repo card</sub><br>
 <sub><code>WASD</code> / touch to walk · ask Gitber · <code>Enter</code> / tap to open · no sign-up or build · <strong><a href="#run-in-60-seconds">Run locally</a></strong> · ⭐ <strong><a href="https://github.com/hyeonsangjeon/Repolis">Star Repolis</a></strong></sub><br>
-<sub>Type any GitHub username on the first screen. Repolis uses public metadata only.</sub>
+<sub>Type a GitHub username, <code>owner/repo</code>, or repository URL on the first screen. Repolis uses public metadata only.</sub>
 
 [![Daily refresh](https://img.shields.io/github/actions/workflow/status/hyeonsangjeon/Repolis/refresh.yml?style=flat-square&label=daily%20refresh&logo=githubactions&logoColor=white)](https://github.com/hyeonsangjeon/Repolis/actions/workflows/refresh.yml)
 [![Three.js](https://img.shields.io/badge/Three.js-r160-000000?style=flat-square&logo=three.js&logoColor=white)](https://threejs.org)
@@ -33,7 +33,7 @@
 | Gitber searches by natural language, then physically drives to the result | repository discovery becomes an interaction, not another list |
 | `?user=<login>` rebuilds the town from any public GitHub account | you can test the same engine with your work before cloning or configuring anything |
 
-**Fastest proof:** open **[Try my GitHub](https://hyeonsangjeon.github.io/Repolis/?launch=1)**, type your login, and walk through your public repos. No token, account connection, or fork is required.
+**Fastest proof:** open **[Try my GitHub](https://hyeonsangjeon.github.io/Repolis/?launch=1)** and enter your login or one `owner/repo`. A username builds the public town; a repository opens that project first. No token, account connection, or fork is required.
 
 <div align="center">
 
@@ -50,6 +50,7 @@ If this gives you a useful way to present repositories, **[star Repolis](https:/
 | Goal | What to do | Result |
 |---|---|---|
 | preview my public repos | use the live username field | a shareable metadata-built town in seconds |
+| share one repository as an experience | paste `owner/repo` or a GitHub repository URL, then use **Copy Repo Portal** in its Atelier | a canonical `?repo=owner/repo&ref=repo-portal` link that loads one target before the owner catalog |
 | introduce who built the town | visit **Town Creator Hall** or open **Meet the town creator** in the city menu | public bio, followers, GitHub tenure, top languages, badges, and signature projects tied to the current town owner |
 | watch my open-source history unfold | open **Town Growth Replay** from Wayfinding, the Passport, or my completed public-town preview | a creation-date timeline where repo houses rise year by year, with a shareable year link and era postcard |
 | connect with another developer | click **Connect with a friend** after a preview, or open **Twin Towns** in the city menu | a two-person link that opens both towns and their shared languages or topics |
@@ -72,7 +73,7 @@ Repolis turns public GitHub metadata and cumulative traffic into a place instead
 | stars | roof ornaments |
 | recent activity | window glow at night |
 
-Repositories are grouped into topic districts with roads, signs, hubs, and a world map. The owner town refreshes daily from committed traffic history plus the GitHub API; `?user=<login>` can build a lighter town from any user's public repositories.
+Repositories are grouped into topic districts with roads, signs, hubs, and a world map. The owner town refreshes daily from committed traffic history plus the GitHub API. `?user=<login>` builds a lighter public town, while `?repo=<owner>/<repo>` loads one project first. GitHub does not publish visitor, view, or clone traffic for those public API modes, so their buildings use stars, forks, and update recency without inventing traffic.
 At ordinary walking distances, a one-draw architectural LOD keeps each repo house's textured walls and roof while preserving its plot, hedge, path, real window panes, shutters, sills, flower boxes, gutters, and tier-specific porch, balcony, or portico.
 
 ## A village that lives
@@ -80,7 +81,8 @@ At ordinary walking distances, a one-draw architectural LOD keeps each repo hous
 - **Residents have lives, not idle loops.** Named townspeople wander their districts, keep daily rhythms, carry changing moods, visit cherished haunts, recognize friends, stroll and sit together, gather around the campfire, and sometimes celebrate a recent repository release. Their cottages form **Starlight Row** on the north-east edge, with resident-coloured gardens, three roof silhouettes, shutters, transoms, selected window boxes, canopies, chimneys, and roof finials. A shared flower bed, lanterns, hedges, and broadleaf/cypress trees care for the commons. Night brings residents home to warm windows and porch seats, while morning sends them back to their district work. Pairs also choose their own short **Shared Joy** excursions to real flower patches, visible night stars, or a real repo house—without a player prompt or AI call. Ask a specialist question and they introduce the right scholar instead of pretending to know: follow the compass and find that scholar in the world.
 - **Exploration has continuity.** The Explorer Passport records houses and landmarks, district progress shows what remains, and the daily **Village Chronicle** connects one resident to their cherished haunt and a truthful related repo or district.
 - **Your repository history becomes a moving city story.** **Town Growth Replay** reads the public creation date already carried by every repo house, then raises the town through its real repo-birth years from the first house to the present. The scrubber, play/pause controls, deep link, and era postcard work for the owner and every `?user=` public town. The timeline covers repos still public today; house appearance and language labels stay explicitly marked as today’s metadata. Replay adds no mesh, texture, light, backend, account, or stored history.
-- **Every repo house opens into one real room.** Its card leads to the reusable **Repository Atelier**: a walkable 3D exhibition whose Repository Core, history/data wall, and action terminals rebind deterministically to that repo. Entering costs no network or AI call; GitHub and Gitber run only when you choose a terminal.
+- **A repository can be the front door.** **Repo Portal** accepts `owner/repo` or a GitHub URL, loads that one public target before the owner catalog, and takes the visitor into its Repository Atelier after one entry click. The Atelier can copy the canonical address, open GitHub, or expand into the owner's full town. A 15-minute, 512 KiB local cache and stale fallback keep the path bounded; unavailable traffic remains unknown.
+- **Every repo house opens into one finished exhibition.** Its card leads to the reusable **Repository Atelier**, now carrying the current Repolis chibi, a History/Data Wall, Impact/Signals Wall, metric artifacts, a curved data path, Repository Core, and action terminals that rebind deterministically to that repo. **Ask Gitber** and **Why this district?** open an in-room conversation without ejecting the visitor; only the exit returns to town, while GitHub remains an explicit external action. Entering still costs no network or AI call.
 - **Daily refresh now means something on return.** The Passport's **Town Gazette** compares the current public repo snapshot with the last one this browser marked read, then highlights new repos, release tags when available, pushes, and positive metric growth. It is entirely local and costs nothing.
 - **Repositories form relationships.** The Stargazer's Observatory finds a truthful three-repo connection from shared topics or languages and draws it as a nighttime Constellation Trail.
 - **Every town introduces its creator.** **Town Creator Hall** belongs to the active town owner—canonical, fork, or `?user=` visitor—and combines an explicitly loaded public GitHub profile with the repositories already rendered in town. The hall highlights truthful stats, languages, earned badges, and three signature projects before crediting the upstream Repolis engine.
@@ -124,7 +126,7 @@ GTM_DIR=data python3 scripts/build_repos.py
 
 ## Build your own city
 
-The quickest preview needs no fork: open **[Try my GitHub](https://hyeonsangjeon.github.io/Repolis/?launch=1)** or share `https://hyeonsangjeon.github.io/Repolis/?user=<login>`.
+The quickest preview needs no fork: open **[Try my GitHub](https://hyeonsangjeon.github.io/Repolis/?launch=1)**, share `https://hyeonsangjeon.github.io/Repolis/?user=<login>`, or point one project at `https://hyeonsangjeon.github.io/Repolis/?repo=<owner>/<repo>&ref=repo-portal`.
 
 For a persistent metadata-built city:
 
@@ -159,6 +161,7 @@ Repolis stays a **zero-build static web app**. The main runtime remains in `inde
 | [`repolis.config.js`](repolis.config.js) | fork owner inference and safe optional-service defaults |
 | [`repos.json`](repos.json) | generated repository and traffic data |
 | [`scholars.js`](scholars.js) | scholar roster |
+| [`assets/repo-portal.js`](assets/repo-portal.js) | strict target parsing, public projection, and canonical repository links |
 | [`assets/town-growth.js`](assets/town-growth.js) | deterministic repo-birth timeline, year snapshots, and share links |
 | [`assets/world-tree/`](assets/world-tree/) | procedural World Tree factory |
 | [`cloudflare-taxi/`](cloudflare-taxi/) | grounded AI and optional resident dialogue Worker |
@@ -191,6 +194,7 @@ Repolis stays a **zero-build static web app**. The main runtime remains in `inde
 
 - [`AGENTS.md`](AGENTS.md) — contributor and agent operating contract
 - [`docs/domain-model.md`](docs/domain-model.md) — repository data and feature model
+- [`docs/repo-portal-change-guide.md`](docs/repo-portal-change-guide.md) — Repo Portal URL, data, cache, privacy, and maintenance contract
 - [`docs/known-limitations.md`](docs/known-limitations.md) — intentional constraints
 - [`SCHOLARS.md`](SCHOLARS.md) — scholar roster and grounding roles
 - [`COUNCIL_PATTERN.md`](COUNCIL_PATTERN.md) — the debate-to-judge pattern

--- a/assets/repo-portal.js
+++ b/assets/repo-portal.js
@@ -1,0 +1,215 @@
+export const REPO_PORTAL_LIMITS = Object.freeze({
+  cacheVersion: 1,
+  cacheTtlMs: 15 * 60 * 1000,
+  cacheMaxBytes: 512 * 1024,
+  cacheMaxEntries: 30,
+});
+
+export const GITHUB_LOGIN_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+export const GITHUB_REPO_RE = /^[A-Za-z0-9_.-]{1,100}$/;
+
+const CONTROL_RE = /[\u0000-\u001f\u007f]/;
+const ENCODED_PATH_RE = /%(?:2e|2f|5c)/i;
+const TRAVERSAL_RE = /(?:^|\/)\.{1,2}(?:\/|$)/;
+
+function invalid(reason) {
+  return Object.freeze({ ok: false, reason });
+}
+
+function validLogin(value) {
+  return GITHUB_LOGIN_RE.test(value);
+}
+
+function validRepo(value) {
+  return GITHUB_REPO_RE.test(value) && value !== '.' && value !== '..';
+}
+
+function cleanRepo(value) {
+  return String(value || '').replace(/\.git$/i, '');
+}
+
+function targetResult(owner, repo, source) {
+  const slug = `${owner}/${repo}`;
+  return Object.freeze({ ok: true, kind: 'repo', owner, repo, slug, source });
+}
+
+function userResult(user, source) {
+  return Object.freeze({ ok: true, kind: 'user', user, source });
+}
+
+function parsePathParts(parts, source) {
+  if (parts.length === 1 && validLogin(parts[0])) return userResult(parts[0], source);
+  if (parts.length !== 2) return invalid('shape');
+  const owner = parts[0], repo = cleanRepo(parts[1]);
+  if (!validLogin(owner) || !validRepo(repo)) return invalid('shape');
+  return targetResult(owner, repo, source);
+}
+
+export function parseRepoPortalInput(value) {
+  if (typeof value !== 'string') return invalid('empty');
+  let input = value.trim();
+  if (!input) return invalid('empty');
+  if (input.length > 320 || CONTROL_RE.test(input) || /\s/.test(input)) return invalid('unsafe');
+
+  const looksLikeUrl = /^https?:\/\//i.test(input) || /^(?:www\.)?github\.com\//i.test(input);
+  if (looksLikeUrl) {
+    const urlInput = /^https?:\/\//i.test(input) ? input : `https://${input}`;
+    const pathProbe = urlInput.replace(/^https?:\/\/(?:www\.)?github\.com/i, '').replace(/[?#].*$/, '');
+    if (ENCODED_PATH_RE.test(pathProbe) || TRAVERSAL_RE.test(pathProbe) || /\\/.test(pathProbe)) return invalid('unsafe');
+    let url;
+    try { url = new URL(urlInput); } catch (_) { return invalid('url'); }
+    const host = url.hostname.toLowerCase().replace(/^www\./, '');
+    if ((url.protocol !== 'https:' && url.protocol !== 'http:') || host !== 'github.com'
+      || url.username || url.password || url.port || url.search || url.hash) return invalid('host');
+    let path;
+    try { path = decodeURIComponent(url.pathname); } catch (_) { return invalid('unsafe'); }
+    if (CONTROL_RE.test(path) || /\\/.test(path) || TRAVERSAL_RE.test(path)) return invalid('unsafe');
+    const parts = path.split('/').filter(Boolean);
+    return parsePathParts(parts, 'url');
+  }
+
+  if (input.includes('?') || input.includes('#') || input.includes('\\') || ENCODED_PATH_RE.test(input)
+    || TRAVERSAL_RE.test(input)) return invalid('unsafe');
+  input = input.replace(/^@+/, '').replace(/\/+$/, '');
+  const parts = input.split('/').filter(Boolean);
+  return parsePathParts(parts, parts.length === 1 ? 'user' : 'slug');
+}
+
+function repoTarget(value) {
+  const parsed = typeof value === 'string' ? parseRepoPortalInput(value) : value;
+  if (!parsed || parsed.ok !== true || parsed.kind !== 'repo') throw new TypeError('A valid owner/repo target is required');
+  return parsed;
+}
+
+function cleanBase(baseUrl) {
+  const url = new URL(baseUrl);
+  url.search = '';
+  url.hash = '';
+  return `${url.origin}${url.pathname}`;
+}
+
+export function createRepoPortalUrl(value, baseUrl) {
+  const target = repoTarget(value);
+  return `${cleanBase(baseUrl)}?repo=${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}&ref=repo-portal`;
+}
+
+export function createRepoOwnerTownUrl(value, baseUrl, projectOwner = '') {
+  const target = repoTarget(value);
+  const params = [];
+  if (target.owner.toLowerCase() !== String(projectOwner || '').toLowerCase()) {
+    params.push(`user=${encodeURIComponent(target.owner)}`);
+  }
+  params.push(`focus=${encodeURIComponent(target.repo)}`, 'ref=repo-portal');
+  return `${cleanBase(baseUrl)}?${params.join('&')}`;
+}
+
+export function resolveRepoPortalRequest(search, projectOwner) {
+  const params = new URLSearchParams(String(search || '').replace(/^\?/, ''));
+  if (params.has('repo')) {
+    const target = parseRepoPortalInput(params.get('repo') || '');
+    if (!target.ok || target.kind !== 'repo') {
+      return Object.freeze({ mode: 'portal', target: null, focus: null, error: target.reason || 'shape', repoWins: true });
+    }
+    return Object.freeze({ mode: 'portal', target, focus: null, error: null, repoWins: true });
+  }
+
+  const requestedUser = String(params.get('user') || '').trim().replace(/^@+/, '');
+  const owner = String(projectOwner || '');
+  const isPublic = validLogin(requestedUser) && requestedUser.toLowerCase() !== owner.toLowerCase();
+  const activeOwner = isPublic ? requestedUser : owner;
+  const focusValue = String(params.get('focus') || '').trim();
+  const focus = focusValue ? parseRepoPortalInput(`${activeOwner}/${focusValue}`) : null;
+  return Object.freeze({
+    mode: isPublic ? 'public' : 'owner',
+    target: null,
+    focus: focus && focus.ok && focus.kind === 'repo' ? focus : null,
+    error: null,
+    repoWins: false,
+  });
+}
+
+function cleanText(value, max) {
+  return String(value || '').replace(/[\u0000-\u001f\u007f]/g, '').trim().slice(0, max);
+}
+
+function count(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function safeHomepage(value) {
+  try {
+    const url = new URL(String(value || ''));
+    return (url.protocol === 'https:' || url.protocol === 'http:') && !url.username && !url.password ? url.href : '';
+  } catch (_) { return ''; }
+}
+
+export function projectPublicRepo(raw, expectedOwner, nowMs = Date.now()) {
+  if (!raw || typeof raw !== 'object' || raw.private === true || raw.disabled === true) return null;
+  const apiOwner = cleanText(raw.owner && raw.owner.login, 39);
+  const owner = cleanText(expectedOwner || apiOwner, 39);
+  const repo = cleanRepo(cleanText(raw.name, 100));
+  if (!validLogin(owner) || !validRepo(repo)) return null;
+  if (apiOwner && apiOwner.toLowerCase() !== owner.toLowerCase()) return null;
+  if (raw.full_name && String(raw.full_name).toLowerCase() !== `${owner}/${repo}`.toLowerCase()) return null;
+
+  const pushed = cleanText(raw.pushed_at || raw.updated_at || raw.created_at, 40);
+  const pushedMs = Date.parse(pushed);
+  const ageDays = Number.isFinite(pushedMs) ? Math.max(0, (nowMs - pushedMs) / 86400000) : 3650;
+  const recency = Math.max(0, 1 - Math.min(ageDays, 365) / 365);
+  const license = raw.license && raw.license.spdx_id !== 'NOASSERTION'
+    ? cleanText(raw.license.spdx_id, 40) : '';
+  const stars = count(raw.stargazers_count), forks = count(raw.forks_count);
+
+  return {
+    repo,
+    desc: cleanText(raw.description, 500),
+    lang: cleanText(raw.language, 50) || 'Other',
+    topics: Array.isArray(raw.topics) ? raw.topics.map(topic => cleanText(topic, 50)).filter(Boolean).slice(0, 24) : [],
+    url: `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    home: safeHomepage(raw.homepage),
+    stars,
+    forks,
+    fork: raw.fork === true,
+    views: null,
+    visitors: null,
+    clones: null,
+    trafficKnown: false,
+    trafficSource: 'unavailable',
+    size: count(raw.size),
+    open_issues: count(raw.open_issues_count),
+    license,
+    archived: raw.archived === true,
+    default_branch: cleanText(raw.default_branch, 100) || 'main',
+    release_tag: '',
+    release_date: null,
+    created: cleanText(raw.created_at, 40),
+    pushed,
+    updated: cleanText(raw.updated_at, 40),
+    tracked: false,
+    first_seen: '',
+    social: '',
+    social_custom: '',
+    score: Math.log1p(stars) * 3 + Math.log1p(forks) * 1.6 + recency * 2.4 + Math.log1p(count(raw.open_issues_count)) * 0.3,
+    rank: 0,
+    _owner: owner,
+    public_mode: true,
+    _recency: recency,
+  };
+}
+
+export function projectPublicRepos(raw, owner, nowMs = Date.now()) {
+  const repos = (Array.isArray(raw) ? raw : []).map(repo => projectPublicRepo(repo, owner, nowMs)).filter(Boolean);
+  repos.sort((a, b) => (b.score - a.score) || (b.stars - a.stars) || a.repo.localeCompare(b.repo));
+  repos.forEach((repo, index) => { repo.rank = index; });
+  return repos;
+}
+
+export function repoPortalLatencyBucket(milliseconds) {
+  const value = Number(milliseconds);
+  if (!Number.isFinite(value) || value < 0) return 'unknown';
+  if (value < 1000) return 'under-1s';
+  if (value < 3000) return '1-3s';
+  if (value < 10000) return '3-10s';
+  return '10s-plus';
+}

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -11,6 +11,7 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | Entity | Where it lives | Notes |
 |---|---|---|
 | **Repo** | one object in `repos.json` | The unit of the world — becomes one house. |
+| **Repo Portal target** | one allowlisted public repo projection | A target-first house and Atelier reached through `?repo=owner/repo`. |
 | **City / Town** | derived in `index.html` at load | The whole 3D scene built from the `repos.json` array. |
 | **District** | deterministic `zoneOf(repo)` result | A topic-shaped neighborhood with a hub, board, map destination, and progress. |
 | **Resident** | resident roster in `index.html` | A townsperson with a residential home, district work anchor, mood, relationships, and a cherished haunt. |
@@ -40,6 +41,7 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | `views` | number | 📈 → **garden** / fence size. |
 | `visitors` | number | 👁 unique visitors → building **height**. |
 | `clones` | number | ⬇ → **ornamentation** (banners, gold trim). |
+| `trafficKnown` | boolean | `true` for the generated owner snapshot; `false` for public API projections where views/visitors/clones stay `null`. |
 | `size` | number | Repo size (KB). |
 | `open_issues` | number | Shown as a live badge on the repo card. |
 | `license` | string | Shown as a badge. |
@@ -80,6 +82,11 @@ the body/roof silhouette so decorative ground geometry cannot pollute the frozen
 
 Counts are **cumulative since move-in day** (`first_seen`/`tracked`), because GitHub's traffic API only
 keeps a rolling 14-day window — a daily collector accumulates the lifetime totals offline.
+
+That mapping applies only when `trafficKnown` is true. GitHub's unauthenticated public repository endpoints
+do not expose visitors, views, or clones. Repo Portal and `?user=` projections leave those fields `null`;
+their architecture uses stars, forks, and update recency directly. Cards, search answers, and Atelier walls
+state the boundary instead of presenting derived values as observed traffic.
 
 ---
 
@@ -152,8 +159,11 @@ Three modes: **Local** (default, keyless, instant) · **WebLLM** (on-device WebG
 |---|---|---|
 | **Owner town** | bare URL | The generated owner snapshot from `repos.json`. The taxi + scholars are fully live. |
 | **Public town** | `?user=<login>` | Rebuilds the town from any public GitHub user's repos (cached in `localStorage`, stale-fallback). Cross-town taxi driving is disabled; a "go home" button returns to the owner city. |
+| **Repo Portal** | `?repo=<owner>/<repo>&ref=repo-portal` | Resolves one public repo first, shows a compact proof, then opens its Atelier after one entry click. |
+| **Expanded owner town** | `?user=<owner>&focus=<repo>&ref=repo-portal` | Loads the existing public-town catalog only after explicit expansion, merges the target when needed, and opens the same Atelier. |
 
-Public mode only activates for a **valid, non-owner** username; the bare URL always loads the owner city unchanged.
+Public mode only activates for a **valid, non-owner** username; the bare URL always loads the owner city
+unchanged. A valid `repo` query takes precedence over `user`, `twin`, `growth`, and repo-card hash state.
 
 ---
 
@@ -216,7 +226,61 @@ snapshots.
 
 ---
 
-## 11. Resident Agency — Shared Joy
+## 11. Repo Portal
+
+[`assets/repo-portal.js`](../assets/repo-portal.js) is the pure contract for username/repository parsing,
+query precedence, public repo projection, canonical share links, owner-town expansion links, and coarse
+latency buckets. It has no DOM, storage, network, Three.js, or random dependency.
+
+The runtime's target-first loader follows one bounded sequence:
+
+1. exact owner `repos.json` match;
+2. fresh 15-minute local cache;
+3. one unauthenticated `GET /repos/{owner}/{repo}`;
+4. explicitly labelled stale cache after failure;
+5. the existing owner town as a usable fallback.
+
+The Portal cache stores only projected public fields, uses LRU order, and is capped at 30 entries and 512
+KiB. A 403/429 is not retried. The target mode creates one normal repo object, so district classification,
+building construction, repo search, and Repository Atelier do not need a parallel rendering model.
+
+The intro and GitHub Station share the parser. A repository resolves to
+`?repo=owner/repo&ref=repo-portal`; entering hides unrelated proof actions and opens the bound Atelier. The
+Atelier can copy the same published address, open GitHub, or navigate to an explicit `?user=&focus=`
+expansion. Expansion is the only action that fetches the owner catalog before showing it.
+
+New Portal funnel events use a page-lifetime session ID and coarse enums only. They remove owner, repo, URL,
+raw input, query text, `cityUser`, and persistent instance ID before the optional analytics sink. See
+[`repo-portal-change-guide.md`](repo-portal-change-guide.md) for the full maintenance and QA contract.
+
+---
+
+## 12. Repository Atelier
+
+Every non-library repo card can enter one lazy-created dedicated Three.js scene. The room is reused rather
+than duplicated: three bounded canvas atlases redraw the History/Data, Impact/Signals, and Action walls, while
+the core shape, metric artifacts, instanced architecture, path, colors, and lighting rebind from the selected
+repo's current metadata. The visitor is a clone of the current Repolis chibi hierarchy with shared GPU
+geometry/materials, not a separate placeholder character.
+
+The room owns update, camera, input, and rendering until explicit exit; exterior simulation renders zero
+frames during that time. Entry snapshots the exact exterior player, camera, navigation, modal, chat, and tour
+state, and exit restores it idempotently.
+
+Terminal ownership is explicit:
+
+- **Open GitHub** is the only external action and opens a safe new tab.
+- **Ask Gitber about this repo** opens the existing Local/WebLLM/grounded chat as a dark in-room panel.
+- **Why this district?** renders the deterministic classifier explanation in the same panel.
+- Taxi rides, scholar handoffs, and repo recommendation ride buttons are unavailable while the room owns
+  interaction, so they cannot leak exterior state into the exhibition.
+
+Entering or rebinding performs no fetch, model call, dynamic import, or backend work. Only an explicit Ask
+turn may use the already selected Gitber mode.
+
+---
+
+## 13. Resident Agency — Shared Joy
 
 Shared Joy is a single session-local pair state in the resident social layer. When no stronger owner is
 active, a deterministic time-slice planner chooses two compatible idle residents, preferring named friends.
@@ -236,7 +300,7 @@ resident movement. The state is not persisted and makes no AI, MCP, network, ass
 
 ---
 
-## 12. Starlight Row — resident homes and routines
+## 14. Starlight Row — resident homes and routines
 
 Starlight Row is a fixed civic landmark at `(130, 130)`, outside the repository rings but inside the
 205-unit map and 215-unit player bounds. It contains one roster-bound cottage per resident. Shared instanced

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -15,6 +15,14 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
   `scripts/build_repos.py` instead.
 - **Public repos only, by design.** Private repo names never appear. Untouched mirror forks are filtered
   out; only forks you've actually committed to are shown.
+- **Public API modes do not have traffic.** Repo Portal and `?user=` receive stars, forks, issues, language,
+  topics, and lifecycle dates from unauthenticated public endpoints. GitHub does not return visitors, views,
+  or clones there, so Repolis keeps those fields unknown and uses stars, forks, and recency for architecture.
+  An exact Portal match in the generated owner snapshot may reuse its known cumulative traffic.
+- **Repo Portal is one unauthenticated request, not a proxy.** An arbitrary target uses one
+  `GET /repos/{owner}/{repo}` request with no retry. A 15-minute LRU cache is limited to 30 entries and 512
+  KiB; failed requests may use an explicitly labelled stale entry. Without one, the target error appears
+  over the existing owner town. GitHub's anonymous 403/429 limit still applies.
 - **Creator Hall reads one public profile explicitly.** Opening the hall requests GitHub's public
   `/users/<login>` endpoint and caches only the fields it renders for 24 hours. Anonymous API rate limits
   can hide the avatar/bio temporarily; the hall still falls back to the public repository facts already
@@ -63,6 +71,10 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
   past Star, fork, traffic, topic, or language snapshots, so a visible house keeps its current architecture
   and language label and the UI says so explicitly. Repos without a valid creation date appear only in the
   present step. Replay state lives in the URL and is not persisted.
+- **Repository Atelier is a metadata exhibition, not a source-code IDE.** One reusable room redraws the
+  current repo description, topics, public metrics, lifecycle dates, and available traffic. It does not clone
+  source files, reconstruct old metrics, or simulate build/runtime behavior. Explicit Gitber questions use
+  the currently selected chat mode and its existing Local or backend fallback.
 - **Resident Shared Joy is bounded and session-local.** At most one pair takes a scripted excursion at a
   time; it is not remembered across reloads and does not use a model. Stargazing starts autonomously only
   while stars are visible, and visitor/chat/festival ownership intentionally interrupts an outing.

--- a/docs/repo-portal-change-guide.md
+++ b/docs/repo-portal-change-guide.md
@@ -1,0 +1,145 @@
+# Repo Portal change guide
+
+Repo Portal gives one public repository its own front door into Repolis:
+
+```text
+https://hyeonsangjeon.github.io/Repolis/?repo=owner/repo&ref=repo-portal
+```
+
+This is the product change most likely to improve Star acquisition because it shortens the path from a
+developer sharing real work to a visitor understanding Repolis. A repository link now opens one
+metadata-shaped building and its Repository Atelier before Repolis requests the owner catalog. The recipient
+gets relevant proof, a GitHub handoff, and a copyable artifact in one short visit. Only after that proof do
+they choose whether to expand into the owner's town. That link can travel with the repository that
+already has an audience instead of asking people to share Repolis as a destination on its own.
+
+## User flow
+
+1. Paste a GitHub username, `owner/repo`, or a GitHub repository root URL into the intro or Station.
+2. A username keeps the existing `?user=<login>` public-town flow.
+3. A repository resolves to the canonical Portal URL and loads that target first.
+4. The first screen confirms stars, forks, language, description, and data source.
+5. **Enter this repo exhibition** opens the target's Repository Atelier.
+6. The Atelier can copy the same Portal address, open GitHub, or explicitly load the owner's full town.
+7. The earned Star invitation remains deferred until the visitor has completed the Atelier Aha or copied
+   the Portal and then returned to the town.
+
+## URL contract
+
+| Purpose | URL |
+|---|---|
+| Canonical repository entry | `?repo=owner/repo&ref=repo-portal` |
+| Public owner-town expansion | `?user=owner&focus=repo&ref=repo-portal` |
+| Canonical owner-town expansion | `?focus=repo&ref=repo-portal` |
+| Existing public town | `?user=owner` |
+
+`repo` is the source of truth when `repo` and `user` disagree. Portal links discard unrelated `user`,
+`twin`, `growth`, and hash state instead of composing ambiguous experiences. Browser history remains
+ordinary navigation: entering the Atelier does not push a synthetic history entry, and Back returns to the
+previous page.
+
+The shared parser accepts:
+
+- a GitHub username;
+- `owner/repo`;
+- `https://github.com/owner/repo`;
+- the same repository forms with one trailing slash or `.git`.
+
+It rejects non-GitHub hosts, credentials, ports, extra path segments, query strings, fragments, encoded path
+separators, traversal, control characters, and malformed owner or repository names. Rejected input never
+starts a GitHub API request.
+
+## Target-first data path
+
+The runtime resolves a repository in this order:
+
+| Step | Source | Result |
+|---|---|---|
+| 1 | Exact match in the generated owner snapshot | Reuses known owner traffic with `trafficKnown: true`. |
+| 2 | Fresh local Portal cache | Reuses allowlisted public metadata for 15 minutes. |
+| 3 | `GET /repos/{owner}/{repo}` | Makes one unauthenticated GitHub request with no automatic retry. |
+| 4 | Stale local Portal cache | Recovers explicitly as stale when the request fails. |
+| 5 | Existing owner town | Preserves a usable local scene and displays the target error. |
+
+The Portal cache is an LRU capped at 30 entries and 512 KiB. It stores only the public fields projected by
+`assets/repo-portal.js`. A 403 or 429 is surfaced immediately; the runtime does not retry or fetch an owner
+catalog. The owner catalog is requested only after the visitor chooses **Explore @owner's full town**.
+Target-only mode does not write a Town Gazette baseline or Village Chronicle payload. A Postcard copy-link
+returns the same canonical Portal URL instead of dropping the target or composing unrelated feature state.
+
+## Traffic truth boundary
+
+GitHub's public repository endpoint does not expose visitors, views, or clones. Repo Portal and `?user=`
+towns therefore keep:
+
+```js
+trafficKnown: false
+visitors: null
+views: null
+clones: null
+```
+
+Public architecture uses stars, forks, and update recency directly. Cards, search answers, and Atelier walls
+do not print unavailable traffic as zero or describe a public building as traffic-shaped. An exact match in
+the generated owner snapshot may show cumulative traffic because that data is already present and marked
+`trafficKnown: true`.
+
+## Funnel events
+
+Repo Portal uses the existing optional analytics sink with a stricter payload:
+
+| Event | Moment |
+|---|---|
+| `feature_seen` | The universal repository entry is visible or a Portal link opens. |
+| `feature_started` | Input is rejected, or a canonical target finishes resolving. |
+| `aha_completed` | The target Atelier reaches its inside state after facts are bound. |
+| `share_created` | A canonical Portal address is copied. |
+| `github_repo_opened` | The visitor explicitly opens the target on GitHub. |
+| `project_star_click` | The earned upstream Repolis Star link is clicked. |
+
+These events may include only a page-lifetime session ID, timestamp, entry surface, device class, language,
+result enum, coarse latency bucket, and channel enum. They omit owner, repository, URL, pasted input, query
+text, `cityUser`, and the persistent anonymous instance ID.
+
+## Performance and accessibility contract
+
+- No binary asset, model, image, texture, light, shadow, backend, package, or build step was added.
+- A cold arbitrary target makes at most one GitHub repository request before Aha.
+- Portal code stays below 30 KiB uncompressed, and the complete local runtime stays below 5 MiB.
+- Target arrival adds no steady-state town draw and no Portal-specific Three.js object.
+- Intro and Station use one labelled 320-character field, visible alert text, and shared validation.
+- Proof and copy results use live regions. Atelier actions use 44 px mobile targets and hide while its chat
+  owns the screen.
+- Reduced-motion visitors keep the same flow with the existing shortened Atelier fade.
+
+## Files to change
+
+| File | Responsibility |
+|---|---|
+| `assets/repo-portal.js` | Parser, route precedence, public projection, canonical links, and latency buckets. |
+| `index.html` | Loading, bounded cache, truthful architecture, intro/Station UX, Atelier actions, and events. |
+| `scripts/smoke.mjs` | Hermetic parser, security, fallback, privacy, i18n, accessibility, and budget guards. |
+| `examples/share-links.md` | Copy-ready public URL examples. |
+| `docs/domain-model.md` | Portal mode and `trafficKnown` semantics. |
+| `docs/known-limitations.md` | API, cache, and public-traffic constraints. |
+
+Keep parsing and link construction in the pure module. Do not add a second input resolver or build Portal
+links by editing `location.search` in place. Do not add synthetic traffic fields to make existing building
+math convenient.
+
+## Verification
+
+Run the golden suite:
+
+```bash
+node council/test.mjs
+node council/test-live.mjs
+node scripts/smoke.mjs
+node --check scholars.js
+node --check cloudflare-taxi/src/grounded.js
+```
+
+Then serve the repository and test a known owner repo, an arbitrary public repo, a fresh and stale cache,
+404, 403/429, offline fallback, malicious input, owner-town expansion, copy, GitHub handoff, Back, KO/EN,
+keyboard operation, reduced motion, desktop, and 390x844 mobile. Both viewports must finish with no console
+errors, overlap, or horizontal overflow.

--- a/examples/share-links.md
+++ b/examples/share-links.md
@@ -9,6 +9,7 @@ Repolis is one static page, so every entry point is just a URL. No accounts, no 
 | `https://hyeonsangjeon.github.io/Repolis/` | The owner's generated city snapshot. |
 | `https://hyeonsangjeon.github.io/Repolis/?launch=1` | The username launchpad, focused and ready to build a personal preview. |
 | `https://hyeonsangjeon.github.io/Repolis/?user=mrdoob` | A town built live from `mrdoob`'s public repos. |
+| `https://hyeonsangjeon.github.io/Repolis/?repo=mrdoob/three.js&ref=repo-portal` | The `three.js` building and Repository Atelier before the owner catalog. |
 | `https://hyeonsangjeon.github.io/Repolis/?user=torvalds` | A town built from `torvalds`' public repos. |
 | `https://hyeonsangjeon.github.io/Repolis/?user=mrdoob&twin=torvalds&ref=twin-town` | Twin Towns for two users, including shared languages/topics and a reversible visit link. |
 
@@ -16,6 +17,28 @@ Repolis is one static page, so every entry point is just a URL. No accounts, no 
 stale fallback). It activates only for a valid, non-owner username; a bad name shows a friendly "lost"
 overlay, and a "go home" button always returns to the owner city. Cross-town taxi driving is disabled in
 public mode.
+
+## Share one repository
+
+Paste a username, `owner/repo`, or a GitHub repository root URL into the first screen or **Station**. A
+repository becomes:
+
+```text
+?repo=<owner>/<repo>&ref=repo-portal
+```
+
+The link loads one target first, confirms its public facts, and opens its Repository Atelier after one entry
+click. **Copy Repo Portal** produces the same canonical address. **Explore @owner's full town** is an
+explicit second step that reuses the existing public-town loader and keeps the target focused.
+
+Trailing slashes and `.git` are accepted. Non-GitHub hosts, extra paths, query injection, traversal, and
+control characters are rejected before any GitHub request. If `repo` and `user` conflict, the repository
+owner wins; Portal links never mix `twin`, `growth`, postcard, or repo-card hash state.
+
+Arbitrary public repositories expose stars, forks, language, topics, dates, and issues. GitHub does not
+publish their visitor, view, or clone traffic, so Repolis leaves those fields unknown rather than showing
+synthetic values. One exact `GET /repos/{owner}/{repo}` request is cached locally for 15 minutes, with a
+bounded stale fallback.
 
 ## Connect two towns
 

--- a/index.html
+++ b/index.html
@@ -424,10 +424,23 @@
   #atelierIdentity .k { display: block; color: #b9cdd1; font-size: 10px; font-weight: 900; letter-spacing: .14em; }
   #atelierIdentity .repo { display: block; margin-top: 2px; overflow: hidden; text-overflow: ellipsis;
     white-space: nowrap; font-size: 15px; font-weight: 800; }
+  #atelierIdentity .sub { display:block; margin-top:3px; color:#8fb7bc; font-size:10px; font-weight:700; letter-spacing:.02em; }
   #atelierExit { position: absolute; top: calc(14px + env(safe-area-inset-top,0px));
     left: calc(14px + env(safe-area-inset-left,0px)); width: 48px; height: 48px; border: 1px solid rgba(255,255,255,.24);
     border-radius: 50%; background: rgba(16,24,27,.88); color: #fff; font-size: 23px; cursor: pointer;
     box-shadow: 0 8px 26px rgba(0,0,0,.3); pointer-events: auto; }
+  #atelierPortalActions { position:absolute; top:calc(86px + env(safe-area-inset-top,0px)); right:14px;
+    display:flex; flex-wrap:wrap; justify-content:flex-end; gap:6px; width:min(610px,calc(100vw - 28px)); pointer-events:auto; }
+  #atelierPortalActions[hidden] { display:none; }
+  #atelierPortalActions [hidden] { display:none; }
+  #atelierPortalActions button, #atelierPortalActions a { display:inline-flex; min-height:40px; align-items:center; justify-content:center;
+    border:1px solid rgba(154,207,211,.36); border-radius:11px; padding:7px 11px; color:#e8f4f3;
+    background:rgba(16,31,35,.9); font:800 11px/1.2 system-ui,sans-serif; text-decoration:none; cursor:pointer;
+    box-shadow:0 6px 20px rgba(0,0,0,.24); backdrop-filter:blur(8px); }
+  #atelierPortalActions button:hover, #atelierPortalActions a:hover { border-color:#8fd6dd; background:#233f45; }
+  #atelierPortalStatus { flex:1 0 100%; min-height:14px; color:#b8d5d5; font-size:10px; text-align:right; }
+  #atelierPortalStatus[data-tone="success"] { color:#9fe0bf; }
+  #atelierPortalStatus[data-tone="error"] { color:#ffc0ae; }
   body.atelier-active #topbar, body.atelier-active #menuBtn, body.atelier-active #panel,
   body.atelier-active #passport, body.atelier-active #mapWrap, body.atelier-active #station,
   body.atelier-active #taxiBtn, body.atelier-active #emoteBtn, body.atelier-active #emoteBar,
@@ -436,15 +449,37 @@
   body.atelier-active #prompt { bottom: calc(26px + env(safe-area-inset-bottom,0px)); max-width: min(660px,calc(100vw - 120px));
     white-space: normal; text-align: center; justify-content: center; line-height: 1.38; }
   body.atelier-active #actBtn { background: #eef5f4; color: #29484e; }
+  body.atelier-chat-open #prompt, body.atelier-chat-open #actBtn, body.atelier-chat-open #atelierPortalActions { display:none !important; }
+  #chat.atelierChat { z-index:82; right:18px; bottom:18px; width:min(390px,calc(100vw - 36px));
+    border:1px solid rgba(132,199,205,.45); background:rgba(11,22,27,.97); box-shadow:0 18px 56px rgba(0,0,0,.52); }
+  #chat.atelierChat .chatHead { background:linear-gradient(135deg,#172c32,#203b42); border-color:rgba(130,190,196,.24); }
+  #chat.atelierChat .chatHead .ttl { color:#e8f4f3; }
+  #chat.atelierChat .chatHead select { color:#d8e9e7; border-color:#46656a; background:#182b30; }
+  #chat.atelierChat .chatHead .x { color:#b5d2d4; }
+  #chat.atelierChat #chatLog { height:min(38vh,330px); background:linear-gradient(180deg,rgba(17,32,37,.98),rgba(12,24,29,.98)); }
+  #chat.atelierChat .msg.bot { color:#dbe9e8; background:#233a3f; }
+  #chat.atelierChat .msg.me { color:#102629; background:#8bd2ca; }
+  #chat.atelierChat .msg.bot b { color:#f1cb7f; }
+  #chat.atelierChat .msg.bot span[style*="#ab8a66"] { color:#dbcba8 !important; }
+  #chat.atelierChat .msg .alt { color:#244d7b; background:#edf4ff; }
+  #chat.atelierChat .chatIn { border-color:#2f4b50; background:#13262b; }
+  #chat.atelierChat .chatIn input { color:#eaf4f3; border-color:#3d5c61; background:#0f2024; }
+  #chat.atelierChat .chatIn input:focus { border-color:#86cbd0; }
+  #chat.atelierChat .chatIn button { color:#102629; background:#8bd2ca; }
   @media (max-width: 520px) {
     #atelierIdentity { top: calc(10px + env(safe-area-inset-top,0px)); width: calc(100vw - 132px); padding: 7px 10px 8px; }
     #atelierIdentity .repo { font-size: 13px; }
     #atelierExit { top: calc(10px + env(safe-area-inset-top,0px)); left: calc(10px + env(safe-area-inset-left,0px)); }
+    #atelierPortalActions { top:calc(90px + env(safe-area-inset-top,0px)); left:10px; right:10px; width:auto; justify-content:stretch; }
+    #atelierPortalActions button, #atelierPortalActions a { flex:1 1 105px; min-height:44px; padding:7px 8px; font-size:10.5px; }
+    #atelierPortalStatus { text-align:center; }
     body.atelier-active #prompt { left: 12px; right: 94px; bottom: calc(18px + env(safe-area-inset-bottom,0px));
       max-width: none; transform: translateY(20px); font-size: 12.5px; padding: 10px 12px; }
     body.atelier-active #prompt.show { transform: translateY(0); }
     body.atelier-active #actBtn { right: calc(14px + env(safe-area-inset-right,0px));
       bottom: calc(16px + env(safe-area-inset-bottom,0px)); width: 64px; height: 64px; }
+    #chat.atelierChat { right:10px; bottom:calc(10px + env(safe-area-inset-bottom,0px)); width:calc(100vw - 20px); max-height:calc(100dvh - 82px); }
+    #chat.atelierChat #chatLog { height:min(46vh,330px); }
   }
   /* Guided tour — caption rail + skip */
   #tourCap{ position:fixed; left:0; right:0; margin-inline:auto; bottom:calc(22px + env(safe-area-inset-bottom,0px)); z-index:65;
@@ -791,7 +826,7 @@
     border: 1px solid rgba(255,255,255,.4); border-radius: 999px; padding: 3px; }
   #intro .langsel button { border: none; background: transparent; color: #fff; font-weight: 800;
     font-size: 13px; padding: 7px 18px; border-radius: 999px; cursor: pointer; opacity: .72; transition: .15s; }
-  #intro .langsel button.active { background: #fff; color: #c2702f; opacity: 1; box-shadow: 0 3px 10px rgba(60,30,10,.2); }
+  #intro .langsel button.active { background: #fff; color: #7a3f12; opacity: 1; box-shadow: 0 3px 10px rgba(60,30,10,.2); }
   #intro h1 { font-size: 27px; line-height: 1.3; margin-bottom: 8px; text-shadow: 0 2px 8px rgba(60,30,10,.25); }
   #intro .sub { font-size: 15px; opacity: .95; margin-bottom: 22px; line-height: 1.5; }
   #intro .priv { margin-top: 16px; font-size: 11.5px; line-height: 1.5; color: rgba(255,255,255,.74); max-width: 400px; }
@@ -818,6 +853,7 @@
   .introProofTop { min-width: 0; overflow: hidden; color: rgba(255,255,255,.84); font-size: 11px;
     line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
   .introProofActions { display: flex; justify-content: center; gap: 7px; flex-wrap: wrap; }
+  .introProofActions[hidden] { display: none; }
   .introProofActions button { flex: 1 1 150px; min-height: 44px; border-radius: 10px; padding: 7px 10px;
     color: #fff; font: inherit; font-size: 11.5px; line-height: 1.25; font-weight: 800; cursor: pointer; }
   #introPinProfile { border: 1px solid rgba(255,255,255,.7); background: #24292f; }
@@ -831,7 +867,7 @@
   #introProfileStatus[data-tone="error"] { color: #fff2ce; }
   #introLaunchErr { min-height: 0; margin-top: 6px; color: #fff2ce; font-size: 11px; font-weight: 700; }
   #introLaunchErr:empty { display: none; }
-  #startBtn { background: #fff; color: #c2702f; border: none; border-radius: 14px; padding: 14px 40px;
+  #startBtn { background: #fff; color: #7a3f12; border: none; border-radius: 14px; padding: 14px 40px;
     font-size: 16px; font-weight: 800; cursor: pointer; box-shadow: 0 8px 24px rgba(60,30,10,.25); }
   #intro.hidden { opacity: 0; pointer-events: none; transition: opacity .4s; }
 
@@ -1159,7 +1195,7 @@
     <div class="sdist-h" data-i18n="stationExternalH">🌍 다른 GitHub 마을</div>
     <div class="ssub" data-i18n="stationSub">GitHub username을 입력하면 그 사람의 공개 레포 마을로 기차가 데려다줘요.</div>
     <div class="srow">
-      <input id="stationInput" type="text" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="39" placeholder="GitHub username 입력" data-i18n-ph="stationUserPh" />
+      <input id="stationInput" type="text" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="320" placeholder="username · owner/repo · GitHub URL" data-i18n-ph="stationUserPh" data-i18n-aria="repoTargetAria" aria-label="GitHub username or repository" />
       <button id="stationGo" data-i18n="stationGo">🚆 기차 타고 이동</button>
     </div>
     <div class="sex" data-i18n="stationExamples">예: mrdoob, torvalds, karpathy, vercel</div>
@@ -1263,6 +1299,13 @@
   <div id="atelierIdentity">
     <span class="k" data-i18n="atelierTitle">REPOSITORY ATELIER</span>
     <span class="repo" id="atelierRepoName"></span>
+    <span class="sub" data-i18n="atelierRoomHint">데이터 전시 · 실내 깃버 · 구역 해설</span>
+  </div>
+  <div id="atelierPortalActions" hidden role="group" data-i18n-aria="portalActionsAria" aria-label="Repository Portal actions">
+    <button id="atelierPortalCopy" type="button" data-i18n="portalCopy">🔗 Repo Portal 복사</button>
+    <a id="atelierPortalGithub" target="_blank" rel="noopener" data-i18n="atelierGithub">GitHub 열기</a>
+    <button id="atelierPortalExplore" type="button"></button>
+    <span id="atelierPortalStatus" role="status" aria-live="polite" aria-atomic="true"></span>
   </div>
 </div>
 <div id="starTrailHud" class="hidden" aria-live="polite">
@@ -1433,14 +1476,14 @@
     <div id="introLaunch">
       <div class="launchLabel" data-i18n="introLaunchLabel">내 공개 레포로 바로 보기</div>
       <form id="introLaunchForm">
-        <span class="at" aria-hidden="true">@</span>
-        <input id="introUser" data-i18n-ph="introUserPh" placeholder="GitHub username" autocomplete="username" spellcheck="false" />
+        <span class="at" aria-hidden="true">⌕</span>
+        <input id="introUser" data-i18n-ph="introUserPh" data-i18n-aria="repoTargetAria" aria-label="GitHub username or repository" placeholder="username · owner/repo · GitHub URL" autocomplete="off" autocapitalize="off" autocorrect="off" maxlength="320" spellcheck="false" />
         <button id="introLaunchGo" type="submit" data-i18n="introLaunchGo">내 마을 만들기 →</button>
       </form>
       <div id="introPublicProof" hidden role="status" aria-live="polite">
         <div class="introProofStats" id="introProofStats"></div>
         <div class="introProofTop" id="introProofTop"></div>
-        <div class="introProofActions">
+        <div class="introProofActions" id="introProofActions">
           <button id="introPinProfile" type="button" data-i18n="introPinProfile">GitHub 프로필에 마을 붙이기</button>
           <button id="introGrowth" type="button" data-i18n="introGrowth">⏳ 내 도시가 자라는 장면 보기</button>
           <button id="introCompare" type="button" data-i18n="introCompare">↔ 친구 마을과 연결하기</button>
@@ -1529,28 +1572,36 @@ import { summarizePublicTown } from './assets/public-town-proof.js?v=personal-re
 import { createTwinTownLink, createTwinTownMatch } from './assets/twin-towns.js?v=twin-towns-v1';
 import { selectTownCreatorFields, summarizeTownCreator } from './assets/town-creator.js?v=creator-hall-v1';
 import { buildTownGrowthTimeline, createTownGrowthShareUrl, townGrowthIndexForYear, townGrowthSnapshot } from './assets/town-growth.js?v=town-growth-v1';
+import { REPO_PORTAL_LIMITS, GITHUB_LOGIN_RE, createRepoOwnerTownUrl, createRepoPortalUrl, parseRepoPortalInput, projectPublicRepo, projectPublicRepos, repoPortalLatencyBucket, resolveRepoPortalRequest } from './assets/repo-portal.js?v=repo-portal-v1';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
    Public mode (?user=someone) builds a town from any GitHub user's PUBLIC
-   repo metadata (derived metrics only — never claims real traffic).
+   repo metadata. Portal mode (?repo=owner/repo) loads exactly that public
+   repo before any owner catalog and opens its Repository Atelier.
    The owner city stays the premium / full-data experience. ================ */
 const OWNER = window.REPOLIS_CONFIG?.town?.owner || 'hyeonsangjeon';
 document.title = `Repolis · ${OWNER}'s City of Repos`;
 let REPOS = [];
 
 /* --- which town are we in? --- */
-const GH_LOGIN_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/;
-const _reqUser = (new URLSearchParams(location.search).get('user') || '').trim();
-const _reqTwin = (new URLSearchParams(location.search).get('twin') || '').trim();
-const _reqGrowth = (new URLSearchParams(location.search).get('growth') || '').trim();
-let currentUser = OWNER;
-let cityMode = 'owner';            // 'owner' | 'public'
-let dataSource = 'owner-ci';       // 'owner-ci' | 'github-public' | 'cache' | 'stale-cache'
+const GH_LOGIN_RE = GITHUB_LOGIN_RE;
+const _QUERY = new URLSearchParams(location.search);
+const _repoRoute = resolveRepoPortalRequest(location.search, OWNER);
+const _reqUser = (_QUERY.get('user') || '').trim().replace(/^@+/,'');
+const _reqTwin = (_QUERY.get('twin') || '').trim();
+const _reqGrowth = (_QUERY.get('growth') || '').trim();
+const _reqFocus = _repoRoute.focus;
+const repoPortalRequested = _repoRoute.mode === 'portal';
+const repoPortalStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
+let repoPortalTarget = _repoRoute.target;
+let repoPortalResult = null;
+let repoPortalFallback = false;
+let currentUser = repoPortalTarget?.owner || (_repoRoute.mode === 'public' ? _reqUser : OWNER);
+let cityMode = _repoRoute.mode;     // 'owner' | 'public' | 'portal'
+let dataSource = cityMode === 'portal' ? 'repo-api' : (cityMode === 'public' ? 'github-public' : 'owner-ci');
 let cityError = null;              // { status, reason } when a public town can't load
-if(_reqUser && GH_LOGIN_RE.test(_reqUser) && _reqUser.toLowerCase() !== OWNER.toLowerCase()){
-  currentUser = _reqUser; cityMode = 'public'; dataSource = 'github-public';
-}
+if(repoPortalTarget) document.title=`${repoPortalTarget.slug} · Repolis Repo Portal`;
 
 /* --- lightweight, non-blocking analytics. Default sink = in-memory (+ console under ?dbg).
    No network unless ANALYTICS_ENDPOINT is set. No tokens, no raw taxi queries. --- */
@@ -1560,7 +1611,6 @@ const ANALYTICS_ENDPOINT = (function(){
   catch(e){ return null; }
 })();
 if(ANALYTICS_ENDPOINT){ try{ const _pn = document.getElementById('privacyNote'); if(_pn) _pn.classList.remove('hidden'); }catch(e){} }
-const _QUERY = new URLSearchParams(location.search);
 const _DBG = _QUERY.has('dbg');
 const _DIAGNOSTICS = _DBG || _QUERY.get('perf')==='1';
 const SESSION_ID = (()=>{ try{ return (crypto.randomUUID && crypto.randomUUID()) || (Date.now()+'-'+Math.random().toString(36).slice(2)); }
@@ -1578,6 +1628,13 @@ function track(eventName, payload){
     const ev = Object.assign({ ev:eventName, cityUser:currentUser, cityMode,
       repoCount:(REPOS && REPOS.length) || 0, source:dataSource, sessionId:SESSION_ID, instanceId:INSTANCE_ID,
       instanceOrigin:instanceOrigin(), ts:_now.getTime(), h:_now.getHours(), wd:_now.getDay() }, payload||{});
+    if(repoPortalRequested){
+      ['cityUser','targetUser','user','repo','owner','url','query','input','instanceId'].forEach(key=>{ delete ev[key]; });
+    }
+    if(ev.__privacy==='repo-portal'){
+      const allowed=new Set(['ev','sessionId','ts','entry','device','lang','result','latency','channel']);
+      Object.keys(ev).forEach(key=>{ if(!allowed.has(key)) delete ev[key]; });
+    }
     recentAnalyticsEvents.push(ev); if(recentAnalyticsEvents.length > 150) recentAnalyticsEvents.shift();
     if(_DBG) console.debug('[track]', eventName, ev);
     if(ANALYTICS_ENDPOINT){ try{
@@ -1589,38 +1646,18 @@ function track(eventName, payload){
     }catch(e){} }
   }catch(e){ /* analytics must never break the app */ }
 }
+function trackPortal(eventName,payload){
+  const safe={__privacy:'repo-portal'},allowed=['entry','device','lang','result','latency','channel'];
+  for(const key of allowed){ const value=payload&&payload[key]; if(typeof value==='string'&&value.length<=32) safe[key]=value; }
+  track(eventName,safe);
+}
+function _repoPortalDevice(){ return matchMedia('(pointer:coarse)').matches||innerWidth<700?'mobile':'desktop'; }
+function _repoPortalLang(){ try{ const value=localStorage.getItem('repolisLang'); if(value==='ko'||value==='en') return value; }catch(e){}
+  return (navigator.language||'').toLowerCase().startsWith('ko')?'ko':'en'; }
 
-/* --- public town: normalize GitHub REST repo objects into Repolis' internal repo shape.
-   Metrics are DERIVED from public signals (stars/forks/recency) — clearly not real traffic. --- */
+/* --- public town: normalize allowlisted GitHub REST fields without manufacturing traffic. --- */
 function _normPublicRepos(raw, user){
-  const now = Date.now();
-  const list = (Array.isArray(raw) ? raw : []).filter(r => r && !r.private && !r.disabled).map(r=>{
-    const stars = r.stargazers_count||0, forks = r.forks_count||0;
-    const pushedAt = r.pushed_at || r.updated_at || r.created_at || null;
-    const ageDays = pushedAt ? Math.max(0,(now - new Date(pushedAt).getTime())/86400000) : 3650;
-    const recency = Math.max(0, 1 - Math.min(ageDays,365)/365);
-    const visitors = Math.round(Math.log1p(stars+1)*12 + recency*24);   // derived "liveliness" → building height
-    const views    = Math.round(stars*8 + forks*12 + recency*40);       // derived → yard size
-    const clones   = Math.round(forks*1.5);                             // derived → fanciness (never a real clone count)
-    const lic = (r.license && r.license.spdx_id && r.license.spdx_id!=='NOASSERTION') ? r.license.spdx_id : '';
-    return {
-      repo:r.name, desc:r.description||'', lang:r.language||'Other',
-      topics: Array.isArray(r.topics) ? r.topics.slice(0,24) : [],
-      url: r.html_url || ('https://github.com/'+user+'/'+r.name), home: r.homepage||'',
-      stars, forks, fork:!!r.fork, views, visitors, clones,
-      size:r.size||0, open_issues:r.open_issues_count||0, license:lic,
-      archived:!!r.archived, default_branch:r.default_branch||'main',
-      release_tag:'', release_date:null,
-      created:r.created_at||'', pushed:pushedAt||'', updated:r.updated_at||'',
-      first_seen:'', social:'', social_custom:'',
-      _owner:user, public_mode:true, _recency:recency
-    };
-  });
-  // client-side score + rank so the existing rank-driven layout / "popular" queries work
-  list.forEach(r=>{ r.score = Math.log1p(r.stars)*3 + Math.log1p(r.forks)*1.6 + r._recency*2.4 + Math.log1p(r.open_issues)*0.3; });
-  list.sort((a,b)=> (b.score-a.score) || (b.stars-a.stars) || a.repo.localeCompare(b.repo));
-  list.forEach((r,i)=> r.rank=i);
-  return list;
+  return projectPublicRepos(raw,user,Date.now());
 }
 function _publicCacheKey(u){ return 'repolis:public-user:'+u.toLowerCase()+':v1'; }
 async function _loadPublicCity(user){
@@ -1646,20 +1683,103 @@ async function _loadPublicCity(user){
   }
 }
 
+let _ownerSnapshotPromise=null;
+function _ownerSnapshot(){
+  if(_ownerSnapshotPromise) return _ownerSnapshotPromise;
+  _ownerSnapshotPromise=fetch('repos.json',{cache:'no-cache'}).then(async res=>{
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    const data=await res.json(); if(!Array.isArray(data)) throw new Error('repos.json is not an array');
+    return data;
+  });
+  return _ownerSnapshotPromise;
+}
+function _ownerRepos(data){
+  return (Array.isArray(data)?data:[]).map(repo=>Object.assign({},repo,{_owner:OWNER,trafficKnown:true,trafficSource:'owner-snapshot'}));
+}
+const REPO_PORTAL_CACHE_KEY='repolis:repo-portal-cache:v'+REPO_PORTAL_LIMITS.cacheVersion;
+function _repoPortalCacheRead(){
+  try{
+    const cache=JSON.parse(localStorage.getItem(REPO_PORTAL_CACHE_KEY)||'null');
+    if(!cache||cache.v!==REPO_PORTAL_LIMITS.cacheVersion||!cache.entries||!Array.isArray(cache.order)) throw new Error('invalid');
+    return cache;
+  }catch(e){ return {v:REPO_PORTAL_LIMITS.cacheVersion,order:[],entries:{}}; }
+}
+function _repoPortalRaw(repo,target){
+  return {name:repo.repo,full_name:target.slug,owner:{login:target.owner},private:false,disabled:false,description:repo.desc,
+    language:repo.lang==='Other'?null:repo.lang,topics:(repo.topics||[]).slice(0,24),homepage:repo.home,
+    stargazers_count:repo.stars,forks_count:repo.forks,fork:repo.fork,size:repo.size,open_issues_count:repo.open_issues,
+    license:repo.license?{spdx_id:repo.license}:null,archived:repo.archived,default_branch:repo.default_branch,
+    created_at:repo.created,pushed_at:repo.pushed,updated_at:repo.updated};
+}
+function _repoPortalCacheLookup(target){
+  const cache=_repoPortalCacheRead(),key=target.slug.toLowerCase(),entry=cache.entries[key];
+  if(!entry||!entry.raw) return {fresh:null,stale:null};
+  const repo=projectPublicRepo(entry.raw,target.owner,Date.now()); if(!repo||repo.repo.toLowerCase()!==target.repo.toLowerCase()) return {fresh:null,stale:null};
+  cache.order=[key,...cache.order.filter(item=>item!==key)]; try{ localStorage.setItem(REPO_PORTAL_CACHE_KEY,JSON.stringify(cache)); }catch(e){}
+  const age=Date.now()-Number(entry.fetchedAt||0); return age<REPO_PORTAL_LIMITS.cacheTtlMs?{fresh:repo,stale:null}:{fresh:null,stale:repo};
+}
+function _repoPortalCacheStore(target,repo){
+  const cache=_repoPortalCacheRead(),key=target.slug.toLowerCase();
+  cache.entries[key]={fetchedAt:Date.now(),raw:_repoPortalRaw(repo,target)};
+  cache.order=[key,...cache.order.filter(item=>item!==key)].slice(0,REPO_PORTAL_LIMITS.cacheMaxEntries);
+  Object.keys(cache.entries).forEach(item=>{ if(!cache.order.includes(item)) delete cache.entries[item]; });
+  let text=JSON.stringify(cache),bytes=typeof TextEncoder!=='undefined'?new TextEncoder().encode(text).length:text.length*2;
+  while(bytes>REPO_PORTAL_LIMITS.cacheMaxBytes&&cache.order.length>1){ const removed=cache.order.pop(); delete cache.entries[removed];
+    text=JSON.stringify(cache); bytes=typeof TextEncoder!=='undefined'?new TextEncoder().encode(text).length:text.length*2; }
+  if(bytes<=REPO_PORTAL_LIMITS.cacheMaxBytes){ try{ localStorage.setItem(REPO_PORTAL_CACHE_KEY,text); }catch(e){} }
+}
+async function _loadRepoPortalTarget(target){
+  if(target.owner.toLowerCase()===OWNER.toLowerCase()){
+    try{ const exact=_ownerRepos(await _ownerSnapshot()).find(repo=>repo.repo.toLowerCase()===target.repo.toLowerCase());
+      if(exact) return {repo:exact,source:'owner-snapshot',result:'local'}; }catch(e){}
+  }
+  const cached=_repoPortalCacheLookup(target); if(cached.fresh) return {repo:cached.fresh,source:'repo-cache',result:'cache'};
+  try{
+    const res=await fetch('https://api.github.com/repos/'+encodeURIComponent(target.owner)+'/'+encodeURIComponent(target.repo),
+      {headers:{Accept:'application/vnd.github+json'}});
+    if(!res.ok){
+      if(cached.stale) return {repo:cached.stale,source:'repo-stale-cache',result:'stale'};
+      return {repo:null,source:'repo-api',result:'error',error:{status:res.status,reason:res.status===404?'not_found':(res.status===403||res.status===429?'rate_limit':'http')}};
+    }
+    const repo=projectPublicRepo(await res.json(),target.owner,Date.now());
+    if(!repo||repo.repo.toLowerCase()!==target.repo.toLowerCase()) return {repo:null,source:'repo-api',result:'error',error:{status:404,reason:'not_found'}};
+    _repoPortalCacheStore(target,repo); return {repo,source:'repo-api',result:'api'};
+  }catch(e){
+    if(cached.stale) return {repo:cached.stale,source:'repo-stale-cache',result:'stale'};
+    return {repo:null,source:'repo-api',result:'error',error:{status:0,reason:'network'}};
+  }
+}
+
 track('page_load');
+trackPortal('feature_seen',{entry:repoPortalRequested?'link':'intro',device:_repoPortalDevice(),lang:_repoPortalLang()});
 
 if(cityMode === 'owner'){
-  try { const res=await fetch('repos.json', { cache:'no-cache' }); if(!res.ok) throw new Error('HTTP '+res.status);
-    const data=await res.json(); if(!Array.isArray(data)) throw new Error('repos.json is not an array'); REPOS=data; }
+  try { REPOS=_ownerRepos(await _ownerSnapshot()); }
   catch(e){ cityError={status:0,reason:'data_load'}; console.error('repos.json load failed', e); }
   track(REPOS.length ? 'city_data_load_success' : 'city_data_load_fail', { repoCount:REPOS.length });
-} else {
+} else if(cityMode === 'public') {
   try{ const _l = (function(){ let l=localStorage.getItem('repolisLang'); if(l!=='ko'&&l!=='en') l=(navigator.language||'').toLowerCase().startsWith('ko')?'ko':'en'; return l; })();
     const le=document.getElementById('loading'); if(le) le.textContent = _l==='ko' ? (currentUser+' 님의 레포를 불러오는 중…') : ('Fetching '+currentUser+"'s repos…"); }catch(e){}
   const pub = await _loadPublicCity(currentUser);
   REPOS = pub.repos || []; dataSource = pub.source || 'github-public'; cityError = pub.error || null;
+  if(_reqFocus&&!REPOS.some(repo=>repo.repo.toLowerCase()===_reqFocus.repo.toLowerCase())){
+    const focused=await _loadRepoPortalTarget(_reqFocus);
+    if(focused.repo){ REPOS.push(focused.repo); REPOS.sort((a,b)=>(b.score-a.score)||(b.stars-a.stars)||a.repo.localeCompare(b.repo)); REPOS.forEach((repo,index)=>{ repo.rank=index; }); }
+  }
   track(cityError ? 'city_data_load_fail' : 'city_data_load_success',
     { targetUser:currentUser, repoCount:REPOS.length, reason: cityError ? cityError.reason : undefined });
+} else {
+  try{ const le=document.getElementById('loading'); if(le) le.textContent=_repoPortalLang()==='ko'?'레포 포털을 여는 중…':'Opening the repo portal…'; }catch(e){}
+  if(!repoPortalTarget) repoPortalResult={repo:null,source:'repo-api',result:'error',error:{status:0,reason:'invalid_repo'}};
+  else repoPortalResult=await _loadRepoPortalTarget(repoPortalTarget);
+  if(repoPortalResult.repo){ REPOS=[repoPortalResult.repo]; dataSource=repoPortalResult.source; currentUser=repoPortalTarget.owner; }
+  else {
+    cityError=repoPortalResult.error||{status:0,reason:'network'}; repoPortalFallback=true;
+    try{ REPOS=_ownerRepos(await _ownerSnapshot()); cityMode='owner'; currentUser=OWNER; dataSource='portal-fallback'; }
+    catch(e){ REPOS=[]; dataSource='portal-fallback'; }
+  }
+  trackPortal('feature_started',{entry:'link',device:_repoPortalDevice(),lang:_repoPortalLang(),result:repoPortalResult.result,
+    latency:repoPortalLatencyBucket((typeof performance!=='undefined'?performance.now():Date.now())-repoPortalStartedAt)});
 }
 const TOWN_GROWTH=buildTownGrowthTimeline(REPOS);
 
@@ -1790,10 +1910,15 @@ const I18N = {
     cityOfRepos:'레포들의 도시',
     introSub:'핀 6개 제한은 잊으세요.<br>내 모든 레포가 사는 도시를 걸으며,<br>깃버에게 물어보면 그 레포까지 데려다줘요.',
     introSubPublic:'{user} 님의 공개 레포로 지은 도시예요.<br>함께 걸으며 둘러보고,<br>🚉 역에서 또 다른 마을로 떠날 수 있어요.',
-    introLaunchLabel:'내 공개 레포로 바로 보기', introUserPh:'GitHub username', introLaunchGo:'내 마을 만들기 →',
-    introLaunchHint:'공개 레포만 사용 · 로그인 없음 · 포크 없음', introLaunchInvalid:'올바른 GitHub username을 입력해 주세요.',
+    introSubPortal:'공개 레포 하나를 먼저 불러왔어요.<br>3D 전시실에서 이 레포를 확인한 뒤,<br>원할 때 소유자의 마을 전체로 넓혀 보세요.',
+    introLaunchLabel:'GitHub 사용자나 레포를 도시로 열기', introUserPh:'username · owner/repo · GitHub URL', introLaunchGo:'Repolis에서 열기 →',
+    introLaunchHint:'공개 레포만 사용 · 로그인 없음 · 레포 링크는 대상 한 건만 먼저 불러옴', introLaunchInvalid:'GitHub username, owner/repo 또는 GitHub 레포 URL을 입력해 주세요.',
+    repoTargetAria:'GitHub username 또는 저장소',
     introReady:'@{user}의 마을이 준비됐어요', introProofStats:'공개 레포 {count}개 · ★ {stars} · 사용 언어 {languages}개',
     introProofTop:'대표 집 · {repos}', introPinProfile:'GitHub 프로필에 마을 붙이기', introGrowth:'⏳ 내 도시가 자라는 장면 보기', introCompare:'↔ 친구 마을과 연결하기', introTryAnother:'↻ 다른 GitHub 계정 보기', enterTownPublic:'이 마을 입장 →',
+    introPortalReady:'{repo} 포털이 준비됐어요', introPortalStats:'★ {stars} · ⑂ {forks} · {language}', enterRepoPortal:'이 레포 3D 전시실로 →',
+    portalSourceLocal:'주인 도시의 검증된 트래픽 스냅샷', portalSourceApi:'GitHub 공개 메타데이터 · 방금 불러옴',
+    portalSourceCache:'GitHub 공개 메타데이터 · 15분 로컬 캐시', portalSourceStale:'GitHub 공개 메타데이터 · 오래된 캐시로 복구',
     introProfileCopied:'프로필 README 코드를 복사했어요. 붙여 넣으면 이 마을로 바로 연결돼요.',
     introProfileCopyFailed:'복사하지 못했어요. 브라우저의 클립보드 권한을 확인해 주세요.',
     starNudge:'이 마을이 마음에 드셨나요? Repolis는 오픈소스예요.', starNudgeGo:'⭐ GitHub에서 Star',
@@ -1801,23 +1926,28 @@ const I18N = {
     ctrlWalk:'걷기', ctrlLookL:'시점 회전(자유 시점)', ctrlAimR:'캐릭터 조준 · WoW식 · 휠 줌', ctrlOpen:'레포 열기',
     enterTown:'마을 입장 →',
     // --- GitHub Station · 다른 마을로 기차 여행 ---
-    modeOwnerLabel:'풀 트래픽 시티', modePublicLabel:'공개 GitHub 마을',
-    townOf:'{user} 님의 마을', myCity:'내 도시',
+    modeOwnerLabel:'풀 트래픽 시티', modePublicLabel:'공개 GitHub 마을', modePortalLabel:'레포 포털',
+    townOf:'{user} 님의 마을', repoPortalOf:'{repo} 포털', myCity:'내 도시',
     stationBtn:'🚉 역', stationLm:'GitHub 역',
-    stationTitle:'Repolis 역 · 어디로 갈까요?', stationSub:'GitHub username을 입력하면 그 사람의 공개 레포 마을로 기차가 데려다줘요.',
-    stationDistrictsH:'🚉 명소로 바로 이동', stationExternalH:'🌍 다른 GitHub 마을',
-    stationCurrent:'현재 마을', stationUserPh:'GitHub username 입력', stationGo:'🚆 기차 타고 이동',
-    stationExamples:'예: mrdoob, torvalds, karpathy, vercel', stationHome:'← {user} 님의 도시로',
-    stationInvalid:'올바른 GitHub username을 입력해 주세요.',
+    stationTitle:'Repolis 역 · 어디로 갈까요?', stationSub:'username은 공개 레포 마을로, owner/repo나 GitHub URL은 그 레포 전시실로 곧장 연결해요.',
+    stationDistrictsH:'🚉 명소로 바로 이동', stationExternalH:'🌍 GitHub 사용자 또는 레포',
+    stationCurrent:'현재 마을', stationUserPh:'username · owner/repo · GitHub URL', stationGo:'🚆 이동',
+    stationExamples:'예: mrdoob · mrdoob/three.js · github.com/vercel/next.js', stationHome:'← {user} 님의 도시로',
+    stationInvalid:'GitHub username, owner/repo 또는 GitHub 레포 URL을 입력해 주세요.',
     stationReached:' — 다른 GitHub 사용자의 레포 마을로 떠나는 기차역. <span class="key">Enter</span> 또는 클릭으로 매표소 열기',
     trainDepart:'🚆 {user} 님의 마을로 출발…', fetchingRepos:'{user} 님의 레포를 불러오는 중…',
+    trainDepartRepo:'🏛️ {repo} 포털로 이동…', fetchingRepo:'이 레포의 공개 메타데이터 한 건을 불러오는 중…',
     arrived:'🚉 {user} 님의 GitHub 마을에 도착했어요!',
     publicBadge:'공개 메타데이터 기반', publicMetricNote:'🏙️ 공개 레포 메타데이터로 지은 마을이에요 — 건물 크기는 ★ stars · ⑂ forks · 최근 업데이트로 정해져요. (실제 트래픽 수치가 아니에요)',
+    publicTrafficUnavailable:'이 마을에는 방문자·조회·클론 트래픽이 공개되지 않아요. stars, forks, 최근 업데이트로 둘러볼 수 있어요.',
     publicEmptyTitle:'🚉 텅 빈 마을', publicEmptyMsg:'{user} 님은 마을을 지을 공개 레포가 없어요.',
     publicNotFound:'🚉 길을 잃었어요', publicNotFoundMsg:'GitHub에서 {user} 님을 찾지 못했어요. username을 확인해 주세요.',
     publicRateMsg:'GitHub API 요청 한도에 걸렸어요. 잠시 후 다시 시도해 주세요.',
     publicNetMsg:'마을을 불러오지 못했어요. 연결을 확인하고 다시 시도해 주세요.',
-    stationRetry:'🚉 다른 마을 가기', goOwnerCity:'🏙️ {user} 님의 도시 가기',
+    portalInvalidTitle:'🏛️ 레포 주소를 확인해 주세요', portalInvalidMsg:'GitHub의 owner/repo 또는 저장소 루트 URL만 열 수 있어요.',
+    portalNotFoundMsg:'이 공개 GitHub 레포를 찾지 못했어요. 이름이나 공개 상태를 확인해 주세요.',
+    portalRateMsg:'GitHub API 요청 한도에 걸려 이 레포를 지금 불러오지 못했어요.', portalNetMsg:'이 레포를 불러오지 못했어요. 주인 도시에는 계속 들어갈 수 있어요.',
+    portalContinue:'🏙️ 주인 도시에서 계속하기', stationRetry:'🚉 다른 마을 가기', goOwnerCity:'🏙️ {user} 님의 도시 가기',
     shareTown:'이 마을 공유', copyLink:'🔗 링크 복사', copied:'복사됨!',
     creatorMenu:'마을 만든 사람', creatorMenuSub:'공개 GitHub 프로필과 대표 작업',
     creatorKicker:'TOWN CREATOR', creatorHallSign:'CREATOR HALL · 창작자 회관',
@@ -1881,10 +2011,14 @@ const I18N = {
     openGithub:'GitHub 열기 ↗', liveDemo:'라이브 데모 ↗', close:'닫기', socialPreview:'소셜 프리뷰',
     cardAskTitle:'🚕 이 레포, 더 알아보기', cardAskRepo:'이 레포 질문하기', cardAskWhy:'왜 이 구역에 있나요?', cardSimilar:'비슷한 레포 보기', cardSuggestHint:'추천 질문',
     atelierTitle:'REPOSITORY ATELIER', atelierEnter:'🏛️ 3D 전시실 입장', atelierInside:'전시실 관람 중',
-    atelierExit:'마을로 나가기', atelierCore:'REPOSITORY CORE', atelierHistory:'HISTORY / DATA WALL', atelierActions:'ACTION TERMINALS',
+    atelierExit:'마을로 나가기', atelierCore:'REPOSITORY CORE', atelierHistory:'HISTORY / DATA WALL', atelierSignals:'IMPACT / SIGNALS WALL', atelierActions:'ACTION TERMINALS',
     atelierGithub:'GitHub 열기', atelierAsk:'깃버에게 이 레포 질문', atelierWhy:'왜 이 구역인가',
+    atelierRoomHint:'데이터 전시 · 실내 깃버 · 구역 해설', atelierChatTitle:'전시실 깃버', atelierChatPh:'이 전시 레포에 이어서 질문…', atelierSignalsNow:'현재 공개 메타데이터 기준',
     atelierDoor:'출구 · 마을로 돌아가기', atelierWalk:'WASD / 터치로 전시실을 걸어 보세요',
     atelierUse:'Enter / 버튼으로 {action}', atelierCoreHint:'★ 크기 · 활동 빛 · score 구조',
+    portalActionsAria:'Repo Portal 작업', portalCopy:'🔗 Repo Portal 복사', portalCopied:'Repo Portal 주소를 복사했어요.',
+    portalCopyFailed:'주소를 복사하지 못했어요. 브라우저의 클립보드 권한을 확인해 주세요.', portalExplore:'@{user}의 마을 전체 보기',
+    atelierTrafficUnavailable:'트래픽 비공개 · 공개 stars, forks, 최근 업데이트로 건축',
     rideThere:'🚕 그 집까지 데려다줄게요', soLead:'그럼 ',
     greeterHtml:'어서오세요! 🚕 <b>Repolis 깃버</b>예요.<br>어떤 걸 찾으세요? 예: <b>제일 인기있는 레포</b>, <b>AI 에이전트</b>, <b>STT</b>, <b>아무거나</b>',
     greetReply:'안녕하세요! 🚕 어떤 레포를 찾으세요? 예: <b>제일 인기있는 레포</b>, <b>AI 에이전트</b>, <b>STT</b>',
@@ -2038,10 +2172,15 @@ const I18N = {
     cityOfRepos:'the city of repos',
     introSub:"Forget the 6-pin limit.<br>Stroll a living city where all my repos live —<br>ask Gitber and it'll drive you right to any repo.",
     introSubPublic:"A city built from {user}'s public repos.<br>Stroll around and explore —<br>or hop the train at 🚉 Station to visit another town.",
-    introLaunchLabel:'See the same engine with your public repos', introUserPh:'GitHub username', introLaunchGo:'Build my town →',
-    introLaunchHint:'Public repos only · no login · no fork', introLaunchInvalid:'Enter a valid GitHub username.',
+    introSubPortal:"One public repo loaded first.<br>Enter its 3D exhibition,<br>then expand into the owner's town when you choose.",
+    introLaunchLabel:'Open a GitHub user or repository as a town', introUserPh:'username · owner/repo · GitHub URL', introLaunchGo:'Open in Repolis →',
+    introLaunchHint:'Public repos only · no login · repo links load one target first', introLaunchInvalid:'Enter a GitHub username, owner/repo, or GitHub repository URL.',
+    repoTargetAria:'GitHub username or repository',
     introReady:"@{user}'s town is ready", introProofStats:'{count} public repos · ★ {stars} · {languages} languages',
     introProofTop:'Featured houses · {repos}', introPinProfile:'Put this town on my GitHub profile', introGrowth:'⏳ Watch my town grow', introCompare:'↔ Connect with a friend', introTryAnother:'↻ Try another GitHub account', enterTownPublic:'Enter this town →',
+    introPortalReady:'{repo} is ready', introPortalStats:'★ {stars} · ⑂ {forks} · {language}', enterRepoPortal:'Enter this repo exhibition →',
+    portalSourceLocal:"Verified traffic snapshot from the owner's town", portalSourceApi:'Public GitHub metadata · loaded now',
+    portalSourceCache:'Public GitHub metadata · 15-minute local cache', portalSourceStale:'Public GitHub metadata · recovered from an older cache',
     introProfileCopied:'Profile README code copied. Paste it to link straight to this town.',
     introProfileCopyFailed:'Could not copy the code. Check this browser\'s clipboard permission.',
     starNudge:'Enjoying the town? Repolis is open source.', starNudgeGo:'⭐ Star on GitHub',
@@ -2049,23 +2188,28 @@ const I18N = {
     ctrlWalk:'Walk', ctrlLookL:'Orbit camera (free look)', ctrlAimR:'Steer character · WoW-style · wheel = zoom', ctrlOpen:'Open repo',
     enterTown:'Enter the town →',
     // --- GitHub Station · train travel to other towns ---
-    modeOwnerLabel:'Full Traffic City', modePublicLabel:'Public GitHub Town',
-    townOf:"{user}'s town", myCity:'My city',
+    modeOwnerLabel:'Full Traffic City', modePublicLabel:'Public GitHub Town', modePortalLabel:'Repo Portal',
+    townOf:"{user}'s town", repoPortalOf:'{repo} portal', myCity:'My city',
     stationBtn:'🚉 Station', stationLm:'GitHub Station',
-    stationTitle:'Repolis Station · Where to?', stationSub:"Enter a GitHub username and the train will take you to that person's public-repo town.",
-    stationDistrictsH:'🚉 Landmark stops', stationExternalH:'🌍 Other GitHub towns',
-    stationCurrent:'Current town', stationUserPh:'Enter GitHub username', stationGo:'🚆 Take the train',
-    stationExamples:'e.g. mrdoob, torvalds, karpathy, vercel', stationHome:"← Back to {user}'s city",
-    stationInvalid:'Please enter a valid GitHub username.',
+    stationTitle:'Repolis Station · Where to?', stationSub:"A username opens that developer's public town. owner/repo or a GitHub URL goes straight to the repo exhibition.",
+    stationDistrictsH:'🚉 Landmark stops', stationExternalH:'🌍 GitHub user or repository',
+    stationCurrent:'Current town', stationUserPh:'username · owner/repo · GitHub URL', stationGo:'🚆 Go',
+    stationExamples:'e.g. mrdoob · mrdoob/three.js · github.com/vercel/next.js', stationHome:"← Back to {user}'s city",
+    stationInvalid:'Enter a GitHub username, owner/repo, or GitHub repository URL.',
     stationReached:" — board a train to another GitHub user's repo town. Press <span class=\"key\">Enter</span> or click to open the ticket office",
     trainDepart:"🚆 Departing for {user}'s town…", fetchingRepos:"Fetching {user}'s repos…",
+    trainDepartRepo:'🏛️ Opening the {repo} portal…', fetchingRepo:'Fetching one public metadata record for this repo…',
     arrived:"🚉 Arrived at {user}'s GitHub town!",
     publicBadge:'From public metadata', publicMetricNote:'🏙️ This town is built from public repo metadata — building size comes from ★ stars · ⑂ forks · recent activity. (Not real traffic numbers.)',
+    publicTrafficUnavailable:'Visitor, view, and clone traffic is not public for this town. You can still explore by stars, forks, and recent updates.',
     publicEmptyTitle:'🚉 An empty town', publicEmptyMsg:'{user} has no public repos to build a town from.',
     publicNotFound:'🚉 Lost the way', publicNotFoundMsg:"Couldn't find {user} on GitHub. Please check the username.",
     publicRateMsg:'Hit the GitHub API rate limit. Please try again in a bit.',
     publicNetMsg:"Couldn't load the town. Check your connection and try again.",
-    stationRetry:'🚉 Visit another town', goOwnerCity:"🏙️ Visit {user}'s city",
+    portalInvalidTitle:'🏛️ Check the repository address', portalInvalidMsg:'Repolis accepts owner/repo or a GitHub repository root URL.',
+    portalNotFoundMsg:"Couldn't find this public GitHub repository. Check its name and visibility.",
+    portalRateMsg:"GitHub's API limit prevented this repository from loading.", portalNetMsg:"Couldn't load this repository. You can still continue in the owner's town.",
+    portalContinue:"🏙️ Continue in the owner's town", stationRetry:'🚉 Visit another town', goOwnerCity:"🏙️ Visit {user}'s city",
     shareTown:'Share this town', copyLink:'🔗 Copy link', copied:'Copied!',
     creatorMenu:'Meet the town creator', creatorMenuSub:'Public GitHub profile and signature work',
     creatorKicker:'TOWN CREATOR', creatorHallSign:'CREATOR HALL',
@@ -2129,10 +2273,14 @@ const I18N = {
     openGithub:'Open on GitHub ↗', liveDemo:'Live demo ↗', close:'Close', socialPreview:'Social preview',
     cardAskTitle:'🚕 Explore this repo', cardAskRepo:'Ask about this repo', cardAskWhy:'Why this district?', cardSimilar:'Similar repos', cardSuggestHint:'Try asking',
     atelierTitle:'REPOSITORY ATELIER', atelierEnter:'🏛️ Enter 3D exhibition', atelierInside:'Inside the exhibition',
-    atelierExit:'Return to town', atelierCore:'REPOSITORY CORE', atelierHistory:'HISTORY / DATA WALL', atelierActions:'ACTION TERMINALS',
+    atelierExit:'Return to town', atelierCore:'REPOSITORY CORE', atelierHistory:'HISTORY / DATA WALL', atelierSignals:'IMPACT / SIGNALS WALL', atelierActions:'ACTION TERMINALS',
     atelierGithub:'Open GitHub', atelierAsk:'Ask Gitber about this repo', atelierWhy:'Why this district?',
+    atelierRoomHint:'Data exhibits · in-room Gitber · district context', atelierChatTitle:'Atelier Gitber', atelierChatPh:'Ask a follow-up about this exhibit…', atelierSignalsNow:"Using today's public metadata",
     atelierDoor:'Exit · return to town', atelierWalk:'Walk the exhibition with WASD / touch',
     atelierUse:'Enter / button to {action}', atelierCoreHint:'★ size · activity light · score structure',
+    portalActionsAria:'Repo Portal actions', portalCopy:'🔗 Copy Repo Portal', portalCopied:'Repo Portal address copied.',
+    portalCopyFailed:"Couldn't copy the address. Check this browser's clipboard permission.", portalExplore:"Explore @{user}'s full town",
+    atelierTrafficUnavailable:'Traffic unavailable · architecture uses public stars, forks, and recent updates',
     rideThere:"🚕 I'll drive you there", soLead:'Then ',
     greeterHtml:"Welcome! 🚕 I'm <b>Gitber</b>, your Repolis taxi.<br>What are you looking for? e.g. <b>most popular repo</b>, <b>AI agents</b>, <b>STT</b>, <b>anything</b>",
     greetReply:"Hello! 🚕 Which repo are you after? e.g. <b>most popular</b>, <b>AI agents</b>, <b>STT</b>",
@@ -2245,20 +2393,32 @@ REPOS.forEach(repo=>{
   repo.label = labelOf(repo.repo);
   repo.wall = p.wall; repo.roof = p.roof; repo.accent = p.accent; repo.color = hexstr(p.accent);
   repo.live = repo.home || ''; repo.vuniq = repo.visitors;
-  const lv = Math.log1p(repo.visitors||0), lc = Math.log1p(repo.clones||0);
-  repo._bright = Math.min(1, lv/Math.log1p(_maxVis));
-  repo._fancy  = Math.min(1, lc/Math.log1p(_maxClones));
-  repo._flags  = Math.round(repo._fancy*6);
-  repo._h = Math.min(18, 4 + lv*1.5 + Math.log1p(repo.stars||0)*0.55);
-  repo._w = 4.4 + Math.min(repo.forks||0,40)*0.13;
-  repo._yard = 5.2 + Math.log1p(repo.views||0)*0.95;
-  repo._downtown = (repo.rank||0) < 14;
-  // activity (= how much work a repo gets): recent pushes + clones + views. Drives night-time window glow.
   const days = repo.pushed ? Math.max(0,(_now - new Date(repo.pushed).getTime())/86400000) : 3650;
   const recency = Math.exp(-days/120);
-  repo._activity = Math.min(1, 0.6*recency
-    + 0.3*(Math.log1p(repo.clones||0)/Math.log1p(_maxClones))
-    + 0.1*(Math.log1p(repo.views||0)/Math.log1p(_maxViews)));
+  if(repo.trafficKnown===false){
+    const starSignal=Math.min(1,Math.log1p(repo.stars||0)/Math.log1p(1000));
+    const forkSignal=Math.min(1,Math.log1p(repo.forks||0)/Math.log1p(200));
+    repo._publicArchitecture=true;
+    repo._bright=Math.min(1,.18+recency*.62+starSignal*.2);
+    repo._fancy=forkSignal;
+    repo._flags=Math.round(forkSignal*4);
+    repo._h=Math.min(18,5.4+starSignal*8+recency*2);
+    repo._w=4.4+forkSignal*4.8;
+    repo._yard=5.2+starSignal*3.4+forkSignal*1.4;
+    repo._activity=Math.min(1,recency*.75+starSignal*.25);
+  } else {
+    const lv = Math.log1p(repo.visitors||0), lc = Math.log1p(repo.clones||0);
+    repo._bright = Math.min(1, lv/Math.log1p(_maxVis));
+    repo._fancy  = Math.min(1, lc/Math.log1p(_maxClones));
+    repo._flags  = Math.round(repo._fancy*6);
+    repo._h = Math.min(18, 4 + lv*1.5 + Math.log1p(repo.stars||0)*0.55);
+    repo._w = 4.4 + Math.min(repo.forks||0,40)*0.13;
+    repo._yard = 5.2 + Math.log1p(repo.views||0)*0.95;
+    repo._activity = Math.min(1, 0.6*recency
+      + 0.3*(Math.log1p(repo.clones||0)/Math.log1p(_maxClones))
+      + 0.1*(Math.log1p(repo.views||0)/Math.log1p(_maxViews)));
+  }
+  repo._downtown = (repo.rank||0) < 14;
   // data-driven town events: a recent release throws a party (garland + confetti); open issues fire up a busy workshop (chimney smoke)
   repo._relDays = repo.release_date ? Math.max(0,(_now - new Date(repo.release_date).getTime())/86400000) : null;
   repo._fresh = repo._relDays!=null && repo._relDays<=60;
@@ -7983,7 +8143,7 @@ function _freshCapture(at=Date.now()){ const repos={}; for(const r of REPOS) if(
 function _freshLoad(){ try{ const x=JSON.parse(localStorage.getItem(FRESHNESS_KEY)||'null');
     if(x&&x.v===1&&x.towns&&typeof x.towns==='object'&&Array.isArray(x.order)) return x; }catch(e){} return {v:1,towns:{},order:[]}; }
 let freshnessStore=_freshLoad(), freshnessTown=_freshTownKey(), freshnessCurrent=_freshCapture(), freshnessBaseline=freshnessStore.towns[freshnessTown]||null;
-const freshnessTrackable=REPOS.length>0&&!cityError;
+const freshnessTrackable=cityMode!=='portal'&&REPOS.length>0&&!cityError;
 let repoFreshness=freshnessTrackable&&freshnessBaseline?diffRepoFreshness(freshnessBaseline,freshnessCurrent):diffRepoFreshness(null,{at:freshnessCurrent.at,repos:{}});
 function _freshSaveStore(){ try{ localStorage.setItem(FRESHNESS_KEY,JSON.stringify(freshnessStore)); }catch(e){} }
 function _freshSetBaseline(snapshot){ freshnessStore.towns[freshnessTown]=snapshot;
@@ -8153,6 +8313,7 @@ function _validCourse(c,date,town){ const shape=c&&Array.isArray(c.items)&&((c.a
   return !!(shape&&c.date===date&&c.town===town&&c.v===COURSE_V&&Array.isArray(c.completed)); }
 function _saveCourse(){ try{ localStorage.setItem(COURSE_KEY,JSON.stringify(course)); }catch(e){} }
 function getCourse(){ const date=_todayKey(), town=_courseTownKey(); if(_validCourse(course,date,town)) return course;
+  if(cityMode==='portal'){ course={date,town,v:COURSE_V,items:[],completed:[],rewarded:false,available:false}; return course; }
   try{ const c=JSON.parse(localStorage.getItem(COURSE_KEY)); if(_validCourse(c,date,town)){ course=c; return course; } }catch(e){}
   course=buildCourse(); _saveCourse(); return course; }
 function courseItemKey(it){ return it.type+':'+it.id; }
@@ -8247,8 +8408,9 @@ const repoList=document.getElementById('repoList');
 function buildRow(repo){
   const row=document.createElement('div'); row.className='repoRow'; repo._row=row;
   if(repo._visited) row.classList.add('visited');
+  const metrics=repo.trafficKnown===false?`${repo.lang} · ⑂${repo.forks} · ★${repo.stars}`:`${repo.lang} · 👁${repo.visitors} · ⑂${repo.forks} · ★${repo.stars}`;
   row.innerHTML=`<div class="pin" style="background:${repo.color}">${repo.label[0]}</div>
-    <div class="meta"><div class="nm">${repo.label}</div><div class="sub">${repo.lang} · 👁${repo.visitors} · ⑂${repo.forks} · ★${repo.stars}</div></div>
+    <div class="meta"><div class="nm">${repo.label}</div><div class="sub">${metrics}</div></div>
     <div class="go">${t('go')}</div>`;
   row.querySelector('.go').onclick=ev=>{ ev.stopPropagation(); setNav(repo); panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); };
   row.onclick=()=> openCard(repo);
@@ -8276,7 +8438,8 @@ function setLang(l){ if(l!==LANG){ LANG=l; localStorage.setItem('repolisLang',LA
   // refresh the taxi chat so no stale-language messages linger after a switch
   if(typeof chatLog!=='undefined' && chatLog){ const wasOpen=!chatEl.classList.contains('hidden');
     chatLog.innerHTML=''; chatGreeted=false;
-    if(wasOpen){ chatGreeted=true; applyNpcChrome(activeNpc); addMsg('bot', npcGreet(activeNpc)); } } }
+    if(wasOpen){ chatGreeted=true; applyNpcChrome(activeNpc); addMsg('bot', npcGreet(activeNpc)); } }
+  if(repositoryAtelierChatActive()) _syncRepositoryAtelierChatChrome(); }
 langBtn.onclick=()=> setLang(LANG==='ko'?'en':'ko');
 document.querySelectorAll('#introLang button').forEach(b=> b.onclick=()=> setLang(b.dataset.lang));
 applyLang();
@@ -8333,7 +8496,7 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
   document.getElementById('cardChips').innerHTML=
     `<span class="chip">★ <b>${repo.stars}</b> stars</span>`+
     `<span class="chip">⑂ <b>${repo.forks}</b> forks</span>`+
-    (cityMode==='public'
+    (repo.trafficKnown===false
       ? (repo.lang&&repo.lang!=='—'?`<span class="chip">⌨ <b>${repo.lang}</b></span>`:'')
       : `<span class="chip">👁 <b>${repo.vuniq}</b> visitors</span>`+
         `<span class="chip">⬇ <b>${repo.clones}</b> clones</span>`)+
@@ -8342,7 +8505,7 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
     (repo.release_tag?`<span class="chip" title="${repo.release_date||''}">🏷 <b>${repo.release_tag}</b></span>`:'')+
     (repo.archived?`<span class="chip">📦 ${LANG==='ko'?'보관됨':'archived'}</span>`:'');
   const mnote=document.getElementById('cardMetricNote');
-  if(mnote) mnote.textContent = cityMode==='public' ? t('publicMetricNote') : t('metricNote');
+  if(mnote) mnote.textContent = repo.trafficKnown===false ? t('publicMetricNote') : t('metricNote');
   const since=document.getElementById('cardSince');
   if(repo.first_seen){ since.style.display='block';
     since.innerHTML = LANG==='ko'
@@ -8362,7 +8525,8 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
     +`<button class="btn close" id="closeBtn">${t('close')}</button>`;
   const atelierBtn=document.getElementById('atelierBtn'); if(atelierBtn&&!inAtelier) atelierBtn.onclick=()=>enterRepositoryAtelier(repo);
   document.getElementById('closeBtn').onclick=closeCard;
-  const ghBtn=act.querySelector('a.gh'); if(ghBtn) ghBtn.onclick=()=>track('github_click',{repo:repo.repo});
+  const ghBtn=act.querySelector('a.gh'); if(ghBtn) ghBtn.onclick=()=>{ if(cityMode==='portal') trackPortal('github_repo_opened',{entry:'card',device:_repoPortalDevice(),lang:LANG,channel:'github'});
+    else track('github_click',{repo:repo.repo}); };
   const liveBtn=act.querySelector('a.live'); if(liveBtn) liveBtn.onclick=()=>track('live_demo_click',{repo:repo.repo});
   track('repo_card_open',{repo:repo.repo});
   renderCardAsk(repo);
@@ -8631,7 +8795,7 @@ function _starNudgeClose(how){ const el=document.getElementById('starNudge'); if
 function maybeStarNudge(reason){ if(_starNudgeShown||_starNudgeSeen()) return false;
   const el=document.getElementById('starNudge'); if(!el) return false;
   // exploring a repo happens inside its card, so wait for the visitor to step back out
-  if(modalOpen||(tour&&tour.active)){ _starNudgePending=reason; return false; }
+  if(modalOpen||(tour&&tour.active)||repositoryAtelierActive()){ _starNudgePending=reason; return false; }
   const go=document.getElementById('starNudgeGo');
   if(go) go.href=(window.REPOLIS_CONFIG&&REPOLIS_CONFIG.project&&REPOLIS_CONFIG.project.url)||go.href;
   _starNudgeShown=true; _starNudgePending=null; el.classList.add('show'); track('star_nudge_shown',{reason}); return true; }
@@ -8639,25 +8803,30 @@ function flushStarNudge(){ if(!_starNudgePending) return; const reason=_starNudg
   setTimeout(()=>{ if(_starNudgePending===reason) maybeStarNudge(reason); }, 900); }
 (function(){ const x=document.getElementById('starNudgeX'), go=document.getElementById('starNudgeGo');
   if(x) x.onclick=()=>{ track('star_nudge_dismiss'); _starNudgeClose('dismissed'); };
-  if(go) go.onclick=()=>{ track('project_star_click'); _starNudgeClose('clicked'); }; })();
+  if(go) go.onclick=()=>{ if(repoPortalRequested) trackPortal('project_star_click',{entry:'earned',device:_repoPortalDevice(),lang:LANG,channel:'github'});
+    else track('project_star_click'); _starNudgeClose('clicked'); }; })();
 document.getElementById('startBtn').onclick=()=>{ document.getElementById('intro').classList.add('hidden');
   track('town_enter', { returning: !!VISITOR.returning });
   const rb=VISITOR.returning, news=hasFreshness();
   if(cityMode==='public'){
-    if(!rb) setTimeout(()=>{ try{ showWave(tf('arrived',{user:currentUser}),3600); }catch(e){} },850);
+    if(!rb&&!_reqFocus) setTimeout(()=>{ try{ showWave(tf('arrived',{user:currentUser}),3600); }catch(e){} },850);
     setTimeout(()=>{ try{ maybeStarNudge('personal_town'); }catch(e){} },14000); }   // only after they have actually walked their own town
-  if(rb){ setTimeout(()=>{ try{ showWave(_welcomeBackLine(),3600); }catch(e){} },850); }   // welcome a familiar face back before Gazette / Chronicle
-  try{ if(REPOS.length){ const c=getCourse(), delay=rb?4700:(cityMode==='public'?4600:1000);
+  if(rb&&cityMode!=='portal'&&!_reqFocus){ setTimeout(()=>{ try{ showWave(_welcomeBackLine(),3600); }catch(e){} },850); }   // welcome a familiar face back before Gazette / Chronicle
+  try{ if(cityMode!=='portal'&&!_reqFocus&&REPOS.length){ const c=getCourse(), delay=rb?4700:(cityMode==='public'?4600:1000);
       if(news) setTimeout(()=>{ try{ showWave(tf('freshBanner',{count:repoFreshness.total}),4200); }catch(e){} },delay);
       else if(c.available) setTimeout(()=>{ try{ showWave(t('courseBanner'),4200); }catch(e){} },delay); } }catch(e){}
-  setTimeout(()=>{ try{ openRepoFromHash(); }catch(e){} }, 480);
-  if(_reqGrowth) setTimeout(()=>{ try{ startTownGrowthReplay({entry:'link',year:_reqGrowth,autoplay:false}); }catch(e){} },620); };
+  setTimeout(()=>{ try{
+    if(cityMode==='portal'&&repoPortalTarget){ const repo=repoByKey(repoPortalTarget.repo); if(repo) enterRepositoryAtelier(repo); }
+    else if(_reqFocus){ const repo=repoByKey(_reqFocus.repo); if(repo) enterRepositoryAtelier(repo); else openRepoFromHash(); }
+    else openRepoFromHash();
+  }catch(e){} }, 480);
+  if(_reqGrowth&&cityMode!=='portal') setTimeout(()=>{ try{ startTownGrowthReplay({entry:'link',year:_reqGrowth,autoplay:false}); }catch(e){} },620); };
 const introLaunch=document.getElementById('introLaunch'),introLaunchLabel=introLaunch.querySelector('.launchLabel'),
   introLaunchForm=document.getElementById('introLaunchForm'),introLaunchHint=document.getElementById('introLaunchHint'),
   introPublicProof=document.getElementById('introPublicProof'),introProofStats=document.getElementById('introProofStats'),
   introProofTop=document.getElementById('introProofTop'),introPinProfile=document.getElementById('introPinProfile'),introGrowth=document.getElementById('introGrowth'),
   introCompare=document.getElementById('introCompare'),introTryAnother=document.getElementById('introTryAnother'),introProfileStatus=document.getElementById('introProfileStatus'),
-  introStartBtn=document.getElementById('startBtn');
+  introProofActions=document.getElementById('introProofActions'),introStartBtn=document.getElementById('startBtn'),introTourBtn=document.getElementById('introTour');
 let introChoosingAnother=false,introProfileResult=null;
 function publicIntroSummary(){ return summarizePublicTown(currentUser,REPOS); }
 function introProofNumber(value){ try{ return new Intl.NumberFormat(LANG==='ko'?'ko-KR':'en-US').format(value); }catch(e){ return String(value); } }
@@ -8666,19 +8835,28 @@ function renderIntroProfileStatus(){
   introProfileStatus.dataset.tone=introProfileResult?.tone||'';
 }
 function renderPublicIntro(){
-  const summary=publicIntroSummary(),ready=cityMode==='public'&&!cityError&&summary.count>0&&!introChoosingAnother;
+  const summary=publicIntroSummary(),publicReady=cityMode==='public'&&!cityError&&summary.count>0&&!introChoosingAnother;
+  const portalRepo=cityMode==='portal'&&!cityError&&repoPortalTarget?repoByKey(repoPortalTarget.repo):null;
+  const portalReady=!!portalRepo&&!introChoosingAnother,ready=publicReady||portalReady;
   introLaunch.classList.toggle('ready',ready); introPublicProof.hidden=!ready; introLaunchForm.hidden=ready; introLaunchHint.hidden=ready;
-  if(ready){
+  introProofActions.hidden=portalReady; introTourBtn.hidden=portalReady;
+  if(portalReady){
+    introLaunchLabel.textContent=tf('introPortalReady',{repo:repoPortalTarget.slug});
+    introProofStats.textContent=tf('introPortalStats',{stars:introProofNumber(portalRepo.stars),forks:introProofNumber(portalRepo.forks),language:portalRepo.lang||'Other'});
+    introProofTop.textContent=portalRepo.desc||t('noDesc'); introProofTop.title=portalRepo.desc||'';
+    const sourceKey=dataSource==='owner-snapshot'?'portalSourceLocal':(dataSource==='repo-cache'?'portalSourceCache':(dataSource==='repo-stale-cache'?'portalSourceStale':'portalSourceApi'));
+    introProfileResult={key:sourceKey,tone:dataSource==='repo-stale-cache'?'':'success'}; introStartBtn.textContent=t('enterRepoPortal');
+  }else if(publicReady){
     introLaunchLabel.textContent=tf('introReady',{user:summary.user});
     introProofStats.textContent=tf('introProofStats',{count:introProofNumber(summary.count),stars:introProofNumber(summary.stars),languages:introProofNumber(summary.languages)});
     const featured=summary.topRepos.join(' · '); introProofTop.textContent=tf('introProofTop',{repos:featured}); introProofTop.title=featured;
     introGrowth.hidden=!TOWN_GROWTH.available;
     introStartBtn.textContent=t('enterTownPublic');
   }else{
-    introProfileResult=null; introLaunchLabel.textContent=t('introLaunchLabel'); introStartBtn.textContent=t('enterTown');
+    introProfileResult=null; introProofActions.hidden=false; introTourBtn.hidden=false; introLaunchLabel.textContent=t('introLaunchLabel'); introStartBtn.textContent=t('enterTown');
   }
   renderIntroProfileStatus();
-  return {ready,choosingAnother:introChoosingAnother,summary};
+  return {ready,publicReady,portalReady,choosingAnother:introChoosingAnother,summary};
 }
 async function copyIntroProfileReadme(){
   introPinProfile.disabled=true; let ok=false;
@@ -8692,12 +8870,14 @@ introGrowth.onclick=()=>{ introStartBtn.click(); setTimeout(()=>startTownGrowthR
 introCompare.onclick=()=>openTwinTowns('intro');
 introTryAnother.onclick=()=>{ introChoosingAnother=true; introProfileResult=null; renderPublicIntro(); const input=document.getElementById('introUser'); input.value=''; setTimeout(()=>input.focus(),0); };
 (function(){ const form=introLaunchForm, input=document.getElementById('introUser'), err=document.getElementById('introLaunchErr');
-  if(!form||!input) return; if(cityMode==='public') input.value=currentUser;
+  if(!form||!input) return; if(cityMode==='public') input.value=currentUser; else if(cityMode==='portal'&&repoPortalTarget) input.value=repoPortalTarget.slug;
   if(new URLSearchParams(location.search).has('launch')) setTimeout(()=>input.focus(),80);
   input.addEventListener('keydown',e=>e.stopPropagation());
-  form.onsubmit=e=>{ e.preventDefault(); const user=input.value.trim().replace(/^@/,'');
-    if(!GH_LOGIN_RE.test(user)){ if(err) err.textContent=t('introLaunchInvalid'); track('intro_launch_invalid'); input.focus(); return; }
-    if(err) err.textContent=''; track('intro_personal_preview',{targetUser:user});
+  form.onsubmit=e=>{ e.preventDefault(); const target=parseRepoPortalInput(input.value);
+    if(!target.ok){ if(err) err.textContent=t('introLaunchInvalid'); track('intro_launch_invalid'); trackPortal('feature_started',{entry:'intro',device:_repoPortalDevice(),lang:LANG,result:'invalid'}); input.focus(); return; }
+    if(err) err.textContent='';
+    if(target.kind==='repo'){ location.href=createRepoPortalUrl(target,location.href); return; }
+    const user=target.user; track('intro_personal_preview',{targetUser:user});
     const url=location.origin+location.pathname+(user.toLowerCase()===OWNER.toLowerCase()?'':'?user='+encodeURIComponent(user));
     location.href=url; }; renderPublicIntro(); })();
 (function(){ const it=document.getElementById('introTour'); if(it) it.onclick=()=>{ document.getElementById('intro').classList.add('hidden');
@@ -8813,7 +8993,7 @@ twinModal.addEventListener('keydown',event=>{
 twinCopy.onclick=copyTwinTownLink; twinShare.onclick=shareTwinTowns;
 twinVisit.onclick=()=>{ if(TWIN.match) location.href=createTwinTownLink(TWIN.match.right.user,TWIN.match.left.user,_twinBaseUrl()); };
 twinMenuBtn.onclick=()=>openTwinTowns('menu'); window.__twinLangRefresh=syncTwinTownsLang; syncTwinTownsLang();
-if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!==currentUser.toLowerCase())
+if(cityMode!=='portal'&&!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!==currentUser.toLowerCase())
   setTimeout(()=>openTwinTowns('link',_reqTwin),120);
 
 /* ====================== 🚉 GITHUB STATION (city mode: travel to public towns) ====================== */
@@ -8831,15 +9011,21 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
   const shareBtn=document.getElementById('shareBtn');
   const curName=document.getElementById('stationCurName');
   const stationClose=document.getElementById('stationClose');
-  const EXAMPLES=['mrdoob','torvalds','karpathy','vercel','sindresorhus'];
+  const EXAMPLES=['mrdoob','mrdoob/three.js','vercel/next.js'];
   const LANDMARK_STOPS=[{id:'plaza',ico:'⛲'},{id:'creator',ico:'👤'},{id:'rain',ico:'🌦️'},{id:'homes',ico:'🏘️'},{id:'library',ico:'📚'},{id:'chrono',ico:'⏳'},{id:'observatory',ico:'🔭'},{id:'canal',ico:'🛶'},{id:'ferris',ico:'🎡'},{id:'carousel',ico:'🎠'}];
   const baseUrl=()=>location.origin+location.pathname;
-  const townName=()=> cityMode==='public' ? tf('townOf',{user:currentUser}) : t('myCity');
+  const townName=()=> cityMode==='portal'&&repoPortalTarget ? tf('repoPortalOf',{repo:repoPortalTarget.slug}) : (cityMode==='public' ? tf('townOf',{user:currentUser}) : t('myCity'));
 
-  function depart(user){
-    user=String(user||'').trim().replace(/^@+/,'');
-    if(!GH_LOGIN_RE.test(user)){ errLine.style.display='block'; errLine.textContent=t('stationInvalid'); track('travel_fail',{reason:'invalid'}); return; }
-    errLine.style.display='none'; track('travel_submit',{user});
+  function depart(value){
+    const target=parseRepoPortalInput(String(value||''));
+    if(!target.ok){ errLine.style.display='block'; errLine.textContent=t('stationInvalid'); trackPortal('feature_started',{entry:'station',device:_repoPortalDevice(),lang:LANG,result:'invalid'}); return; }
+    errLine.style.display='none';
+    if(target.kind==='repo'){
+      document.getElementById('trainMsg').textContent=tf('trainDepartRepo',{repo:target.slug});
+      document.getElementById('trainSub').textContent=t('fetchingRepo'); trainOv.classList.add('show');
+      setTimeout(()=>{ location.href=createRepoPortalUrl(target,location.href); },950); return;
+    }
+    const user=target.user; track('travel_submit',{user});
     document.getElementById('trainMsg').textContent=tf('trainDepart',{user});
     document.getElementById('trainSub').textContent=tf('fetchingRepos',{user});
     trainOv.classList.add('show');
@@ -8872,7 +9058,9 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
     curName.textContent=townName();
     renderLandmarkStops();
     quick.innerHTML=''; EXAMPLES.forEach(u=>{ const b=document.createElement('button'); b.textContent=u; b.onclick=()=>{ inp.value=u; depart(u); }; quick.appendChild(b); });
-    if(cityMode==='public'){ homeWrap.style.display='block'; homeWrap.innerHTML='<button id="goHomeBtn"></button>'; const hb=document.getElementById('goHomeBtn'); hb.textContent=tf('stationHome',{user:OWNER}); hb.onclick=goHome; }
+    if(cityMode==='public'||(cityMode==='portal'&&repoPortalTarget)){ homeWrap.style.display='block'; homeWrap.innerHTML='<button id="goHomeBtn"></button>'; const hb=document.getElementById('goHomeBtn');
+      if(cityMode==='portal'){ hb.textContent=tf('portalExplore',{user:repoPortalTarget.owner}); hb.onclick=()=>{ location.href=createRepoOwnerTownUrl(repoPortalTarget,location.href,OWNER); }; }
+      else { hb.textContent=tf('stationHome',{user:OWNER}); hb.onclick=goHome; } }
     else homeWrap.style.display='none';
     shareBtn.textContent=t('copyLink'); shareBtn.classList.remove('ok');
     if(stationClose) stationClose.setAttribute('aria-label', t('close'));
@@ -8886,9 +9074,12 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
   goBtn.onclick=()=>depart(inp.value);
   inp.addEventListener('keydown',e=>{ if(e.key==='Enter'&&!e.isComposing&&e.keyCode!==229){ e.preventDefault(); depart(inp.value); } });
 
-  shareBtn.onclick=async()=>{ const link = cityMode==='public' ? (baseUrl()+'?user='+encodeURIComponent(currentUser)) : baseUrl(); track('share_click');
+  shareBtn.onclick=async()=>{ const link = cityMode==='portal'&&repoPortalTarget ? createRepoPortalUrl(repoPortalTarget,location.href)
+      : (cityMode==='public' ? (baseUrl()+'?user='+encodeURIComponent(currentUser)) : baseUrl());
     let ok=false; try{ await navigator.clipboard.writeText(link); ok=true; }
     catch(e){ try{ const ta=document.createElement('textarea'); ta.value=link; ta.style.position='fixed'; ta.style.opacity='0'; document.body.appendChild(ta); ta.select(); ok=document.execCommand('copy'); document.body.removeChild(ta); }catch(_){ } }
+    if(cityMode==='portal') trackPortal('share_created',{entry:'station',device:_repoPortalDevice(),lang:LANG,result:ok?'success':'error',channel:'clipboard'});
+    else track('share_click',{channel:'station',ok});
     shareBtn.textContent = ok ? t('copied') : link; shareBtn.classList.toggle('ok',ok);
     setTimeout(()=>{ shareBtn.textContent=t('copyLink'); shareBtn.classList.remove('ok'); },1600); };
 
@@ -8896,7 +9087,10 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
   const effErr = cityError ? (cityError.reason||'http') : ((cityMode==='public' && !REPOS.length) ? 'empty' : null);
   function showCityError(){
     let title,msg;
-    if(effErr==='empty'){ title=t('publicEmptyTitle'); msg=tf('publicEmptyMsg',{user:currentUser}); }
+    if(repoPortalRequested){
+      title=effErr==='invalid_repo'?t('portalInvalidTitle'):t('publicNotFound');
+      msg=effErr==='invalid_repo'?t('portalInvalidMsg'):(effErr==='not_found'?t('portalNotFoundMsg'):(effErr==='rate_limit'?t('portalRateMsg'):t('portalNetMsg')));
+    }else if(effErr==='empty'){ title=t('publicEmptyTitle'); msg=tf('publicEmptyMsg',{user:currentUser}); }
     else if(effErr==='rate_limit'){ title=t('publicNotFound'); msg=t('publicRateMsg'); }
     else if(effErr==='network'){ title=t('publicNotFound'); msg=t('publicNetMsg'); }
     else if(effErr==='not_found'){ title=t('publicNotFound'); msg=tf('publicNotFoundMsg',{user:currentUser}); }
@@ -8904,7 +9098,8 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
     document.getElementById('ceTitle').textContent=title; document.getElementById('ceMsg').textContent=msg;
     const a=document.getElementById('ceActions'); a.innerHTML='';
     const retry=document.createElement('button'); retry.textContent=t('stationRetry'); retry.onclick=()=>{ errEl.classList.add('hidden'); openStation(); }; a.appendChild(retry);
-    const home=document.createElement('button'); home.className='alt'; home.textContent=tf('goOwnerCity',{user:OWNER}); home.onclick=goHome; a.appendChild(home);
+    const home=document.createElement('button'); home.className='alt'; home.textContent=repoPortalFallback?t('portalContinue'):tf('goOwnerCity',{user:OWNER});
+    home.onclick=()=>{ if(repoPortalFallback){ errEl.classList.add('hidden'); try{ history.replaceState(null,'',baseUrl()); }catch(e){} } else goHome(); }; a.appendChild(home);
     const intro=document.getElementById('intro'); if(intro) intro.classList.add('hidden');
     errEl.classList.remove('hidden');
   }
@@ -8912,6 +9107,8 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
   window.__cityLangRefresh=()=>{
     if(cityMode==='public'){ townLabel.style.display=''; townLabel.textContent='🚉 '+tf('townOf',{user:currentUser});
       const isub=document.querySelector('#intro .sub'); if(isub) isub.innerHTML=tf('introSubPublic',{user:currentUser}); }
+    else if(cityMode==='portal'&&repoPortalTarget){ townLabel.style.display=''; townLabel.textContent='🏛️ '+tf('repoPortalOf',{repo:repoPortalTarget.slug});
+      const isub=document.querySelector('#intro .sub'); if(isub) isub.innerHTML=t('introSubPortal'); }
     else townLabel.style.display='none';
     if(!stationEl.classList.contains('hidden')) renderStation();
     if(!errEl.classList.contains('hidden')) showCityError();
@@ -8919,11 +9116,16 @@ if(!cityError&&REPOS.length&&GH_LOGIN_RE.test(_reqTwin)&&_reqTwin.toLowerCase()!
   window.__station=()=>({ mode:cityMode, user:currentUser, source:dataSource, error:effErr, repoCount:REPOS.length, open:!stationEl.classList.contains('hidden') });
   window.__city=()=>({ mode:cityMode, user:currentUser, source:dataSource, repoCount:REPOS.length, error:cityError });
   window.__events=()=>recentAnalyticsEvents.slice();
+  window.__repoPortal=()=>({requested:repoPortalRequested,mode:cityMode,target:repoPortalTarget&&repoPortalTarget.slug||null,
+    source:dataSource,result:repoPortalResult&&repoPortalResult.result||null,fallback:repoPortalFallback,trafficKnown:REPOS[0]?.trafficKnown??null});
   window.__depart=depart; window.__goHome=goHome;
 
   // --- init city-mode visuals ---
   if(cityMode==='public'){ townLabel.style.display=''; townLabel.textContent='🚉 '+tf('townOf',{user:currentUser});
     const isub=document.querySelector('#intro .sub'); if(isub) isub.innerHTML=tf('introSubPublic',{user:currentUser});
+    const ms=document.getElementById('modeSel'); if(ms){ ms.value='local'; ms.style.display='none'; } }
+  else if(cityMode==='portal'&&repoPortalTarget){ townLabel.style.display=''; townLabel.textContent='🏛️ '+tf('repoPortalOf',{repo:repoPortalTarget.slug});
+    const isub=document.querySelector('#intro .sub'); if(isub) isub.innerHTML=t('introSubPortal');
     const ms=document.getElementById('modeSel'); if(ms){ ms.value='local'; ms.style.display='none'; } }
   else townLabel.style.display='none';
   if(effErr){ showCityError(); }
@@ -8943,6 +9145,7 @@ const POSTCARD={open:false,busy:false,blob:null,entry:'menu',previousFocus:null,
 
 function _postcardShareUrl(){
   const base=location.origin+location.pathname,params=new URLSearchParams();
+  if(cityMode==='portal'&&repoPortalTarget) return createRepoPortalUrl(repoPortalTarget,base);
   if(cityMode==='public') params.set('user',currentUser);
   const growth=new URLSearchParams(location.search).get('growth');
   if(document.body.classList.contains('growth-replay-active')&&/^\d{4}$/.test(growth||'')){ params.set('growth',growth); params.set('ref','growth-replay'); }
@@ -9411,13 +9614,13 @@ const CHAT_QUEUE_MAX=4,queuedChatQuestions=[]; let pendingChatNpc=null;
 function _queueChatAction(action){ if(!action) return false; if(queuedChatQuestions.length>=CHAT_QUEUE_MAX){ showWave(t('chatQueueFull'),2600); return false; }
   pendingChatNpc=null; queuedChatQuestions.push(action); showWave(t('chatQueued'),1800); return true; }
 function _queueChatQuestion(q,npc){ return q?_queueChatAction({kind:'ask',q,npc}):false; }
-function _drainQueuedChat(){ if(busy||repositoryAtelierActive()||!queuedChatQuestions.length) return false;
+function _drainQueuedChat(){ if(busy||(repositoryAtelierActive()&&!repositoryAtelierChatActive())||!queuedChatQuestions.length) return false;
   while(queuedChatQuestions.length){ const next=queuedChatQuestions.shift(),repo=next.repoKey&&repoByKey(next.repoKey);
     if(next.kind==='why'&&repo){ _showCardWhyZone(repo); continue; }
     if(next.kind==='similar'&&repo){ _showCardSimilar(repo); continue; }
     openChat(next.npc||_taxiNpc()); chatText.value=next.q; sendChat(); return true; }
   _resumePendingChatNpc(); return true; }
-function _resumePendingChatNpc(){ if(busy||repositoryAtelierActive()||!pendingChatNpc) return false;
+function _resumePendingChatNpc(){ if(busy||(repositoryAtelierActive()&&!repositoryAtelierChatActive())||!pendingChatNpc) return false;
   const next=pendingChatNpc; pendingChatNpc=null; openChat(next); return true; }
 
 function scrollChat(){ chatLog.scrollTop=chatLog.scrollHeight; }
@@ -9450,13 +9653,13 @@ function recentHist(){ return chatHistory.slice(-8); }
 function priorHist(){ const h=recentHist(); return (h.length&&h[h.length-1].role==='user')? h.slice(0,-1):h; }   // history minus the current question (the worker appends it)
 function addMsg(who,html,opts){
   const m=document.createElement('div'); m.className='msg '+who; m.innerHTML=html;
-  if(opts&&opts.repo){ const r=document.createElement('div'); r.className='ride'; r.innerHTML=t('rideThere');
+  if(opts&&opts.repo&&!repositoryAtelierActive()){ const r=document.createElement('div'); r.className='ride'; r.innerHTML=t('rideThere');
     r.onclick=()=>taxiTo(opts.repo); m.appendChild(document.createElement('br')); m.appendChild(r); }
   if(opts&&opts.alts&&opts.alts.length){ const wrap=document.createElement('div');
     opts.alts.forEach(a=>{ const c=document.createElement('span'); c.className='alt'; c.textContent=a.label;
       c.onclick=()=>{ addMsg('me',a.label); replyFor(a,t('soLead')); }; wrap.appendChild(c); });
     m.appendChild(wrap); }
-  if(opts&&opts.handoff){ const kind=typeof opts.handoff==='string'?opts.handoff:opts.handoff.kind, sc=window.scholarByKind&&window.scholarByKind(kind);
+  if(opts&&opts.handoff&&!repositoryAtelierActive()){ const kind=typeof opts.handoff==='string'?opts.handoff:opts.handoff.kind, sc=window.scholarByKind&&window.scholarByKind(kind);
     if(sc){ const h=document.createElement('div'); h.className='ride handoff'; h.textContent=tf('handoffGo',{name:sc.star});
       h.onclick=()=>startScholarHandoff(kind); m.appendChild(document.createElement('br')); m.appendChild(h); } }
   if(opts&&opts.trace){ m.appendChild(buildTracePanel(opts.trace)); }
@@ -9467,7 +9670,7 @@ function addMsg(who,html,opts){
   }
   return m;
 }
-function startScholarHandoff(kind){ const n=NPCS.find(x=>x.kind===kind), sc=window.scholarByKind&&window.scholarByKind(kind); if(!n||!sc) return false;
+function startScholarHandoff(kind){ if(repositoryAtelierActive()) return false; const n=NPCS.find(x=>x.kind===kind), sc=window.scholarByKind&&window.scholarByKind(kind); if(!n||!sc) return false;
   closeChat(); setNav({label:sc.star+' · '+(LANG==='ko'?sc.epithetKo:sc.epithetEn),_pos:n.group.position,_scholarHandoff:kind});
   showWave(tf('handoffNav',{name:sc.star}),3400); trackChatEvent('scholar_handoff_start',{npc:kind}); return true; }
 function showTyping(m){ if(!m) return m; m.classList.add('typing');
@@ -9545,8 +9748,9 @@ function openChat(npc){ npc=npc||activeNpc||NPCS.find(n=>n.kind==='taxi');
   applyNpcChrome(npc);
   if(!chatGreeted){ chatGreeted=true; addMsg('bot', npcGreet(npc), {noHist:true}); }
   trackChatEvent('chat_open', { npc:npcKindOf(npc) });
-  setTimeout(()=>{ if(!repositoryAtelierActive()&&!chatEl.classList.contains('hidden')) chatText.focus(); },60); return true; }
-function closeChat(){ cancelMarketRequest(); queuedChatQuestions.length=0; pendingChatNpc=null; chatEl.classList.add('hidden'); _releaseGroup(); trackChatEvent('chat_close'); }
+  setTimeout(()=>{ if((!repositoryAtelierActive()||repositoryAtelierChatActive())&&!chatEl.classList.contains('hidden')) chatText.focus(); },60); return true; }
+function closeChat(){ cancelMarketRequest(); queuedChatQuestions.length=0; pendingChatNpc=null; chatEl.classList.add('hidden'); chatEl.classList.remove('atelierChat');
+  document.body.classList.remove('atelier-chat-open'); if(REPOSITORY_ATELIER) REPOSITORY_ATELIER.inRoomChat=false; _releaseGroup(); trackChatEvent('chat_close'); }
 
 /* ---- Mode A: local intent search (no key, always works) ---- */
 const SYN={ rag:['rag','retrieval','faq','vector','embedding','검색증강','지식'], llm:['llm','gpt','openai','azure','generative','genai','foundry','language model','파운드리'],
@@ -9729,6 +9933,8 @@ function _coreIntent(q){
   if(/아무|랜덤|골라|추천만|\brandom\b/.test(ql)){ const r=REPOS[Math.floor(Math.random()*REPOS.length)]; return pick(r,t('leadRandom'),[]); }
   if(/스타|별|\bstars?\b/.test(ql)){ const a=[...REPOS].sort((x,y)=>y.stars-x.stars); return M(pick(a[0],t('leadStar'),a.slice(1,4))); }
   if(/최근|새로|요즘 만든|\brecent\b|\bnew\b|\blatest\b/.test(ql)){ const a=[...REPOS].sort((x,y)=>new Date(y.pushed)-new Date(x.pushed)); return M(pick(a[0],t('leadRecent'),a.slice(1,4))); }
+  if(REPOS.every(repo=>repo.trafficKnown===false)&&/방문|왕래|사람 많|트래픽|클론|다운로드|받아|설치|조회|페이지뷰|\bvisitors?\b|\btraffic\b|\bclones?\b|\bdownloads?\b|\bviews?\b/.test(ql))
+    return {repo:null,message:t('publicTrafficUnavailable'),alts:[]};
   if(/방문|왕래|사람 많|트래픽|\bvisitors?\b|\btraffic\b/.test(ql)){ const a=[...REPOS].sort((x,y)=>(y.visitors||0)-(x.visitors||0)); return M(pick(a[0],t('leadVisitors'),a.slice(1,4))); }
   if(/클론|다운로드|받아|설치|\bclones?\b|\bdownloads?\b/.test(ql)){ const a=[...REPOS].sort((x,y)=>(y.clones||0)-(x.clones||0)); return M(pick(a[0],t('leadClones'),a.slice(1,4))); }
   if(/포크|파생|갈라|\bforks?\b/.test(ql)){ const a=[...REPOS].sort((x,y)=>(y.forks||0)-(x.forks||0)); return M(pick(a[0],t('leadForks'),a.slice(1,4))); }
@@ -9759,7 +9965,8 @@ function padAlts(main, alts){ const out=(alts||[]).filter(Boolean); const seen=n
   for(const r of byRank()){ if(out.length>=3) break; if(!seen.has(r.repo)){ out.push(r); seen.add(r.repo); } } return out; }
 function pick(repo,lead,alts,weak){
   const d=repo.desc?repo.desc.replace(/\s+/g,' ').slice(0,70):'';
-  const msg=`${lead}‘<b>${repo.label}</b>’${weak?t('howAbout'):t('recommend')}${d?'<br>“'+d+(repo.desc.length>70?'…':'')+'”':''}<br><span style="color:#ab8a66">★${repo.stars} · 👁${repo.visitors} · ⬇${repo.clones||0} · ⑂${repo.forks} · ${repo.lang}</span>`;
+  const metricLine=repo.trafficKnown===false?`★${repo.stars} · ⑂${repo.forks} · ${repo.lang}`:`★${repo.stars} · 👁${repo.visitors} · ⬇${repo.clones||0} · ⑂${repo.forks} · ${repo.lang}`;
+  const msg=`${lead}‘<b>${repo.label}</b>’${weak?t('howAbout'):t('recommend')}${d?'<br>“'+d+(repo.desc.length>70?'…':'')+'”':''}<br><span style="color:#ab8a66">${metricLine}</span>`;
   return { repo, message:msg, alts:(alts||[]).filter(Boolean) };
 }
 function replyFor(repo,lead){ const r=pick(repo,lead||'',[]); addMsg('bot',r.message,{repo:r.repo}); }
@@ -9973,7 +10180,7 @@ async function sendChat(){ const q=chatText.value.trim(); if(!q||busy) return; b
   addMsg('me',q.replace(/</g,'&lt;'));
   try{ if(_isGroupChat(activeNpc)){ await groupSay(q); } else if(activeNpc&&activeNpc.resident){ await residentSay(q); } else { await askDriver(q); } ok=true; }
   finally{ trackChatEvent('chat_turn_done', { npc, qLen, ok, ms:elapsedMs(started) }); busy=false;
-    if(!_drainQueuedChat()&&!_resumePendingChatNpc()&&!repositoryAtelierActive()&&!chatEl.classList.contains('hidden')) chatText.focus(); } }
+    if(!_drainQueuedChat()&&!_resumePendingChatNpc()&&(!repositoryAtelierActive()||repositoryAtelierChatActive())&&!chatEl.classList.contains('hidden')) chatText.focus(); } }
 
 /* ---- taxi ride: the cab drives to you, picks you up, carries you there ---- */
 let ride=null, ridePostActionUntil=0; // ride phases plus a brief guard for delayed arrival UI
@@ -9983,7 +10190,7 @@ function driveTaxiToward(px,pz,speed,dt,stop=0){
     taxi.rotation.y=lerpA(taxi.rotation.y, Math.atan2(-dz,dx), 0.2); }
   return dd;
 }
-function taxiTo(repo){ standUp(); ridePostActionUntil=0; ride={repo, phase:'coming', t:0}; setNav(repo); closeChat(); freeLook=false; model.visible=true;
+function taxiTo(repo){ if(repositoryAtelierActive()) return false; standUp(); ridePostActionUntil=0; ride={repo, phase:'coming', t:0}; setNav(repo); closeChat(); freeLook=false; model.visible=true;
   if(document.activeElement&&document.activeElement.blur) document.activeElement.blur();
   driveNameEl.textContent=repo.label; driveBar.style.display='flex'; }
 function endDrive(){ if(ride){ taxi.position.copy(TAXI_POS); taxi.rotation.y=-0.85; } ride=null; ridePostActionUntil=0; driveBar.style.display='none'; model.visible=true; }
@@ -10154,10 +10361,14 @@ const REPOSITORY_ATELIER_LAYER=6;
 const REPOSITORY_ATELIER_FADE=matchMedia('(prefers-reduced-motion: reduce)').matches?0.08:0.18;
 var REPOSITORY_ATELIER=null;
 const atelierFade=document.getElementById('atelierFade'),atelierHud=document.getElementById('atelierHud'),
-  atelierExit=document.getElementById('atelierExit'),atelierRepoName=document.getElementById('atelierRepoName');
+  atelierExit=document.getElementById('atelierExit'),atelierRepoName=document.getElementById('atelierRepoName'),
+  atelierPortalActions=document.getElementById('atelierPortalActions'),atelierPortalCopy=document.getElementById('atelierPortalCopy'),
+  atelierPortalGithub=document.getElementById('atelierPortalGithub'),atelierPortalExplore=document.getElementById('atelierPortalExplore'),
+  atelierPortalStatus=document.getElementById('atelierPortalStatus');
 
 function repositoryAtelierActive(){ return !!REPOSITORY_ATELIER&&REPOSITORY_ATELIER.state!=='outside'; }
 function repositoryAtelierTransitioning(){ return !!REPOSITORY_ATELIER&&(REPOSITORY_ATELIER.state==='entering'||REPOSITORY_ATELIER.state==='exiting'); }
+function repositoryAtelierChatActive(){ return !!REPOSITORY_ATELIER&&REPOSITORY_ATELIER.state==='inside'&&REPOSITORY_ATELIER.inRoomChat===true; }
 function _atelierHex(value){ return '#'+((value>>>0)&0xffffff).toString(16).padStart(6,'0'); }
 function _atelierHash(value){ let h=2166136261; for(const c of String(value||'')){ h^=c.charCodeAt(0); h=Math.imul(h,16777619); } return h>>>0; }
 function _atelierDate(value){ return value?String(value).slice(0,10):'—'; }
@@ -10203,14 +10414,15 @@ function _createRepositoryAtelier(){
   if(A.repo===undefined) A.repo=null; if(A.lastRepo===undefined) A.lastRepo=null; if(A.snapshot===undefined) A.snapshot=null;
   if(A.lastSaved===undefined) A.lastSaved=null; if(A.lastRestored===undefined) A.lastRestored=null; if(A.pendingExit==null) A.pendingExit=false;
   if(A.afterExit===undefined) A.afterExit=null; if(A.near===undefined) A.near=null; if(A.walk==null) A.walk=0; if(A.lastAction===undefined) A.lastAction=null;
+  if(A.inRoomChat==null) A.inRoomChat=false; if(A.roomPanel===undefined) A.roomPanel=null;
   A.lastInterior=A.lastInterior||{calls:0,triangles:0}; A.peakInterior=A.peakInterior||{calls:0,triangles:0};
   A.resources=A.resources||{geometries:new Set(),materials:new Set(),textures:new Set()};
-  A.dummy=A.dummy||new THREE.Object3D(); A.moveForward=A.moveForward||new THREE.Vector3(); A.moveRight=A.moveRight||new THREE.Vector3();
+  A.dummy=A.dummy||new THREE.Object3D(); A.color=A.color||new THREE.Color(); A.moveForward=A.moveForward||new THREE.Vector3(); A.moveRight=A.moveRight||new THREE.Vector3();
   A.moveDelta=A.moveDelta||new THREE.Vector3(); A.cameraTarget=A.cameraTarget||new THREE.Vector3(); A.up=A.up||new THREE.Vector3(0,1,0);
   REPOSITORY_ATELIER=A;
   const atlasW=(LOW_END||IS_MOBILE)?1024:1536,history=_atelierCanvas(atlasW,Math.round(atlasW/1.6),'history'),
-    actions=_atelierCanvas(atlasW,Math.round(atlasW/2.6667),'actions');
-  A.history=history; A.actionsCanvas=actions;
+    signals=_atelierCanvas(atlasW,Math.round(atlasW/1.6),'signals'),actions=_atelierCanvas(atlasW,Math.round(atlasW/2.6667),'actions');
+  A.history=history; A.signalsCanvas=signals; A.actionsCanvas=actions;
   A.scene=new THREE.Scene(); A.scene.background=new THREE.Color(0x11191c); A.scene.fog=new THREE.Fog(0x11191c,18,30);
   A.group=new THREE.Group(); A.group.name='RepositoryAtelier_Room'; A.scene.add(A.group);
 
@@ -10224,8 +10436,8 @@ function _createRepositoryAtelier(){
     terminal:_atelierTrackMaterial(new THREE.MeshStandardMaterial({color:0xffffff,emissive:0x172326,emissiveIntensity:.72,roughness:.55,metalness:.2,vertexColors:true})),
     screen:_atelierTrackMaterial(new THREE.MeshBasicMaterial({color:0xffffff,vertexColors:true})),
     door:_atelierTrackMaterial(new THREE.MeshStandardMaterial({color:0x49656a,emissive:0x183238,emissiveIntensity:.38,roughness:.55,metalness:.25})),
-    avatar:_atelierTrackMaterial(new THREE.MeshStandardMaterial({color:0xf0eee7,roughness:.72,metalness:.04})),
-    avatarDark:_atelierTrackMaterial(new THREE.MeshStandardMaterial({color:0x293239,roughness:.78,metalness:.03}))
+    exhibit:_atelierTrackMaterial(new THREE.MeshStandardMaterial({color:0xffffff,emissive:0x132a2f,emissiveIntensity:.32,roughness:.5,metalness:.42,vertexColors:true})),
+    coreWire:_atelierTrackMaterial(new THREE.MeshBasicMaterial({color:0x8fdde4,wireframe:true,transparent:true,opacity:.34,depthWrite:false}))
   };
 
   const shell=_atelierMesh(new THREE.BoxGeometry(16,8.2,22),A.materials.shell); shell.position.y=4.1; shell.name='AtelierShell'; A.group.add(shell);
@@ -10237,8 +10449,33 @@ function _createRepositoryAtelier(){
     .forEach((v,i)=>_atelierSetInstance(trim,i,...v));
   trim.instanceMatrix.needsUpdate=true; trim.name='AtelierTrim'; A.group.add(trim); A.trim=trim;
 
+  const architectureParts=[];
+  [-8,-4,0,4,8].forEach(z=>architectureParts.push([0,7.46,z,15.1,.09,.11]));
+  architectureParts.push([7.58,4,-4.38,.1,5.85,.12],[7.58,4,4.38,.1,5.85,.12],
+    [7.58,6.94,0,.1,.12,8.88],[7.58,1.06,0,.1,.12,8.88],
+    [-6.95,.08,0,.11,.08,19.4],[6.95,.08,0,.11,.08,19.4]);
+  const architecture=new THREE.InstancedMesh(_atelierTrackGeometry(new THREE.BoxGeometry(1,1,1)),A.materials.exhibit,architectureParts.length);
+  architectureParts.forEach((part,index)=>_atelierSetInstance(architecture,index,...part));
+  architecture.instanceMatrix.needsUpdate=true; architecture.name='AtelierArchitecture'; A.group.add(architecture); A.architecture=architecture;
+
+  const pathCount=14,pathTiles=new THREE.InstancedMesh(_atelierTrackGeometry(new THREE.BoxGeometry(.82,.045,.56)),A.materials.exhibit,pathCount);
+  for(let index=0;index<pathCount;index++){ const p=index/(pathCount-1),z=8.45-p*16.2,x=3.05*Math.sin(p*Math.PI);
+    _atelierSetInstance(pathTiles,index,x,.045,z,1,1,1,0,0,0); }
+  pathTiles.instanceMatrix.needsUpdate=true; pathTiles.name='AtelierDataPath'; A.group.add(pathTiles); A.pathTiles=pathTiles;
+
+  A.metricPositions=[new THREE.Vector3(6.15,0,-4.2),new THREE.Vector3(6.15,0,0),new THREE.Vector3(6.15,0,4.2)];
+  const metricPillars=new THREE.InstancedMesh(_atelierTrackGeometry(new THREE.CylinderGeometry(.42,.62,1,LOW_END?8:12)),A.materials.exhibit,3);
+  const metricNodes=new THREE.InstancedMesh(_atelierTrackGeometry(new THREE.OctahedronGeometry(.58,LOW_END?0:1)),A.materials.exhibit,3);
+  A.metricPositions.forEach((position,index)=>{ _atelierSetInstance(metricPillars,index,position.x,.5,position.z,1,1,1);
+    _atelierSetInstance(metricNodes,index,position.x,1.45,position.z,1,1,1,0,index*.3,0); });
+  metricPillars.instanceMatrix.needsUpdate=true; metricNodes.instanceMatrix.needsUpdate=true;
+  metricPillars.name='AtelierMetricPillars'; metricNodes.name='AtelierMetricArtifacts'; A.group.add(metricPillars,metricNodes);
+  A.metricPillars=metricPillars; A.metricNodes=metricNodes;
+
   const historyPanel=_atelierMesh(new THREE.PlaneGeometry(8.48,5.3),new THREE.MeshBasicMaterial({map:history.texture,toneMapped:false}));
   historyPanel.position.set(-7.82,4,-.5); historyPanel.rotation.y=Math.PI/2; historyPanel.name='AtelierHistoryWall'; A.group.add(historyPanel);
+  const signalsPanel=_atelierMesh(new THREE.PlaneGeometry(8.48,5.3),new THREE.MeshBasicMaterial({map:signals.texture,toneMapped:false}));
+  signalsPanel.position.set(7.82,4,-.5); signalsPanel.rotation.y=-Math.PI/2; signalsPanel.name='AtelierSignalsWall'; A.group.add(signalsPanel);
   const actionPanel=_atelierMesh(new THREE.PlaneGeometry(12.8,4.2),new THREE.MeshBasicMaterial({map:actions.texture,toneMapped:false}));
   actionPanel.position.set(0,4.16,-10.78); actionPanel.name='AtelierActionWall'; A.group.add(actionPanel);
 
@@ -10264,21 +10501,27 @@ function _createRepositoryAtelier(){
     _atelierMesh(new THREE.DodecahedronGeometry(1.08,LOW_END?0:1),A.materials.core)
   ];
   A.coreShapes.forEach(shape=>{ shape.visible=false; A.core.add(shape); });
+  const coreShell=_atelierMesh(new THREE.SphereGeometry(1.58,LOW_END?10:16,LOW_END?8:12),A.materials.coreWire);
+  coreShell.scale.y=.78; coreShell.name='RepositoryCoreArchiveShell'; A.core.add(coreShell); A.coreShell=coreShell;
   const ringGeo=_atelierTrackGeometry(new THREE.TorusGeometry(1.72,.055,LOW_END?6:10,LOW_END?24:36)),rings=new THREE.InstancedMesh(ringGeo,A.materials.ring,3);
   rings.instanceMatrix.setUsage(THREE.DynamicDrawUsage); A.core.add(rings); A.rings=rings;
   const rodGeo=_atelierTrackGeometry(new THREE.CylinderGeometry(.045,.045,2.7,LOW_END?5:8)),rods=new THREE.InstancedMesh(rodGeo,A.materials.ring,10);
   rods.instanceMatrix.setUsage(THREE.DynamicDrawUsage); A.core.add(rods); A.rods=rods;
   A.coreLight=new THREE.PointLight(0x8fdde4,12,12,1.8); A.coreLight.position.set(0,.5,0); A.core.add(A.coreLight);
 
-  A.avatar=new THREE.Group(); A.avatar.name='AtelierVisitor'; A.group.add(A.avatar);
-  const avatarBody=_atelierMesh(new THREE.CapsuleGeometry(.32,.64,4,8),A.materials.avatar); avatarBody.position.y=1.17; A.avatar.add(avatarBody);
-  const avatarHead=_atelierMesh(new THREE.SphereGeometry(.42,LOW_END?10:16,LOW_END?8:12),A.materials.avatar); avatarHead.position.y=2.05; A.avatar.add(avatarHead);
-  const limbGeo=_atelierTrackGeometry(new THREE.CapsuleGeometry(.09,.42,3,LOW_END?5:7)),limbs=new THREE.InstancedMesh(limbGeo,A.materials.avatarDark,4);
-  limbs.instanceMatrix.setUsage(THREE.DynamicDrawUsage); A.avatar.add(limbs); A.avatarLimbs=limbs;
+  A.avatar=model.clone(true); A.avatar.name='AtelierVisitor_CurrentChibi'; A.avatar.position.set(0,0,3.65); A.avatar.rotation.set(0,Math.PI,0); A.avatar.scale.setScalar(.82);
+  A.avatar.traverse(object=>{ if(object.isSprite) object.visible=false; if(object.isLight){ object.castShadow=false; object.intensity=Math.min(object.intensity,7); } });
+  const avatarCloneOf=source=>{ const path=[]; for(let node=source;node&&node!==model;node=node.parent) path.unshift(node.parent.children.indexOf(node));
+    let clone=A.avatar; for(const index of path) clone=clone&&clone.children[index]; return clone||null; };
+  A.avatarArmL=avatarCloneOf(armL); A.avatarArmR=avatarCloneOf(armR); A.avatarLegL=avatarCloneOf(legL); A.avatarLegR=avatarCloneOf(legR);
+  let avatarDraws=0; A.avatar.traverse(object=>{ if(object.isMesh||object.isLine||object.isSprite||object.isPoints) avatarDraws++; }); A.avatarDraws=avatarDraws;
+  A.group.add(A.avatar);
+  const avatarShadow=_atelierMesh(new THREE.CircleGeometry(.72,20),_atelierTrackMaterial(new THREE.MeshBasicMaterial({color:0x07151a,transparent:true,opacity:.38,depthWrite:false})));
+  avatarShadow.rotation.x=-Math.PI/2; avatarShadow.position.set(0,.025,3.65); avatarShadow.name='AtelierVisitorShadow'; A.group.add(avatarShadow); A.avatarShadow=avatarShadow;
 
-  const hemi=new THREE.HemisphereLight(0xdde9e7,0x253337,2.15); hemi.position.y=6; A.group.add(hemi);
-  const key=new THREE.PointLight(0xffe3b0,17,24,2); key.position.set(5,6,5); A.group.add(key);
-  const fill=new THREE.PointLight(0x8fd6dd,14,22,2); fill.position.set(-5,5,-4); A.group.add(fill); A.roomLights={key,fill};
+  const hemi=new THREE.HemisphereLight(0xdde9e7,0x253337,2.65); hemi.position.y=6; A.group.add(hemi);
+  const key=new THREE.PointLight(0xffe3b0,22,24,2); key.position.set(5,6,5); A.group.add(key);
+  const fill=new THREE.PointLight(0x8fd6dd,18,22,2); fill.position.set(-5,5,-4); A.group.add(fill); A.roomLights={key,fill};
   _atelierLayer(A.group); A.group.visible=false; A.created=true; A.createCount++; A.texturesAtCreate=A.resources.textures.size;
   return A;
 }
@@ -10303,12 +10546,43 @@ function _drawRepositoryAtelierHistory(repo){
   y+=54; ctx.fillStyle='#c8d4d3'; ctx.font='600 25px system-ui,sans-serif';
   ctx.fillText(`${LANG==='ko'?'생성':'Created'}  ${_atelierDate(repo.created)}     ${LANG==='ko'?'최근 push':'Pushed'}  ${_atelierDate(repo.pushed)}`,88,y);
   y+=45; ctx.fillText(`${LANG==='ko'?'릴리스':'Release'}  ${repo.release_tag||'—'}  ·  ${_atelierDate(repo.release_date)}`,88,y);
-  const hasTraffic=repo.tracked===true;
+  const hasTraffic=repo.trafficKnown===true;
   if(hasTraffic){ y+=58; ctx.fillStyle='#90c8bd'; ctx.font='800 23px system-ui,sans-serif'; ctx.fillText('TRAFFIC',88,y);
     y+=38; ctx.fillStyle='#c8d4d3'; ctx.font='600 25px system-ui,sans-serif';
     ctx.fillText(`👁 ${LANG==='ko'?'방문자':'visitors'} ${_atelierMetric(repo.visitors)}     📈 ${LANG==='ko'?'조회':'views'} ${_atelierMetric(repo.views)}     ↓ clones ${_atelierMetric(repo.clones)}     ${LANG==='ko'?'추적 시작':'tracked since'} ${repo.first_seen||'—'}`,88,y); }
+  else { y+=58; ctx.fillStyle='#90c8bd'; ctx.font='700 23px system-ui,sans-serif'; _atelierWrapText(ctx,t('atelierTrafficUnavailable'),88,y,1320,34,2); }
   ctx.fillStyle=_atelierHex(accent); ctx.fillRect(88,870,1360,8);
   A.textLayout={historyWithinCanvas:y<846,historyLines:Math.round(y),actionWithinCanvas:true,traffic:hasTraffic}; s.texture.needsUpdate=true;
+}
+function _drawRepositoryAtelierSignals(repo){
+  const A=REPOSITORY_ATELIER,s=A.signalsCanvas,ctx=s.ctx,zone=zoneCatById(repo._zone),accent=repo.accent||pal(repo.lang).accent,
+    tone=zone?zone.tone:accent,W=s.canvas.width,H=s.canvas.height,activity=Math.round((repo._activity||0)*100);
+  ctx.setTransform(1,0,0,1,0,0); ctx.clearRect(0,0,W,H); ctx.setTransform(W/1536,0,0,H/960,0,0);
+  ctx.fillStyle='#10191c'; ctx.fillRect(0,0,1536,960); ctx.fillStyle=_atelierHex(tone); ctx.fillRect(1512,0,24,960);
+  ctx.fillStyle='rgba(255,255,255,.05)'; ctx.fillRect(56,44,1424,872); ctx.textBaseline='top';
+  ctx.fillStyle='#9fb7bb'; ctx.font='800 25px system-ui,sans-serif'; ctx.letterSpacing='4px'; ctx.fillText(t('atelierSignals'),88,76);
+  ctx.fillStyle='#f5f0e7'; _atelierFitText(ctx,repo.repo,88,126,1360,58,34);
+  ctx.fillStyle=_atelierHex(accent); ctx.font='800 26px system-ui,sans-serif';
+  ctx.fillText(`${repo.lang||'Other'}  ·  ${zone?zone.icon+' '+(LANG==='ko'?zone.ko:zone.en):(repo._zone||'')}`,88,198);
+  const cards=[
+    {label:'STARS',value:`★ ${_atelierMetric(repo.stars)}`,color:0xf0c96b},
+    {label:'FORKS',value:`⑂ ${_atelierMetric(repo.forks)}`,color:0x8fd6dd},
+    {label:'ACTIVITY',value:`${activity}%`,color:0x8fd3a8},
+    {label:'SCORE',value:_atelierMetric(repo.score),color:tone}
+  ];
+  cards.forEach((card,index)=>{ const x=88+index*348; ctx.fillStyle='rgba(255,255,255,.055)'; ctx.fillRect(x,264,316,176);
+    ctx.fillStyle=_atelierHex(card.color); ctx.fillRect(x,264,316,8);
+    ctx.fillStyle='#91a7aa'; ctx.font='800 20px system-ui,sans-serif'; ctx.fillText(card.label,x+24,296);
+    ctx.fillStyle='#f4efe6'; ctx.font='900 42px system-ui,sans-serif'; _atelierFitText(ctx,card.value,x+24,340,268,42,25); });
+  ctx.fillStyle='#91b6b6'; ctx.font='800 22px system-ui,sans-serif'; ctx.fillText(LANG==='ko'?'TOPICS / 주제 신호':'TOPICS / DISCOVERY SIGNALS',88,492);
+  const topics=(repo.topics||[]).slice(0,8).map(topic=>'#'+topic).join('  ')||(LANG==='ko'?'표시할 주제 없음':'No public topics');
+  ctx.fillStyle='#d0dcda'; ctx.font='650 25px system-ui,sans-serif'; let y=_atelierWrapText(ctx,topics,88,532,1350,38,3)+28;
+  ctx.fillStyle='#91b6b6'; ctx.font='800 22px system-ui,sans-serif'; ctx.fillText('LIFECYCLE',88,y); y+=42;
+  ctx.fillStyle='#d0dcda'; ctx.font='650 25px system-ui,sans-serif';
+  y=_atelierWrapText(ctx,`${LANG==='ko'?'생성':'Created'} ${_atelierDate(repo.created)}   ·   ${LANG==='ko'?'최근 push':'Pushed'} ${_atelierDate(repo.pushed)}   ·   ${LANG==='ko'?'릴리스':'Release'} ${repo.release_tag||'—'}`,88,y,1350,38,2)+28;
+  ctx.fillStyle='#829a9c'; ctx.font='650 20px system-ui,sans-serif'; ctx.fillText(t('atelierSignalsNow'),88,y);
+  ctx.fillStyle=_atelierHex(accent); ctx.fillRect(88,870,1360,8);
+  A.textLayout=A.textLayout||{}; A.textLayout.signalsWithinCanvas=y<846; A.textLayout.signalCards=cards.length; s.texture.needsUpdate=true;
 }
 function _drawRepositoryAtelierActions(repo){
   const A=REPOSITORY_ATELIER,s=A.actionsCanvas,ctx=s.ctx,zone=zoneCatById(repo._zone),tone=zone?zone.tone:(repo.accent||0x7ea4aa),W=s.canvas.width,H=s.canvas.height;
@@ -10330,27 +10604,85 @@ function _bindRepositoryAtelier(repo){
     stars=Math.min(1,Math.log1p(canonical.stars||0)/Math.log(1001)),activity=canonical._activity||0;
   A.repo=canonical; A.lastRepo=canonical.repo; A.bindCount++; A.hash=hash; A.score=score; A.activity=activity;
   A.scene.background.set(ground).lerp(new THREE.Color(0x1f2b2e),.46); A.scene.fog.color.copy(A.scene.background);
-  A.materials.shell.color.copy(A.scene.background).lerp(new THREE.Color(0x42565a),.4);
-  A.materials.floor.color.copy(new THREE.Color(ground)).lerp(new THREE.Color(0x3b5054),.68);
+  A.materials.shell.color.copy(A.scene.background).lerp(new THREE.Color(0x4b6267),.52);
+  A.materials.floor.color.copy(new THREE.Color(ground)).lerp(new THREE.Color(0x465f64),.76);
   A.materials.trim.color.set(zoneColor); A.materials.core.color.set(langColor); A.materials.core.emissive.set(langColor).multiplyScalar(.34);
   A.materials.core.emissiveIntensity=.25+activity*.78; A.materials.ring.color.set(zoneColor); A.materials.ring.emissive.set(zoneColor).multiplyScalar(.28);
+  A.materials.coreWire.color.set(zoneColor); A.materials.coreWire.opacity=.24+activity*.22;
+  A.materials.exhibit.emissive.set(zoneColor).multiplyScalar(.36); A.materials.exhibit.emissiveIntensity=.46;
   A.materials.door.color.set(zoneColor).lerp(new THREE.Color(0x40575d),.45); A.materials.door.emissive.set(zoneColor).multiplyScalar(.2);
   A.coreLight.color.set(langColor); A.coreLight.intensity=7+activity*12+score*5; A.roomLights.fill.color.set(langColor); A.roomLights.key.color.set(zoneColor).lerp(new THREE.Color(0xffe5b8),.55);
   A.coreShapes.forEach((shape,index)=>{ shape.visible=index===hash%3; shape.scale.setScalar(.88+stars*.55); shape.scale.y*=.78+score*.7; });
-  A.activeShape=A.coreShapes[hash%3]; A.rings.count=LOW_END?2:3;
-  for(let i=0;i<A.rings.count;i++){ const scale=.78+i*.26+stars*.18,tilt=((hash>>i*3)&7)*.035; _atelierSetInstance(A.rings,i,0,.12+i*.1,0,scale,scale,scale,Math.PI/2+tilt,tilt*.6,(hash%17)*.02+i*.42); }
+  A.activeShape=A.coreShapes[hash%3]; A.coreShell.scale.setScalar(.96+stars*.2); A.coreShell.scale.y*=.78+score*.18; A.rings.count=LOW_END?2:3;
+  for(let i=0;i<A.rings.count;i++){ const scale=.82+i*.27+stars*.14,tilt=(i-(A.rings.count-1)*.5)*.12;
+    _atelierSetInstance(A.rings,i,0,.08+i*.18,0,scale,scale,scale,Math.PI/2+tilt,((hash>>i*3)&3)*.035,0); }
   A.rings.instanceMatrix.needsUpdate=true; A.rods.count=LOW_END?4:5+Math.round(score*5);
-  for(let i=0;i<A.rods.count;i++){ const angle=i/A.rods.count*Math.PI*2+(hash%31)*.02,radius=1.32+stars*.28; _atelierSetInstance(A.rods,i,Math.cos(angle)*radius,.05,Math.sin(angle)*radius,1,.72+activity*.32,1,0,0,angle); }
+  for(let i=0;i<A.rods.count;i++){ const angle=i/A.rods.count*Math.PI*2+(hash%31)*.02,radius=1.32+stars*.28;
+    _atelierSetInstance(A.rods,i,Math.cos(angle)*radius,.42,Math.sin(angle)*radius,1,.52+activity*.24,1,0,0,0); }
   A.rods.instanceMatrix.needsUpdate=true;
   for(let i=0;i<A.trim.count;i++) A.trim.setColorAt(i,new THREE.Color(i%2===hash%2?zoneColor:langColor));
   A.trim.instanceColor.needsUpdate=true;
-  _drawRepositoryAtelierHistory(canonical); _drawRepositoryAtelierActions(canonical);
+  for(let i=0;i<A.architecture.count;i++){ A.color.set(i%3===0?zoneColor:langColor).multiplyScalar(i<5?.82:.68); A.architecture.setColorAt(i,A.color); }
+  A.architecture.instanceColor.needsUpdate=true;
+  for(let i=0;i<A.pathTiles.count;i++){ A.color.set(i%4===0?0xe5bc67:(i%2?zoneColor:langColor)); A.pathTiles.setColorAt(i,A.color); }
+  A.pathTiles.instanceColor.needsUpdate=true;
+  const metricSignals=[Math.min(1,Math.log1p(canonical.stars||0)/Math.log(201)),Math.min(1,Math.log1p(canonical.forks||0)/Math.log(101)),Math.min(1,activity)],
+    metricColors=[0xf0c96b,langColor,zoneColor];
+  A.metricSignals=metricSignals;
+  for(let i=0;i<3;i++){ const position=A.metricPositions[i],height=1.15+metricSignals[i]*2.55;
+    _atelierSetInstance(A.metricPillars,i,position.x,height*.5,position.z,1,height,1);
+    _atelierSetInstance(A.metricNodes,i,position.x,height+.48,position.z,.72+metricSignals[i]*.42,.72+metricSignals[i]*.42,.72+metricSignals[i]*.42,0,(hash%19)*.08+i*.5,0);
+    A.color.set(metricColors[i]); A.metricPillars.setColorAt(i,A.color); A.metricNodes.setColorAt(i,A.color); }
+  A.metricPillars.instanceMatrix.needsUpdate=true; A.metricNodes.instanceMatrix.needsUpdate=true;
+  A.metricPillars.instanceColor.needsUpdate=true; A.metricNodes.instanceColor.needsUpdate=true;
+  _drawRepositoryAtelierHistory(canonical); _drawRepositoryAtelierSignals(canonical); _drawRepositoryAtelierActions(canonical);
   A.bindings={github:canonical.repo,ask:canonical.repo,why:canonical.repo};
   atelierRepoName.textContent=canonical.repo;
+  _bindRepositoryPortalActions(canonical);
 }
 function _refreshRepositoryAtelierLanguage(){
   if(!REPOSITORY_ATELIER||!REPOSITORY_ATELIER.created||!REPOSITORY_ATELIER.repo) return;
-  _drawRepositoryAtelierHistory(REPOSITORY_ATELIER.repo); _drawRepositoryAtelierActions(REPOSITORY_ATELIER.repo);
+  _drawRepositoryAtelierHistory(REPOSITORY_ATELIER.repo); _drawRepositoryAtelierSignals(REPOSITORY_ATELIER.repo); _drawRepositoryAtelierActions(REPOSITORY_ATELIER.repo);
+  _bindRepositoryPortalActions(REPOSITORY_ATELIER.repo,true);
+  if(repositoryAtelierChatActive()) _syncRepositoryAtelierChatChrome();
+}
+function _repositoryPortalTarget(repo){
+  const parsed=parseRepoPortalInput(`${repo?._owner||currentUser}/${repo?.repo||''}`);
+  return parsed.ok&&parsed.kind==='repo'?parsed:null;
+}
+function _setRepositoryPortalStatus(key='',tone=''){
+  if(!atelierPortalStatus) return; if(REPOSITORY_ATELIER) REPOSITORY_ATELIER.portalStatus=key?{key,tone}:null;
+  atelierPortalStatus.textContent=key?t(key):''; atelierPortalStatus.dataset.tone=tone;
+}
+function _bindRepositoryPortalActions(repo,preserveStatus=false){
+  const target=_repositoryPortalTarget(repo); if(!target){ atelierPortalActions.hidden=true; return; }
+  const A=REPOSITORY_ATELIER; if(A) A.portal={slug:target.slug,url:createRepoPortalUrl(target,_postcardPublishedBase()),ownerTown:createRepoOwnerTownUrl(target,location.href,OWNER)};
+  atelierPortalActions.hidden=false; atelierPortalGithub.href=repo.url;
+  atelierPortalExplore.hidden=cityMode!=='portal'; atelierPortalExplore.textContent=tf('portalExplore',{user:target.owner});
+  if(preserveStatus&&A?.portalStatus) _setRepositoryPortalStatus(A.portalStatus.key,A.portalStatus.tone); else _setRepositoryPortalStatus();
+}
+async function _copyRepositoryPortal(){
+  const A=REPOSITORY_ATELIER,target=A&&A.repo&&_repositoryPortalTarget(A.repo); if(!target) return false;
+  let ok=false; try{ ok=await _copyPostcardText(createRepoPortalUrl(target,_postcardPublishedBase())); }catch(e){ ok=false; }
+  _setRepositoryPortalStatus(ok?'portalCopied':'portalCopyFailed',ok?'success':'error');
+  trackPortal('share_created',{entry:'atelier',device:_repoPortalDevice(),lang:LANG,result:ok?'success':'error',channel:'clipboard'});
+  if(ok) maybeStarNudge('repo_portal_share'); return ok;
+}
+function _syncRepositoryAtelierChatChrome(){
+  const A=REPOSITORY_ATELIER;if(!A||!A.repo||!A.inRoomChat) return;
+  document.body.classList.add('atelier-chat-open'); chatEl.classList.add('atelierChat');
+  if(chatHeadTtl) chatHeadTtl.textContent=`🚕 ${t('atelierChatTitle')} · ${A.repo.label}`;
+  chatText.placeholder=t('atelierChatPh');
+}
+function _openRepositoryAtelierChat(kind,repo){
+  const A=REPOSITORY_ATELIER;if(!A||A.state!=='inside'||!repo||(kind!=='ask'&&kind!=='why')) return false;
+  A.inRoomChat=true; A.roomPanel=kind; chatEl.classList.remove('hidden');
+  const npc=_taxiNpc(),question=repoSuggestedQs(repo)[0]||(LANG==='ko'?`${repo.label}는 무엇을 하는 레포예요?`:`What does ${repo.label} do?`);
+  if(kind==='why'){
+    if(busy) _queueChatAction({kind:'why',repoKey:repo.repo,npc}); else _showCardWhyZone(repo);
+  } else if(busy) _queueChatQuestion(question,npc);
+  else { openChat(npc); chatText.value=question; sendChat(); }
+  _syncRepositoryAtelierChatChrome(); setTimeout(()=>{ if(repositoryAtelierChatActive()) chatText.focus(); },60); return true;
 }
 
 function _repositoryAtelierPose(){
@@ -10367,7 +10699,7 @@ function _snapshotRepositoryAtelier(repo){
     cameraLayerMask:camera.layers.mask,camYaw,camPitch,camDist,freeLook,dragging,dragBtn,walk,
     navTarget,navVisible:navHolder.visible,navBadgeDisplay:document.getElementById('navBadge').style.display,
     sitting,ride,ferris,carousel,modalOpen,modalShown:modal.classList.contains('show'),modalKey:modal._repoKey||null,
-    chatHidden:chatEl.classList.contains('hidden'),hash:location.hash,tourPause:_pauseTourForAtelier()};
+    chatHidden:chatEl.classList.contains('hidden'),introInert:document.getElementById('intro').inert,hash:location.hash,tourPause:_pauseTourForAtelier()};
   A.snapshotId=snapshot.id; A.snapshot=snapshot; A.lastSaved=_repositoryAtelierPose();
   A.lastExterior={calls:RENDER_METRICS.latest?.total?.calls??renderer.info.render.calls,triangles:RENDER_METRICS.latest?.total?.triangles??renderer.info.render.triangles};
 }
@@ -10385,10 +10717,13 @@ function enterRepositoryAtelier(repo){
 }
 function _activateRepositoryAtelier(){
   const A=_createRepositoryAtelier(),snapshot=A.snapshot; _bindRepositoryAtelier(A.repo);
-  modal.classList.remove('show'); modalOpen=false; chatEl.classList.add('hidden'); if(document.activeElement===chatText) chatText.blur(); A.group.visible=true;
+  modal.classList.remove('show'); modalOpen=false; chatEl.classList.add('hidden'); chatEl.classList.remove('atelierChat');
+  document.body.classList.remove('atelier-chat-open'); A.inRoomChat=false; A.roomPanel=null;
+  document.getElementById('intro').inert=true;
+  if(document.activeElement===chatText) chatText.blur(); A.group.visible=true;
   document.body.classList.add('atelier-active'); atelierHud.classList.remove('hidden');
-  player.position.set(0,0,4.15); model.position.set(0,0,0); model.rotation.set(0,Math.PI,0); model.visible=snapshot.modelVisible;
-  camYaw=.1; camPitch=IS_MOBILE?.34:.38; camDist=IS_MOBILE?5.6:5.9; freeLook=false;
+  player.position.set(0,0,3.65); model.position.set(0,0,0); model.rotation.set(0,Math.PI,0); model.visible=snapshot.modelVisible;
+  camYaw=.1; camPitch=IS_MOBILE?.34:.38; camDist=IS_MOBILE?6.8:6.5; freeLook=false;
   const ox=Math.sin(camYaw)*Math.cos(camPitch)*camDist,oz=Math.cos(camYaw)*Math.cos(camPitch)*camDist,oy=Math.sin(camPitch)*camDist;
   camera.position.set(player.position.x+ox,player.position.y+oy+1.5,player.position.z+oz); camera.lookAt(player.position.x,player.position.y+1.7,player.position.z);
   camera.layers.set(REPOSITORY_ATELIER_LAYER); navHolder.visible=false; A.renderInterior=true; A.near=null; A.walk=0;
@@ -10408,7 +10743,9 @@ function _restoreRepositoryAtelier(){
   camera.position.copy(s.cameraPosition); camera.quaternion.copy(s.cameraQuaternion); camera.layers.mask=s.cameraLayerMask;
   camYaw=s.camYaw; camPitch=s.camPitch; camDist=s.camDist; freeLook=s.freeLook; dragging=false; dragBtn=s.dragBtn; walk=s.walk;
   navTarget=s.navTarget; navHolder.visible=s.navVisible; document.getElementById('navBadge').style.display=s.navBadgeDisplay;
-  document.body.classList.remove('atelier-active'); atelierHud.classList.add('hidden'); promptEl.classList.remove('show'); actBtn.classList.remove('avail'); actBtn.textContent='🚪';
+  document.body.classList.remove('atelier-active','atelier-chat-open'); chatEl.classList.remove('atelierChat'); A.inRoomChat=false; A.roomPanel=null;
+  document.getElementById('intro').inert=s.introInert;
+  atelierHud.classList.add('hidden'); promptEl.classList.remove('show'); actBtn.classList.remove('avail'); actBtn.textContent='🚪';
   if(!A.afterExit&&!A.pendingHash){ modalOpen=s.modalOpen; modal.classList.toggle('show',s.modalShown); modal._repoKey=s.modalKey;
     chatEl.classList.toggle('hidden',s.chatHidden);
     const target=location.pathname+location.search+(s.hash||''); if(location.pathname+location.search+location.hash!==target) history.replaceState(null,'',target);
@@ -10430,6 +10767,10 @@ function _repositoryAtelierTransition(dt){
       if(A.t>=REPOSITORY_ATELIER_FADE){ _activateRepositoryAtelier(); A.phase='reveal'; A.t=0; atelierFade.style.opacity='1'; } return A.renderInterior?'interior':'exterior'; }
     atelierFade.style.opacity=String(Math.max(0,1-A.t/REPOSITORY_ATELIER_FADE));
     if(A.t>=REPOSITORY_ATELIER_FADE){ A.state='inside'; A.phase=null; A.t=0; atelierFade.style.opacity='0'; atelierFade.classList.remove('blocking');
+      if(repoPortalRequested&&!A.ahaTracked){ A.ahaTracked=true;
+        trackPortal('aha_completed',{entry:'link',device:_repoPortalDevice(),lang:LANG,result:repoPortalResult?.result||'local',
+          latency:repoPortalLatencyBucket((typeof performance!=='undefined'?performance.now():Date.now())-repoPortalStartedAt)});
+        maybeStarNudge('repo_portal_aha'); }
       if(A.pendingExit){ A.pendingExit=false; exitRepositoryAtelier(); } } return 'interior';
   }
   if(A.phase==='cover'){ atelierFade.style.opacity=String(Math.min(1,A.t/REPOSITORY_ATELIER_FADE));
@@ -10440,15 +10781,17 @@ function _repositoryAtelierTransition(dt){
     if(pendingHash&&tour&&tour.active) endTour(false); else _resumeTourAfterAtelier(pausedTour);
     if(pendingHash){ A.afterExit=null; const key=repoHashKey(),repo=repoByKey(key); if(repo) openCard(repo); else { modalOpen=false; modal.classList.remove('show'); modal._repoKey=null; } }
     _runRepositoryAtelierAfterExit();
+    flushStarNudge();
     if(typeof _drainQueuedChat==='function'&&!_drainQueuedChat()&&typeof _resumePendingChatNpc==='function') _resumePendingChatNpc(); }
   return 'exterior';
 }
 function _updateRepositoryAtelierAvatar(dt,moving){
   const A=REPOSITORY_ATELIER; A.walk=moving?A.walk+dt*10:A.walk*.82;
-  A.avatar.position.set(player.position.x,Math.abs(Math.sin(A.walk))*(moving?.09:0),player.position.z); A.avatar.rotation.y=model.rotation.y;
-  const swing=moving?Math.sin(A.walk)*.55:0,positions=[[-.2,.52,0,swing],[.2,.52,0,-swing],[-.42,1.24,0,-swing], [.42,1.24,0,swing]];
-  positions.forEach((v,i)=>_atelierSetInstance(A.avatarLimbs,i,v[0],v[1],v[2],1,1,1,v[3],0,0));
-  A.avatarLimbs.instanceMatrix.needsUpdate=true;
+  const bob=Math.abs(Math.sin(A.walk))*(moving?.09:0),swing=moving?Math.sin(A.walk)*.5:0;
+  A.avatar.position.set(player.position.x,bob,player.position.z); A.avatar.rotation.y=model.rotation.y;
+  if(A.avatarLegL) A.avatarLegL.rotation.x=swing; if(A.avatarLegR) A.avatarLegR.rotation.x=-swing;
+  if(A.avatarArmL) A.avatarArmL.rotation.x=-swing; if(A.avatarArmR) A.avatarArmR.rotation.x=swing;
+  A.avatarShadow.position.set(player.position.x,.025,player.position.z);
 }
 function _updateRepositoryAtelierTerminalHighlight(index){
   const A=REPOSITORY_ATELIER;if(A.highlight===index) return; A.highlight=index;
@@ -10501,23 +10844,31 @@ function _performRepositoryAtelierAction(kind){
   if(kind==='exit') return exitRepositoryAtelier();
   if(kind!=='github'&&kind!=='ask'&&kind!=='why') return false;
   A.lastAction={kind,repo:repo.repo}; track('atelier_terminal',{repo:repo.repo,kind});
-  if(kind==='github'){ const opened=window.open(repo.url,'_blank','noopener'); if(opened) opened.opener=null; return true; }
-  if(kind==='ask'||kind==='why') return exitRepositoryAtelier({kind,repoKey:repo.repo});
+  if(kind==='github'){ trackPortal('github_repo_opened',{entry:'terminal',device:_repoPortalDevice(),lang:LANG,channel:'github'});
+    const opened=window.open(repo.url,'_blank','noopener'); if(opened) opened.opener=null; return true; }
+  if(kind==='ask'||kind==='why') return _openRepositoryAtelierChat(kind,repo);
   return false;
 }
 function repositoryAtelierAct(){ const near=REPOSITORY_ATELIER&&REPOSITORY_ATELIER.near; return near?_performRepositoryAtelierAction(near.kind):false; }
 function _repositoryAtelierContextRestored(){ const A=REPOSITORY_ATELIER;if(!A||!A.created) return; A.contextRestores++; A.resources.textures.forEach(texture=>{ texture.needsUpdate=true; }); }
 atelierExit.addEventListener('click',event=>{ event.stopPropagation(); exitRepositoryAtelier(); });
+atelierPortalCopy.addEventListener('click',event=>{ event.stopPropagation(); _copyRepositoryPortal(); });
+atelierPortalGithub.addEventListener('click',()=>trackPortal('github_repo_opened',{entry:'atelier',device:_repoPortalDevice(),lang:LANG,channel:'github'}));
+atelierPortalExplore.addEventListener('click',event=>{ event.stopPropagation(); const A=REPOSITORY_ATELIER,target=A&&A.repo&&_repositoryPortalTarget(A.repo);
+  if(target) location.href=createRepoOwnerTownUrl(target,location.href,OWNER); });
 
 function _repositoryAtelierDebug(){
   const A=REPOSITORY_ATELIER;if(!A) return {state:'outside',created:false};
   const interior=A.lastInterior||{calls:0,triangles:0},peak=A.peakInterior||interior;
   return {state:A.state,phase:A.phase,activeRepo:A.repo&&A.repo.repo||null,lastRepo:A.lastRepo,created:A.created,createCount:A.createCount,bindCount:A.bindCount,restoreCount:A.restoreCount,
     layers:{camera:camera.layers.mask,atelier:1<<REPOSITORY_ATELIER_LAYER,interior:A.renderInterior,roomVisible:!!A.group?.visible},
-    resources:{rooms:A.created?1:0,geometries:A.resources.geometries.size,materials:A.resources.materials.size,canvasTextures:A.resources.textures.size},
+    resources:{rooms:A.created?1:0,geometries:A.resources.geometries.size,materials:A.resources.materials.size,canvasTextures:A.resources.textures.size,
+      sharedAvatarDraws:A.avatarDraws||0,exhibitBatches:A.created?5:0},
     render:{calls:interior.calls,triangles:interior.triangles,peakCalls:peak.calls,peakTriangles:peak.triangles,exteriorCalls:A.renderInterior?0:null},
     style:A.created?{roomId:A.group.uuid.slice(0,8),seed:A.hash,shape:A.hash%3,language:A.materials.core.color.getHexString(),district:A.materials.ring.color.getHexString()}:null,
-    bindings:A.bindings||null,near:A.near&&A.near.kind||null,lastAction:A.lastAction,saved:A.lastSaved,restored:A.lastRestored,
+    bindings:A.bindings||null,portal:A.portal||null,near:A.near&&A.near.kind||null,lastAction:A.lastAction,inRoomChat:!!A.inRoomChat,roomPanel:A.roomPanel,
+    exhibits:A.created?{architecture:A.architecture.count,path:A.pathTiles.count,signals:A.metricSignals||[],signalCards:A.textLayout?.signalCards||0}:null,
+    saved:A.lastSaved,restored:A.lastRestored,
     text:A.textLayout||null,paused:{exterior:repositoryAtelierActive(),realtimeSocket:rtSock?rtSock.readyState:-1},contextRestores:A.contextRestores};
 }
 if(_DIAGNOSTICS){

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@
 - [scholars.js](scholars.js): POLARIS, VEGA, RIGEL, MIRA, and LYRA scholar roster.
 - [assets/world-tree/createRepolisHero.js](assets/world-tree/createRepolisHero.js): procedural World Tree factory.
 - [assets/town-growth.js](assets/town-growth.js): deterministic repository creation timeline, year snapshots, and Growth Replay share links.
+- [assets/repo-portal.js](assets/repo-portal.js): strict GitHub target parser, public repo projection, route precedence, and canonical Repo Portal links.
 - [assets/contribution-library.json](assets/contribution-library.json): generated bilingual Contribution Library data.
 
 ## Main product systems
@@ -27,6 +28,8 @@
 - Metric-shaped repository houses and deterministic topic districts with hubs, boards, and a world map.
 - Explorer Passport, district progress, the daily resident→haunt→repo/district Village Chronicle, Repository Constellation Trail, and Maintainers' Night Watch for recently tended low-star repos.
 - Town Growth Replay: repo houses rise through truthful public creation years, with a reversible year link and era postcard; building metrics remain explicitly current.
+- Repo Portal: `?repo=owner/repo&ref=repo-portal` loads one public target before the owner catalog, opens its Atelier, and never invents traffic.
+- Repository Atelier: one walkable room rebinds current repo history, impact signals, metric artifacts, current chibi avatar, and in-room Gitber/Why actions without rendering the exterior.
 - Local Town Gazette: added/removed repos, releases, pushes, and positive metric deltas since the last marked-read snapshot.
 - Named residents with individually styled Starlight Row cottages, resident-coloured gardens, a shared flower commons, perimeter trees, home/work commutes, moods, friendships, Shared Joy, conversations, festivals, and specialist handoffs.
 - Gitber/POLARIS taxi: keyless Local search by default; optional WebLLM and grounded AI.

--- a/repolis.yaml
+++ b/repolis.yaml
@@ -45,6 +45,7 @@ entrypoints:
   scholars: scholars.js
   world_tree: assets/world-tree/createRepolisHero.js
   town_growth: assets/town-growth.js
+  repo_portal: assets/repo-portal.js
   data_builder: scripts/build_repos.py
   launch_config: repolis.config.js
   library_builder: scripts/build-contribution-library.mjs
@@ -102,6 +103,13 @@ features:
     summary: Explorer Passport, district progress, daily Village Chronicle, and Repository Constellation Trail.
   - id: town-growth-replay
     summary: Public repo creation dates raise existing houses through a reversible, shareable year timeline without inventing historical metrics or adding render assets.
+  - id: repo-portal
+    summary: A canonical owner/repo link loads one public target before the owner catalog, opens its Atelier, and keeps unavailable traffic unknown.
+    url: "?repo=<owner>/<repo>&ref=repo-portal"
+    cache: "15 minutes, 30 entries, 512 KiB LRU"
+    cold_github_requests_before_aha: 1
+  - id: repository-atelier
+    summary: One reusable walkable exhibition rebinds repo history, current impact signals, the current chibi avatar, and in-room Gitber/district actions while restoring the exterior exactly.
   - id: village-chronicle
     summary: A deterministic town/day story connects one resident to their cherished haunt and a related repo or district.
   - id: town-gazette

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -39,12 +39,30 @@ import {
 import { createTwinTownLink, createTwinTownMatch, summarizeTwinTown } from '../assets/twin-towns.js';
 import { selectTownCreatorFields, summarizeTownCreator } from '../assets/town-creator.js';
 import { buildTownGrowthTimeline, createTownGrowthShareUrl, townGrowthIndexForYear, townGrowthSnapshot } from '../assets/town-growth.js';
+import {
+  REPO_PORTAL_LIMITS,
+  createRepoOwnerTownUrl,
+  createRepoPortalUrl,
+  parseRepoPortalInput,
+  projectPublicRepo,
+  projectPublicRepos,
+  repoPortalLatencyBucket,
+  resolveRepoPortalRequest
+} from '../assets/repo-portal.js';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const HTML = readFileSync(join(ROOT, 'index.html'), 'utf8');
 const README_EN = readFileSync(join(ROOT, 'README.md'), 'utf8');
 const README_KO = readFileSync(join(ROOT, 'README.ko.md'), 'utf8');
+const AGENTS_GUIDE = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8');
+const CHANGELOG = readFileSync(join(ROOT, 'CHANGELOG.md'), 'utf8');
+const DOMAIN_MODEL = readFileSync(join(ROOT, 'docs/domain-model.md'), 'utf8');
+const KNOWN_LIMITATIONS = readFileSync(join(ROOT, 'docs/known-limitations.md'), 'utf8');
+const REPO_PORTAL_GUIDE = readFileSync(join(ROOT, 'docs/repo-portal-change-guide.md'), 'utf8');
+const SHARE_LINKS = readFileSync(join(ROOT, 'examples/share-links.md'), 'utf8');
+const MANIFEST = readFileSync(join(ROOT, 'repolis.yaml'), 'utf8');
+const LLMS_INDEX = readFileSync(join(ROOT, 'llms.txt'), 'utf8');
 const DEMO_EN = readFileSync(join(ROOT, 'assets/demo.gif'));
 const DEMO_KO = readFileSync(join(ROOT, 'assets/demo.ko.gif'));
 const LAUNCH_GIF_EN = readFileSync(join(ROOT, 'assets/launch.gif'));
@@ -61,6 +79,7 @@ const PUBLIC_TOWN_PROOF_SRC = readFileSync(join(ROOT, 'assets/public-town-proof.
 const TWIN_TOWNS_SRC = readFileSync(join(ROOT, 'assets/twin-towns.js'), 'utf8');
 const TOWN_CREATOR_SRC = readFileSync(join(ROOT, 'assets/town-creator.js'), 'utf8');
 const TOWN_GROWTH_SRC = readFileSync(join(ROOT, 'assets/town-growth.js'), 'utf8');
+const REPO_PORTAL_SRC = readFileSync(join(ROOT, 'assets/repo-portal.js'), 'utf8');
 
 let pass = 0, fail = 0; const fails = [];
 function ok(cond, msg) { if (cond) { pass++; } else { fail++; fails.push(msg); console.log('  ✗ ' + msg); } }
@@ -131,7 +150,8 @@ ok(/border\s*:\s*2px/i.test(introTour), '#introTour keeps a visible 2px border')
 
 group('Launch Kit — personal preview + fork-safe runtime + PAT-optional refresh');
 ok(/id="introLaunchForm"/.test(HTML) && /id="introUser"/.test(HTML) && /data-i18n="introLaunchGo"/.test(HTML), 'intro contains the bilingual username launchpad');
-ok(/form\.onsubmit=e=>[\s\S]*?GH_LOGIN_RE\.test\(user\)[\s\S]*?\?user='\+encodeURIComponent\(user\)/.test(HTML), 'launchpad validates a GitHub login and reuses the established public-town URL');
+ok(/form\.onsubmit=e=>[\s\S]*?parseRepoPortalInput\(input\.value\)[\s\S]*?target\.kind==='repo'[\s\S]*?createRepoPortalUrl\(target,location\.href\)[\s\S]*?\?user='\+encodeURIComponent\(user\)/.test(HTML),
+  'launchpad resolves usernames and repo targets while preserving the established public-town URL');
 ok(/new URLSearchParams\(location\.search\)\.has\('launch'\)/.test(HTML), '?launch=1 focuses the personal preview field');
 ok((HTML.match(/introLaunchLabel:/g)||[]).length===2 && (HTML.match(/introLaunchInvalid:/g)||[]).length===2, 'launchpad labels and errors are bilingual');
 const townProof = summarizePublicTown('Octo-Cat', [
@@ -168,7 +188,7 @@ ok(/introProfileStatus\.textContent=introProfileResult\?t\(introProfileResult\.k
 ok(/\.introProofActions \{[^}]*display: flex[^}]*flex-wrap: wrap/.test(HTML)
   && /\.introProofActions button \{[^}]*flex: 1 1 150px[^}]*min-height: 44px/.test(HTML), 'the ready-state actions stay stable, touch-sized, and wrap instead of overflowing on mobile');
 ok(/document\.getElementById\('startBtn'\)\.onclick=[\s\S]*?showWave\(tf\('arrived',\{user:currentUser\}\),3600\)/.test(HTML)
-  && /if\(!rb\) setTimeout\(\(\)=>\{ try\{ showWave\(tf\('arrived'/.test(HTML)
+  && /if\(!rb&&!_reqFocus\) setTimeout\(\(\)=>\{ try\{ showWave\(tf\('arrived'/.test(HTML)
   && (HTML.match(/showWave\(tf\('arrived',\{user:currentUser\}\),3600\)/g)||[]).length===1,
   'a public-town arrival toast waits for actual entry and cannot cover the first-screen proof');
 ok(/Put this town on my GitHub profile/.test(README_EN) && /GitHub 프로필에 마을 붙이기/.test(README_KO), 'EN/KO adoption tables surface the same profile portal at the moment the preview is ready');
@@ -204,6 +224,172 @@ ok(/GTM_DIR=data\/towns\/\$REPO_OWNER/.test(REFRESH_WORKFLOW)
 ok(/\/users\/\{OWNER\}\/repos\?per_page=100&type=owner/.test(REPO_BUILDER)
   &&/Public owner endpoint works with the built-in Actions token/.test(REPO_BUILDER), 'builder lists public owner repos without requiring an authenticated user endpoint');
 ok(/Path\("data"\) \/ "towns" \/ OWNER/.test(REPO_BUILDER), 'manual non-upstream builds default to an owner-scoped traffic root');
+
+group('Repo Portal — one repository becomes the first shareable destination');
+const portalUser=parseRepoPortalInput('@Octo-Cat');
+const portalSlug=parseRepoPortalInput('Octo-Cat/hello-world.git/');
+const portalUrl=parseRepoPortalInput('https://github.com/Octo-Cat/hello-world.git/');
+const portalBareUrl=parseRepoPortalInput('github.com/Octo-Cat/hello-world');
+ok(portalUser.ok&&portalUser.kind==='user'&&portalUser.user==='Octo-Cat', 'parser keeps the established username grammar');
+ok(portalSlug.ok&&portalSlug.kind==='repo'&&portalSlug.slug==='Octo-Cat/hello-world'
+  && portalUrl.ok&&portalUrl.slug===portalSlug.slug&&portalBareUrl.ok&&portalBareUrl.slug===portalSlug.slug,
+  'owner/repo, GitHub root URLs, trailing slashes, and .git normalize to one target');
+[
+  'https://gitlab.com/octo/repo',
+  'https://github.com/octo/repo/issues',
+  'https://github.com/octo/repo?tab=readme',
+  'octo/../repo',
+  'octo/%2e%2e/repo',
+  'octo/repo?user=other',
+  'octo/repo\u0000',
+  'octo/repo/extra'
+].forEach(value=>ok(!parseRepoPortalInput(value).ok,`unsafe or non-root target fails closed: ${JSON.stringify(value)}`));
+const portalCanonical=createRepoPortalUrl(portalSlug,'https://example.test/Repolis/?user=other&twin=friend&growth=2020#repo=old');
+ok(portalCanonical==='https://example.test/Repolis/?repo=Octo-Cat/hello-world&ref=repo-portal',
+  'canonical Portal URL strips town, twin, growth, and hash state without hiding the owner/repo slash');
+ok(createRepoOwnerTownUrl(portalSlug,'https://example.test/Repolis/?repo=old','owner')
+    ==='https://example.test/Repolis/?user=Octo-Cat&focus=hello-world&ref=repo-portal'
+  && createRepoOwnerTownUrl('owner/repo','https://example.test/Repolis/','owner')
+    ==='https://example.test/Repolis/?focus=repo&ref=repo-portal',
+  'explicit expansion keeps the target focus and omits a redundant owner query');
+const portalWins=resolveRepoPortalRequest('?user=someone-else&repo=Octo-Cat/hello-world&twin=x&growth=2020','owner');
+const portalFocus=resolveRepoPortalRequest('?user=Octo-Cat&focus=hello-world&ref=repo-portal','owner');
+const portalBad=resolveRepoPortalRequest('?repo=Octo-Cat/../secret&user=someone','owner');
+const publicAtUser=resolveRepoPortalRequest('?user=@Octo-Cat','owner');
+ok(portalWins.mode==='portal'&&portalWins.repoWins&&portalWins.target.slug==='Octo-Cat/hello-world',
+  'repo is the single source of truth when user and legacy feature parameters conflict');
+ok(portalFocus.mode==='public'&&portalFocus.focus?.slug==='Octo-Cat/hello-world',
+  'owner-town expansion carries one validated repo focus without staying in target-first mode');
+ok(portalBad.mode==='portal'&&!portalBad.target&&!!portalBad.error, 'an invalid repo query stays an explicit Portal error instead of falling through to user mode');
+ok(publicAtUser.mode==='public'&&/const _reqUser = \(_QUERY\.get\('user'\) \|\| ''\)\.trim\(\)\.replace\(\/\^@\+\/,''\)/.test(HTML),
+  'an @-prefixed public-town query uses the same cleaned username for routing and the GitHub fetch');
+
+const portalRaw={
+  name:'hello-world',full_name:'Octo-Cat/hello-world',owner:{login:'Octo-Cat'},private:false,disabled:false,
+  description:'A public fixture',language:'JavaScript',topics:['demo','threejs'],homepage:'https://example.test/',
+  stargazers_count:12,forks_count:3,fork:false,size:44,open_issues_count:2,license:{spdx_id:'MIT'},
+  archived:false,default_branch:'main',created_at:'2020-01-02T00:00:00Z',pushed_at:'2026-08-19T00:00:00Z',
+  updated_at:'2026-08-19T00:00:00Z',email:'private@example.test',subscribers_count:999,watchers_count:999
+};
+const portalProjection=projectPublicRepo(portalRaw,'Octo-Cat',Date.parse('2026-08-20T00:00:00Z'));
+ok(portalProjection.repo==='hello-world'&&portalProjection.stars===12&&portalProjection.forks===3
+  &&portalProjection.trafficKnown===false&&portalProjection.visitors===null&&portalProjection.views===null&&portalProjection.clones===null,
+  'public projection keeps GitHub facts and represents unavailable traffic as unknown, never synthetic zero');
+ok(!('email' in portalProjection)&&!('subscribers_count' in portalProjection)&&!('watchers_count' in portalProjection)
+  &&projectPublicRepo({...portalRaw,private:true},'Octo-Cat')===null
+  &&projectPublicRepo({...portalRaw,owner:{login:'Other'}},'Octo-Cat')===null,
+  'projection allowlists rendered fields and rejects private or owner-mismatched responses');
+const portalRanked=projectPublicRepos([
+  {...portalRaw,name:'quiet',full_name:'Octo-Cat/quiet',stargazers_count:0,forks_count:0},
+  portalRaw
+],'Octo-Cat',Date.parse('2026-08-20T00:00:00Z'));
+ok(portalRanked.map(repo=>repo.repo).join(',')==='hello-world,quiet'&&portalRanked[0].rank===0&&portalRanked[1].rank===1,
+  'public projection ranks the same allowlisted signals deterministically');
+ok(repoPortalLatencyBucket(999)==='under-1s'&&repoPortalLatencyBucket(1000)==='1-3s'
+  &&repoPortalLatencyBucket(3000)==='3-10s'&&repoPortalLatencyBucket(10000)==='10s-plus',
+  'funnel latency uses four coarse buckets rather than exact request timing');
+
+const portalLoader=(HTML.match(/let _ownerSnapshotPromise=null;[\s\S]*?(?=\ntrack\('page_load'\);)/)||[''])[0];
+const portalTargetLoader=(portalLoader.match(/async function _loadRepoPortalTarget\(target\)\{[\s\S]*?\n\}/)||[''])[0];
+ok(/from '\.\/assets\/repo-portal\.js\?v=repo-portal-v1'/.test(HTML)&&REPO_PORTAL_SRC.length<30*1024,
+  'the zero-build runtime imports one small dedicated Portal module');
+ok(!/document|window|localStorage|sessionStorage|fetch\(|Math\.random|THREE/.test(REPO_PORTAL_SRC),
+  'parser, canonicalizer, projection, and link builders stay pure and browser-independent');
+ok(REPO_PORTAL_LIMITS.cacheTtlMs===15*60*1000&&REPO_PORTAL_LIMITS.cacheMaxBytes===512*1024&&REPO_PORTAL_LIMITS.cacheMaxEntries===30,
+  'public repo cache is fixed at 15 minutes, 512 KiB, and 30 LRU entries');
+ok(/_ownerRepos\(await _ownerSnapshot\(\)\)\.find/.test(portalTargetLoader)
+  &&portalTargetLoader.indexOf('_ownerSnapshot')<portalTargetLoader.indexOf('_repoPortalCacheLookup')
+  &&portalTargetLoader.indexOf('_repoPortalCacheLookup')<portalTargetLoader.indexOf("fetch('https://api.github.com/repos/"),
+  'target loading checks the local owner snapshot, then fresh cache, then one exact repo endpoint');
+ok((portalTargetLoader.match(/fetch\(/g)||[]).length===1
+  &&/if\(!res\.ok\)\{[\s\S]*?if\(cached\.stale\) return \{repo:cached\.stale,source:'repo-stale-cache',result:'stale'\}/.test(portalTargetLoader)
+  &&!/retry|setTimeout/.test(portalTargetLoader),
+  'the target path makes one GitHub request, never retries 403/429, and labels stale recovery');
+ok(/while\(bytes>REPO_PORTAL_LIMITS\.cacheMaxBytes&&cache\.order\.length>1\)/.test(portalLoader)
+  &&/cache\.order=\[key,\.\.\.cache\.order\.filter/.test(portalLoader)
+  &&/slice\(0,REPO_PORTAL_LIMITS\.cacheMaxEntries\)/.test(portalLoader),
+  'cache writes enforce byte and entry bounds while touching the latest target first');
+ok(/if\(!repoPortalTarget\) repoPortalResult=\{repo:null/.test(HTML)
+  &&/else repoPortalResult=await _loadRepoPortalTarget\(repoPortalTarget\)/.test(HTML),
+  'invalid repo queries perform no GitHub target request');
+ok(/if\(repoPortalResult\.repo\)\{ REPOS=\[repoPortalResult\.repo\]/.test(HTML)
+  &&/repoPortalFallback=true;[\s\S]*?REPOS=_ownerRepos\(await _ownerSnapshot\(\)\); cityMode='owner'/.test(HTML),
+  'success builds one target first while failure preserves the existing owner town');
+ok(/return projectPublicRepos\(raw,user,Date\.now\(\)\)/.test(HTML)
+  &&!/derived "liveliness"|derived → yard size|never a real clone count/.test(HTML)
+  &&/if\(repo\.trafficKnown===false\)\{[\s\S]*?starSignal[\s\S]*?forkSignal/.test(HTML),
+  'all public towns share truthful unknown traffic and map only stars, forks, and recency to architecture');
+ok(/REPOS\.every\(repo=>repo\.trafficKnown===false\)[\s\S]*?publicTrafficUnavailable/.test(HTML)
+  &&/repo\.trafficKnown===false\?`★\$\{repo\.stars\}/.test(HTML),
+  'search answers and repo facts never print unavailable traffic as observed zero');
+ok(/const freshnessTrackable=cityMode!=='portal'&&REPOS\.length>0&&!cityError/.test(HTML)
+  &&/if\(cityMode==='portal'\)\{ course=\{date,town,v:COURSE_V,items:\[\],completed:\[\],rewarded:false,available:false\}; return course; \}/.test(HTML),
+  'target-only visits cannot overwrite the owner Town Gazette baseline or Village Chronicle progress');
+
+ok(/id="introUser"[\s\S]*?maxlength="320"/.test(HTML)&&/id="stationInput"[\s\S]*?maxlength="320"/.test(HTML)
+  &&/data-i18n-aria="repoTargetAria"/.test(HTML),
+  'intro and Station accept the full target grammar through labelled bounded text fields');
+ok(/target=parseRepoPortalInput\(input\.value\)/.test(HTML)
+  &&/const target=parseRepoPortalInput\(String\(value\|\|''\)\)/.test(HTML)
+  &&/createRepoPortalUrl\(target,location\.href\)/.test(HTML),
+  'both entry surfaces use the same strict resolver and canonical link builder');
+ok(/const portalRepo=cityMode==='portal'[\s\S]*?introPortalReady[\s\S]*?introPortalStats/.test(HTML)
+  &&/introProofActions\.hidden=portalReady/.test(HTML)&&/introTourBtn\.hidden=portalReady/.test(HTML),
+  'a loaded target replaces generic actions with one concise repo proof and one exhibition CTA');
+ok(/if\(cityMode==='portal'&&repoPortalTarget\)[\s\S]*?enterRepositoryAtelier\(repo\)/.test(HTML)
+  &&/else if\(_reqFocus\)[\s\S]*?enterRepositoryAtelier\(repo\)/.test(HTML),
+  'shared targets and expanded owner towns arrive at the exact Atelier after one entry click');
+ok(/if\(!rb&&!_reqFocus\) setTimeout\(\(\)=>\{ try\{ showWave\(tf\('arrived'/.test(HTML)
+  &&/if\(cityMode!=='portal'&&!_reqFocus&&REPOS\.length\)/.test(HTML),
+  'target arrivals suppress the generic public-town toast, Gazette, and Chronicle until after the focused Aha');
+ok(/id="atelierPortalActions" hidden role="group"[\s\S]*?id="atelierPortalCopy"[\s\S]*?id="atelierPortalGithub"[\s\S]*?id="atelierPortalExplore"/.test(HTML)
+  &&/#atelierPortalActions button, #atelierPortalActions a \{[\s\S]*?min-height:40px/.test(HTML)
+  &&/@media \(max-width: 520px\)[\s\S]*?#atelierPortalActions button, #atelierPortalActions a \{[^}]*min-height:44px/.test(HTML),
+  'Atelier exposes copy, GitHub, and full-town actions with desktop and mobile touch targets');
+ok(/createRepoOwnerTownUrl\(target,location\.href,OWNER\)/.test(HTML)
+  &&/_copyPostcardText\(createRepoPortalUrl\(target,_postcardPublishedBase\(\)\)\)/.test(HTML),
+  'Atelier can copy the canonical address or explicitly expand into the existing owner-town loader');
+ok(/if\(cityMode==='portal'&&repoPortalTarget\) return createRepoPortalUrl\(repoPortalTarget,base\)/.test(HTML),
+  'Postcard copy-link keeps the canonical target without composing postcard, growth, or twin state');
+ok(/atelierPortalExplore\.hidden=cityMode!=='portal'/.test(HTML)
+  &&/#atelierPortalActions \[hidden\] \{ display:none; \}/.test(HTML),
+  'full owner towns hide the now-redundant expansion action while keeping copy and GitHub');
+['introSubPortal','introPortalReady','introPortalStats','enterRepoPortal','portalSourceLocal','portalSourceApi',
+  'portalSourceCache','portalSourceStale','repoTargetAria','modePortalLabel','repoPortalOf','trainDepartRepo',
+  'fetchingRepo','portalInvalidTitle','portalInvalidMsg','portalNotFoundMsg','portalRateMsg','portalNetMsg',
+  'portalContinue','portalActionsAria','portalCopy','portalCopied','portalCopyFailed','portalExplore',
+  'atelierTrafficUnavailable','publicTrafficUnavailable']
+  .forEach(key=>ok((HTML.match(new RegExp(key+":[\\\"']",'g'))||[]).length===2,`Repo Portal key ${key} is bilingual`));
+ok(/id="introPublicProof" hidden role="status" aria-live="polite"/.test(HTML)
+  &&/id="introLaunchErr" role="alert"/.test(HTML)
+  &&/id="atelierPortalStatus" role="status" aria-live="polite" aria-atomic="true"/.test(HTML),
+  'loading proof, validation errors, and copy results use accessible live semantics');
+ok(/#intro \.langsel button\.active \{[^}]*color: #7a3f12/.test(HTML)
+  &&/#startBtn \{[^}]*color: #7a3f12/.test(HTML),
+  'active language and primary entry text retain AA contrast on white');
+ok(/const allowed=new Set\(\['ev','sessionId','ts','entry','device','lang','result','latency','channel'\]\)/.test(HTML)
+  &&/\['cityUser','targetUser','user','repo','owner','url','query','input','instanceId'\]/.test(HTML),
+  'Portal events remove identities, URLs, raw input, query text, and persistent instance IDs');
+['feature_seen','feature_started','aha_completed','share_created','github_repo_opened','project_star_click']
+  .forEach(event=>ok(HTML.includes(`'${event}'`),`privacy-safe Repo Portal event ${event} is instrumented`));
+ok(/repoPortalRequested&&!A\.ahaTracked[\s\S]*?trackPortal\('aha_completed'/.test(HTML)
+  &&/maybeStarNudge\('repo_portal_aha'\)/.test(HTML)&&/maybeStarNudge\('repo_portal_share'\)/.test(HTML),
+  'Aha fires only after the target room is inside, then reuses the earned Star invitation after exit or share');
+ok(/#atelierPortalActions \{[\s\S]*?pointer-events:auto/.test(HTML)
+  &&/#atelierPortalActions\[hidden\] \{ display:none; \}/.test(HTML)
+  &&/body\.atelier-chat-open #atelierPortalActions \{ display:none !important; \}/.test(HTML),
+  'Portal actions remain operable without overlapping the in-room chat');
+ok(/A repository can be the front door/.test(README_EN)&&/레포 하나가 입구가 됩니다/.test(README_KO)
+  &&/repo=mrdoob\/three\.js&ref=repo-portal/.test(SHARE_LINKS),
+  'EN/KO product docs and copy-ready examples expose the same repository-first loop');
+ok(/This is the product change most likely to improve Star acquisition/.test(REPO_PORTAL_GUIDE)
+  &&/trafficKnown: false/.test(REPO_PORTAL_GUIDE)&&/512 KiB/.test(REPO_PORTAL_GUIDE)
+  &&/These events may include only/.test(REPO_PORTAL_GUIDE),
+  'the change guide records the Star rationale, URL/data/cache boundary, and privacy allowlist');
+ok(/## 11\. Repo Portal/.test(DOMAIN_MODEL)&&/Public API modes do not have traffic/.test(KNOWN_LIMITATIONS)
+  &&/assets\/repo-portal\.js/.test(AGENTS_GUIDE)&&/id: repo-portal/.test(MANIFEST)
+  &&/Repo Portal: `\?repo=owner\/repo/.test(LLMS_INDEX)&&/\[1\.87\.0\]/.test(CHANGELOG),
+  'domain, limitations, agent guide, manifest, LLM index, and changelog stay in sync');
 
 group('Twin Towns — recipient-specific, reversible public-town referrals');
 const twinLeft = [
@@ -245,8 +431,9 @@ ok(/id="twinModal" role="dialog" aria-modal="true" aria-labelledby="twinTitle" a
   && /id="twinResult" hidden aria-live="polite" aria-atomic="true"/.test(HTML), 'comparison state is exposed as a labelled modal with polite live results');
 ok(/id="introCompare" type="button" data-i18n="introCompare"/.test(HTML)
   && /id="twinMenuBtn" type="button"/.test(HTML), 'Twin Towns is discoverable after personal proof and from the in-city menu');
-ok(/const _reqTwin = \(new URLSearchParams\(location\.search\)\.get\('twin'\)/.test(HTML)
-  && /setTimeout\(\(\)=>openTwinTowns\('link',_reqTwin\),120\)/.test(twinBlock), 'a shared twin parameter opens the recipient-specific comparison automatically');
+ok(/const _reqTwin = \(_QUERY\.get\('twin'\)/.test(HTML)
+  && /cityMode!=='portal'[\s\S]*?setTimeout\(\(\)=>openTwinTowns\('link',_reqTwin\),120\)/.test(twinBlock),
+  'a shared twin parameter opens its comparison automatically unless a repo target owns the route');
 ok(/const currentLoad=cityMode==='owner'\?_loadPublicCity\(currentUser\)/.test(twinBlock)
   && /Promise\.all\(\[currentLoad,_loadPublicCity\(user\)\]\)/.test(twinBlock)
   && /createTwinTownMatch\(currentUser,leftRepos,user,loaded\.repos\)/.test(twinBlock)
@@ -480,7 +667,7 @@ ok(/Your repository history becomes a moving city story/.test(README_EN)
 const runtimeLocalFiles = [
   'index.html','repolis.config.js','scholars.js','repos.json','assets/contribution-library.json',
   'assets/world-tree/createRepolisHero.js','assets/camera-obstruction.js','assets/canal-ferry.js',
-  'assets/public-town-proof.js','assets/rain-garden.js','assets/town-postcard.js','assets/twin-towns.js','assets/town-creator.js','assets/town-growth.js',
+  'assets/public-town-proof.js','assets/rain-garden.js','assets/town-postcard.js','assets/twin-towns.js','assets/town-creator.js','assets/town-growth.js','assets/repo-portal.js',
   'council/council.config.json','council/engine.js','council/fixtures.js','council/guards.js','council/live.js'
 ];
 const runtimeLocalBytes = runtimeLocalFiles.reduce((sum,file)=>sum+readFileSync(join(ROOT,file)).length,0);
@@ -492,7 +679,7 @@ ok((HTML.match(/starNudge:'/g)||[]).length===2 && (HTML.match(/starNudgeGo:'/g)|
 ok(/if\(passport\.repos\.length>=3\) maybeStarNudge\('repos_visited'\)/.test(HTML)
   &&/if\(cityMode==='public'\)\{[\s\S]*?maybeStarNudge\('personal_town'\)/.test(HTML), 'the invitation is earned: three explored repo houses, or time spent in a self-built town');
 ok(/if\(_starNudgeShown\|\|_starNudgeSeen\(\)\) return false/.test(HTML)
-  &&/if\(modalOpen\|\|\(tour&&tour\.active\)\)\{ _starNudgePending=reason; return false; \}/.test(HTML)
+  &&/if\(modalOpen\|\|\(tour&&tour\.active\)\|\|repositoryAtelierActive\(\)\)\{ _starNudgePending=reason; return false; \}/.test(HTML)
   &&/function flushStarNudge\(\)/.test(HTML)
   &&/clearRepoHash\(\); flushStarNudge\(\);/.test(HTML)
   &&/localStorage\.setItem\(STAR_NUDGE_KEY,how\)/.test(HTML), 'it shows at most once per browser, waits out a modal or the tour, and returns when the visitor steps back out');
@@ -1105,21 +1292,32 @@ ok(atelierSrc.length>0, 'atelier runtime is a bounded, extractable integration b
 ok(/id="atelierBtn"/.test(HTML) && /class="btn atelier"/.test(HTML)
   && /class="btn gh"[\s\S]*?target="_blank" rel="noopener"/.test(HTML), 'repo card adds a clear room entry command without removing quick GitHub access');
 ok((HTML.match(/atelierEnter:\s*['"]/g)||[]).length===2 && (HTML.match(/atelierExit:\s*['"]/g)||[]).length===2
-  && (HTML.match(/atelierAsk:\s*['"]/g)||[]).length===2 && (HTML.match(/atelierWhy:\s*['"]/g)||[]).length===2, 'atelier card, exit, and terminal copy is bilingual');
+  && (HTML.match(/atelierAsk:\s*['"]/g)||[]).length===2 && (HTML.match(/atelierWhy:\s*['"]/g)||[]).length===2
+  && (HTML.match(/atelierSignals:\s*['"]/g)||[]).length===2 && (HTML.match(/atelierRoomHint:\s*['"]/g)||[]).length===2
+  && (HTML.match(/atelierChatTitle:\s*['"]/g)||[]).length===2, 'atelier card, exhibits, chat, exit, and terminal copy is bilingual');
 ok(/const REPOSITORY_ATELIER_LAYER=6/.test(atelierSrc) && /new THREE\.Scene\(\)/.test(atelierCreateSrc)
   && /renderer\.render\(A\.scene,camera\)/.test(atelierSrc), 'interior uses a dedicated scene plus camera layer instead of drawing the town behind it');
 ok(/if\(REPOSITORY_ATELIER&&REPOSITORY_ATELIER\.created\) return REPOSITORY_ATELIER/.test(atelierCreateSrc)
   && /A\.created=true; A\.createCount\+\+/.test(atelierCreateSrc), 'the single room is lazy-created once');
-ok((atelierCreateSrc.match(/_atelierCanvas\(/g)||[]).length===2
+ok((atelierCreateSrc.match(/_atelierCanvas\(/g)||[]).length===3
   && /history=_atelierCanvas\([^,]+,[^,]+,'history'\)/.test(atelierCreateSrc)
-  && /actions=_atelierCanvas\([^,]+,[^,]+,'actions'\)/.test(atelierCreateSrc), 'the reusable room owns exactly two bounded canvas textures');
+  && /signals=_atelierCanvas\([^,]+,[^,]+,'signals'\)/.test(atelierCreateSrc)
+  && /actions=_atelierCanvas\([^,]+,[^,]+,'actions'\)/.test(atelierCreateSrc), 'the reusable room owns exactly three bounded data, signal, and action atlases');
 ok(/A\.resources=\S*\|\|\{geometries:new Set\(\),materials:new Set\(\),textures:new Set\(\)\}/.test(atelierCreateSrc)
   && /resources:\{rooms:A\.created\?1:0,geometries:/.test(atelierSrc), 'room geometry, material, and texture resources are explicitly counted');
 ok(!/new THREE\.(?:CanvasTexture|Texture|Material|Geometry)/.test(atelierBindSrc)
-  && /_drawRepositoryAtelierHistory\(canonical\); _drawRepositoryAtelierActions\(canonical\)/.test(atelierBindSrc)
+  && /_drawRepositoryAtelierHistory\(canonical\); _drawRepositoryAtelierSignals\(canonical\); _drawRepositoryAtelierActions\(canonical\)/.test(atelierBindSrc)
   && /A\.bindings=\{github:canonical\.repo,ask:canonical\.repo,why:canonical\.repo\}/.test(atelierBindSrc), 'repo switches redraw existing atlases and rebind all actions without allocating a second room');
 ok(/RepositoryCore/.test(atelierCreateSrc) && /AtelierHistoryWall/.test(atelierCreateSrc)
-  && /AtelierTerminals/.test(atelierCreateSrc), 'Repository Core, History/Data Wall, and action terminals are real 3D exhibits');
+  && /AtelierSignalsWall/.test(atelierCreateSrc) && /AtelierTerminals/.test(atelierCreateSrc),
+  'Repository Core, History/Data Wall, Signals Wall, and action terminals are real 3D exhibits');
+ok(/AtelierArchitecture/.test(atelierCreateSrc)&&/AtelierDataPath/.test(atelierCreateSrc)
+  &&/AtelierMetricPillars/.test(atelierCreateSrc)&&/AtelierMetricArtifacts/.test(atelierCreateSrc),
+  'ceiling frames, a curved data path, and three metric artifacts replace the sparse placeholder floor');
+ok(/model\.clone\(true\)/.test(atelierCreateSrc)&&/AtelierVisitor_CurrentChibi/.test(atelierCreateSrc)
+  &&/avatarCloneOf\(armL\)/.test(atelierCreateSrc)&&/avatarCloneOf\(legL\)/.test(atelierCreateSrc)
+  &&!/new THREE\.CapsuleGeometry\(\.32,\.64/.test(atelierCreateSrc),
+  'the Atelier reuses the current chibi avatar design and mapped limb animation instead of a primitive placeholder');
 ok(/canonical\.stars/.test(atelierBindSrc) && /canonical\._activity/.test(atelierBindSrc) && /canonical\.score/.test(atelierBindSrc)
   && /langColor[\s\S]*?zoneColor[\s\S]*?hash=_atelierHash\(canonical\.repo\)/.test(atelierBindSrc), 'core size, light, structure, language, district, and deterministic repo identity all bind from shipped data');
 ok(/repo\.desc\|\|t\('noDesc'\)/.test(atelierSrc) && /repo\.topics\|\|\[\]/.test(atelierSrc)
@@ -1127,10 +1325,37 @@ ok(/repo\.desc\|\|t\('noDesc'\)/.test(atelierSrc) && /repo\.topics\|\|\[\]/.test
   && /repo\.license/.test(atelierSrc) && /repo\.created/.test(atelierSrc) && /repo\.pushed/.test(atelierSrc)
   && /repo\.release_tag/.test(atelierSrc) && /repo\.visitors/.test(atelierSrc) && /repo\.views/.test(atelierSrc)
   && /repo\.clones/.test(atelierSrc), 'data wall covers identity, description, topics, repo metrics, dates, releases, and available traffic');
-ok(/const hasTraffic=repo\.tracked===true/.test(atelierSrc), 'the TRAFFIC section appears only for genuinely tracked owner data, never public-mode synthetic metrics');
+ok(/const hasTraffic=repo\.trafficKnown===true/.test(atelierSrc)
+  && /else \{ y\+=58;[\s\S]*?atelierTrafficUnavailable/.test(atelierSrc),
+  'the TRAFFIC section appears only for known owner traffic and explains the public-metadata boundary otherwise');
+ok(/function _drawRepositoryAtelierSignals\(repo\)/.test(atelierSrc)
+  &&/canonical\.stars/.test(atelierBindSrc)&&/canonical\.forks/.test(atelierBindSrc)&&/canonical\._activity/.test(atelierBindSrc)
+  &&/A\.metricSignals=metricSignals/.test(atelierBindSrc)&&/atelierSignalsNow/.test(atelierSrc),
+  'the Signals Wall and metric artifacts bind stars, forks, activity, lifecycle, language, and topics from current public data');
 ok(/A\.terminalKinds=\['github','ask','why'\]/.test(atelierCreateSrc)
   && /window\.open\(repo\.url,'_blank','noopener'\)/.test(atelierSrc)
-  && /askInChat\(q\)/.test(atelierSrc) && /cardWhyZone\(repo\)/.test(atelierSrc), 'three terminals reuse exact GitHub, Gitber, and deterministic district paths only on activation');
+  && /_openRepositoryAtelierChat\(kind,repo\)/.test(atelierSrc)
+  && !/exitRepositoryAtelier\(\{kind,repoKey:repo\.repo\}\)/.test(atelierSrc),
+  'GitHub remains external while Ask and Why open their exact flows without leaving the room');
+ok(/function _openRepositoryAtelierChat\(kind,repo\)/.test(atelierSrc)
+  && /kind==='why'[\s\S]*?_showCardWhyZone\(repo\)/.test(atelierSrc)
+  && /chatText\.value=question; sendChat\(\)/.test(atelierSrc)
+  && /A\.inRoomChat=true; A\.roomPanel=kind/.test(atelierSrc),
+  'in-room Gitber sends a real repo question and renders deterministic district context under Atelier ownership');
+ok(/#chat\.atelierChat/.test(HTML)&&/body\.atelier-chat-open #prompt/.test(HTML)
+  &&/atelierRoomHint/.test(HTML)&&/atelierChatTitle/.test(HTML)&&/atelierChatPh/.test(HTML),
+  'the room owns a dark responsive chat surface, hides conflicting prompts, and explains its completed interaction model');
+ok(/#chat\.atelierChat \.msg\.bot span\[style\*="#ab8a66"\] \{ color:#dbcba8 !important; \}/.test(HTML)
+  && /#chat\.atelierChat \.msg \.alt \{ color:#244d7b; background:#edf4ff; \}/.test(HTML),
+  'in-room metric text and alternative repo chips retain AA contrast on the dark chat surface');
+ok(/if\(repositoryAtelierChatActive\(\)\) _syncRepositoryAtelierChatChrome\(\); \}/.test(HTML)
+  &&/if\(repositoryAtelierChatActive\(\)\) _syncRepositoryAtelierChatChrome\(\);/.test(atelierSrc),
+  'live language switching redraws all three walls and restores the in-room chat title and placeholder');
+ok(/opts&&opts\.repo&&!repositoryAtelierActive\(\)/.test(HTML)
+  &&/opts&&opts\.handoff&&!repositoryAtelierActive\(\)/.test(HTML)
+  &&/function taxiTo\(repo\)\{ if\(repositoryAtelierActive\(\)\) return false/.test(HTML)
+  &&/function startScholarHandoff\(kind\)\{ if\(repositoryAtelierActive\(\)\) return false/.test(HTML),
+  'chat replies cannot start an exterior taxi ride or scholar handoff while the room owns interaction');
 ok(!/fetch\(|new WebSocket|groundedAsk|webllmAsk|proxyAsk|import\(/.test(atelierCreateSrc+atelierBindSrc), 'entering and rebinding the room has no network, model, CDN, or dynamic-import work');
 ok(!/track\('atelier_(?:enter|exit)'/.test(atelierSrc) && /track\('atelier_terminal'/.test(atelierSrc),
   'enter and exit emit no remote analytics; only an explicit terminal action may record an event');
@@ -1143,20 +1368,24 @@ ok(/playerPosition:player\.position\.clone\(\)/.test(atelierSrc)
   && /cameraPosition:camera\.position\.clone\(\)/.test(atelierSrc)
   && /cameraLayerMask:camera\.layers\.mask,camYaw,camPitch,camDist/.test(atelierSrc)
   && /navTarget,navVisible:navHolder\.visible/.test(atelierSrc)
-  && /sitting,ride,ferris,carousel,modalOpen/.test(atelierSrc), 'entry snapshot owns exact player, camera, navigation, seat, ride, and UI safety state');
+  && /sitting,ride,ferris,carousel,modalOpen/.test(atelierSrc)
+  && /introInert:document\.getElementById\('intro'\)\.inert/.test(atelierSrc),
+  'entry snapshot owns exact player, camera, navigation, seat, ride, and UI accessibility state');
 ok(/player\.position\.copy\(s\.playerPosition\)/.test(atelierSrc)
   && /camera\.position\.copy\(s\.cameraPosition\)/.test(atelierSrc)
   && /camYaw=s\.camYaw; camPitch=s\.camPitch; camDist=s\.camDist/.test(atelierSrc)
   && /navTarget=s\.navTarget; navHolder\.visible=s\.navVisible/.test(atelierSrc)
+  && /document\.getElementById\('intro'\)\.inert=s\.introInert/.test(atelierSrc)
   && /if\(!s\|\|s\.restored\) return/.test(atelierSrc), 'exit restore is exact and idempotent');
 ok(/_resetRepositoryAtelierInput\(\)/.test(atelierSrc) && /clearKeys\(\); stickVec=\{x:0,y:0\}/.test(atelierSrc)
   && /moveTid=null; lookTid=null/.test(atelierSrc), 'entry and exit clear keyboard and touch ownership so movement cannot stick');
 ok(/if\(e\.code==='Enter'&&e\.repeat\)\{ e\.preventDefault\(\); return; \}/.test(HTML), 'held Enter cannot repeatedly fire a room terminal');
 ok(/const isUiKeyTarget=e=>/.test(HTML) && /if\(isTyping\(\)\|\|isUiKeyTarget\(e\)\) return/.test(HTML)
   && /\^\(BUTTON\|A\|INPUT\|SELECT\|TEXTAREA\)\$/.test(HTML), 'focused native controls own Enter/Space without also firing a world action');
-ok(/if\(!repositoryAtelierActive\(\)&&!chatEl\.classList\.contains\('hidden'\)\) chatText\.focus\(\)/.test(HTML)
-  && /if\(!_drainQueuedChat\(\)&&!_resumePendingChatNpc\(\)&&!repositoryAtelierActive\(\)&&!chatEl\.classList\.contains\('hidden'\)\) chatText\.focus\(\)/.test(HTML)
-  && /if\(document\.activeElement===chatText\) chatText\.blur\(\)/.test(atelierSrc), 'hidden or in-flight chat cannot steal keyboard focus from the room');
+ok(/!repositoryAtelierActive\(\)\|\|repositoryAtelierChatActive\(\)/.test(HTML)
+  && /\(!repositoryAtelierActive\(\)\|\|repositoryAtelierChatActive\(\)\)&&!chatEl\.classList\.contains\('hidden'\)/.test(HTML)
+  && /if\(document\.activeElement===chatText\) chatText\.blur\(\)/.test(atelierSrc),
+  'only the explicit in-room chat may own keyboard focus while the room is active');
 ok(/if\(repositoryAtelierActive\(\)\)\{ REPOSITORY_ATELIER\.pendingHash=true; exitRepositoryAtelier\(\); return; \}/.test(HTML)
   && /pendingHash=A\.pendingHash/.test(atelierSrc) && /if\(pendingHash\)\{ A\.afterExit=null; const key=repoHashKey\(\),repo=repoByKey\(key\); if\(repo\) openCard\(repo\)/.test(atelierSrc),
   'repo hash changes exit the room and rebuild the requested card only after the exterior reveal');
@@ -1164,8 +1393,9 @@ ok(/if\(pendingHash\)\{ A\.afterExit=null;/.test(atelierSrc), 'explicit hash nav
 ok(/const CHAT_QUEUE_MAX=4,queuedChatQuestions=\[\]; let pendingChatNpc=null/.test(HTML)
   && /if\(busy\)\{ chatText\.value=''; _queueChatQuestion\(q,npc\); return; \}/.test(HTML)
   && /function _queueChatAction\(action\)/.test(HTML) && /_queueChatAction\(\{kind:'ask',q,npc\}\)/.test(HTML)
-  && /function _drainQueuedChat\(\)\{ if\(busy\|\|repositoryAtelierActive\(\)\|\|!queuedChatQuestions\.length\)/.test(HTML)
-  && /if\(!_drainQueuedChat\(\)&&!_resumePendingChatNpc\(\)&&!repositoryAtelierActive\(\)/.test(HTML), 'busy chat preserves a bounded question plus target NPC and switches only after the current turn finishes');
+  && /function _drainQueuedChat\(\)\{ if\(busy\|\|\(repositoryAtelierActive\(\)&&!repositoryAtelierChatActive\(\)\)\|\|!queuedChatQuestions\.length\)/.test(HTML)
+  && /function _resumePendingChatNpc\(\)\{ if\(busy\|\|\(repositoryAtelierActive\(\)&&!repositoryAtelierChatActive\(\)\)\|\|!pendingChatNpc\)/.test(HTML),
+  'busy chat preserves a bounded question and may drain only inside the explicitly opened Atelier chat');
 ok(/if\(busy&&activeNpc&&npc!==activeNpc\)\{ pendingChatNpc=npc;/.test(HTML)
   && /function _resumePendingChatNpc\(\)/.test(HTML), 'an in-flight scholar answer cannot leak into a newly selected Gitber thread');
 ok(/_queueChatAction\(\{kind:'why',repoKey:repo\.repo,npc:_taxiNpc\(\)\}\)/.test(HTML)
@@ -1191,9 +1421,16 @@ ok(/function _realtimeExteriorPose\(\)/.test(HTML)
 ok(/\(LOW_END\|\|IS_MOBILE\)\?1024:1536/.test(atelierCreateSrc) && /LOW_END\?2:3/.test(atelierBindSrc)
   && /A\.rods\.count=LOW_END\?4/.test(atelierBindSrc), 'LOW_END reduces atlas and core detail without removing any exhibit');
 ok(/webglcontextrestored'[\s\S]*?_repositoryAtelierContextRestored/.test(HTML)
-  && /A\.resources\.textures\.forEach\(texture=>\{ texture\.needsUpdate=true; \}\)/.test(atelierSrc), 'context restore marks both reusable atlases for re-upload');
+  && /A\.resources\.textures\.forEach\(texture=>\{ texture\.needsUpdate=true; \}\)/.test(atelierSrc), 'context restore marks all reusable atlases for re-upload');
 ok(/window\.__repositoryAtelier=/.test(atelierSrc) && /window\.__atelierEnter=/.test(atelierSrc)
-  && /window\.__atelierSelect=/.test(atelierSrc), 'short diagnostics expose active repo, state, layers, resources, render cost, bindings, and poses');
+  && /window\.__atelierSelect=/.test(atelierSrc)
+  && /inRoomChat:!!A\.inRoomChat,roomPanel:A\.roomPanel/.test(atelierSrc)
+  && /sharedAvatarDraws:A\.avatarDraws/.test(atelierSrc),
+  'short diagnostics expose active repo, room chat ownership, current avatar, exhibits, resources, render cost, bindings, and poses');
+ok(/one finished exhibition/.test(README_EN)&&/완성된 전시실/.test(README_KO)
+  &&/Ask Gitber[\s\S]*?without ejecting the visitor/.test(README_EN)
+  &&/깃버에게 이 레포 질문[\s\S]*?밖으로 내보내지 않고/.test(README_KO),
+  'both READMEs describe the completed room and in-room action ownership');
 const atelierHashSrc=(atelierSrc.match(/function _atelierHash\(value\)\{[^\n]+\}/)||[''])[0];
 if(atelierHashSrc){ const hash=new Function(`${atelierHashSrc}; return _atelierHash;`)();
   ok(hash('Repolis')===hash('Repolis') && hash('Repolis')!==hash('jenkins-dind'), 'repo style seed is stable across re-entry and differs across repos');
@@ -1235,7 +1472,8 @@ ok(/const FRESHNESS_KEY='repolisFreshness:v1', FRESHNESS_MAX_TOWNS=5/.test(HTML)
 ok(/function _freshTownKey\(\)\{ return \(cityMode==='owner'\?'owner:':'public:'\)\+String\(currentUser/.test(HTML), 'owner and public-user town baselines are independently scoped');
 ok(/freshnessStore\.order=\[freshnessTown\][\s\S]*?slice\(0,FRESHNESS_MAX_TOWNS\)/.test(HTML), 'snapshot LRU pruning is wired');
 ok(/cityError=\{status:0,reason:'data_load'\}/.test(HTML), 'owner repos.json failure becomes an explicit city load error');
-ok(/const freshnessTrackable=REPOS\.length>0&&!cityError/.test(HTML)&&/if\(!freshnessBaseline&&freshnessTrackable\)/.test(HTML), 'only a successful non-empty town load can diff or establish a baseline');
+ok(/const freshnessTrackable=cityMode!=='portal'&&REPOS\.length>0&&!cityError/.test(HTML)&&/if\(!freshnessBaseline&&freshnessTrackable\)/.test(HTML),
+  'only a successful non-empty full-town load can diff or establish a baseline');
 ok(/function hasFreshness\(\)\{ return !!\(freshnessTrackable&&/.test(HTML), 'failed/empty loads can never announce mass-removal news');
 ok(/function markFreshnessRead\(\)[\s\S]*?_freshSetBaseline\(freshnessBaseline\)[\s\S]*?town_gazette_read/.test(HTML), 'baseline advances only through explicit mark-read');
 ok(/id="freshBox"/.test(HTML)&&/function renderFreshness\(\)/.test(HTML)&&/function renderPassport\(\)\{ renderFreshness\(\); renderCourse\(\)/.test(HTML), 'Gazette renders above Chronicle inside the existing Passport');
@@ -1701,7 +1939,8 @@ ok((HTML.match(/if\(_maybeScholarHandoff\(q\)\) return;/g)||[]).length===2, 'sol
 const residentSaySrc=(HTML.match(/async function residentSay\(q\)\{[\s\S]*?\n\}/)||[''])[0];
 const groupSaySrc=(HTML.match(/async function groupSay\(q\)\{[\s\S]*?\n\}/)||[''])[0];
 ok([residentSaySrc,groupSaySrc].every(src=>src.indexOf('_maybeFarewell(q)')<src.indexOf('_maybeScholarHandoff(q)')&&src.indexOf('_maybeScholarHandoff(q)')<src.indexOf('_maybeInvite(q)')), 'specialist handoff wins before resident-name invites (MIRA scholar vs Mira resident collision)');
-ok(/if\(opts&&opts\.handoff\)[\s\S]*?startScholarHandoff\(kind\)/.test(HTML), 'chat messages can render a specialist handoff action');
+ok(/if\(opts&&opts\.handoff&&!repositoryAtelierActive\(\)\)[\s\S]*?startScholarHandoff\(kind\)/.test(HTML),
+  'exterior chat messages can render a specialist handoff while Atelier chat keeps room ownership');
 const startHandoffSrc=(HTML.match(/function startScholarHandoff\(kind\)\{[\s\S]*?return true; \}/)||[''])[0];
 ok(/setNav\(\{label:sc\.star[\s\S]*?_pos:n\.group\.position/.test(startHandoffSrc), 'handoff compass follows the scholar live position');
 ok(!/taxiTo\(/.test(startHandoffSrc) && /closeChat\(\)/.test(startHandoffSrc), 'handoff closes resident chat but never taxis or auto-opens the scholar');
@@ -1861,7 +2100,7 @@ ok(/returning:v\.n>1/.test(HTML) && /longAway:\(v\.n>1 && awayDays>=7\)/.test(HT
 ok(/if\(VISITOR\.returning && Math\.random\(\)<0\.6\)\{/.test(npcBlock) && /VISITOR\.longAway \?/.test(npcBlock), 'a returning visitor gets a warmer resident hello ~60% of the time — with an extra-warm variant after a long absence');
 ok(/function _welcomeBackLine\(\)\{/.test(npcBlock) && /n>=5\?/.test(npcBlock) && /visit #\$\{n\}/.test(npcBlock), 'a one-time welcome-back toast greets a returning visitor (with a little milestone note from the 5th visit)');
 ok(/const rb=VISITOR\.returning, news=hasFreshness\(\)/.test(HTML)
-  && /if\(rb\)\{ setTimeout\(\(\)=>\{ try\{ showWave\(_welcomeBackLine\(\),3600\)/.test(HTML)
+  && /if\(rb&&cityMode!=='portal'&&!_reqFocus\)\{ setTimeout\(\(\)=>\{ try\{ showWave\(_welcomeBackLine\(\),3600\)/.test(HTML)
   && /const c=getCourse\(\), delay=rb\?4700:/.test(HTML), 'entering town shows welcome-back first, then a single deferred Gazette/Chronicle toast');
 ok(/window\.__visitor=\(\)=>/.test(HTML) && /window\.__setVisitor=\(o\)=>/.test(HTML) && /window\.__welcomeBack=\(\)=>/.test(HTML), '?dbg __visitor/__setVisitor/__welcomeBack read + preview the returning-visitor warmth without a reload');
 


### PR DESCRIPTION
## Why

Repo Portal attaches Repolis to repositories developers already share. A canonical `owner/repo` link now loads one relevant project and its Repository Atelier before requesting the owner's catalog, so visitors understand the product through real work instead of a generic landing page.

## What changed

- Accept a GitHub username, `owner/repo`, or repository root URL from the intro and Station, then canonicalize repository links as `?repo=owner/repo&ref=repo-portal`.
- Resolve one target through the owner snapshot, a 15-minute bounded cache, one public GitHub repository request, or an explicit stale fallback. Errors preserve the existing owner town.
- Keep public visitors, views, and clones unknown. Public buildings use stars, forks, and update recency without synthetic traffic.
- Open the exact Repository Atelier after one entry click. Copy Portal, GitHub, and explicit owner-town expansion actions stay in the room.
- Complete the Atelier with the current chibi avatar, History/Data and Impact/Signals walls, metric artifacts, in-room Gitber, and deterministic district context.
- Add coarse, identity-free funnel events and isolate target-only visits from Town Gazette and Village Chronicle storage.
- Document the URL, cache, privacy, truth, maintenance, and QA contracts in `docs/repo-portal-change-guide.md` and the existing EN/KO project docs.

## Runtime limits

No binary asset, model, texture, light, shadow, backend, package, or build step was added. The Portal module is 8.6 KiB, and the complete local runtime remains below 5 MiB.

## Verification

- `node council/test.mjs` — 130 checks
- `node council/test-live.mjs` — 56 checks
- `node scripts/smoke.mjs` — 1,084 checks
- syntax checks for `scholars.js`, `cloudflare-taxi/src/grounded.js`, and `assets/repo-portal.js`
- desktop 1440x900 and mobile 390x844, KO/EN, keyboard, copy, owner expansion, Back, 404, 403, offline, fresh/stale cache, and malicious input
- Lighthouse mobile: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
- no current-page console errors, horizontal overflow, or HUD overlap
