### PR TITLE
feat: add deterministic city time state

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -47,10 +47,19 @@ jobs:
         if: ${{ env.GH_PAT == '' }}
         run: echo "GH_PAT is not set; building from public metadata. Add GH_PAT later to grow cumulative traffic."
 
-      - name: Build repos.json
+      - name: Set deterministic city reference day
+        run: echo "CITY_STATE_AS_OF=$(date -u +%FT00:00:00Z)" >> "$GITHUB_ENV"
+
+      - name: Build generated city data
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: python3 scripts/build_repos.py
+
+      - name: Validate deterministic city state
+        run: |
+          python3 scripts/test_city_state.py
+          python3 scripts/validate_city_state.py
+          node scripts/test-city-time.mjs
 
       - name: Commit if changed
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 |---|---|---|
 | **`index.html`** | Primary app runtime — 3D engine, UI, navigation, residents, exploration, i18n, day/night. | Any UI / gameplay / client behavior change. |
 | **`repolis.config.js`** | Fork-facing runtime identity and optional-service policy. GitHub Pages infers the fork owner; upstream Workers stay off on forks. | Changing owner inference, template behavior, or canonical endpoints. |
-| **`repos.json`** | Generated array of repo objects that build the current owner city. **Do not hand-edit.** | Never directly; regenerate (see below). |
+| **`repos.json` + `data/city-state.json`** | Generated repo catalog plus deterministic era, season, statistics, sap timestamp, and archived roots for the current owner city. **Do not hand-edit.** | Never directly; regenerate (see below). |
+| **`data/city-state.schema.json`** | Strict JSON Schema for the generated city-state artifact. | Changing the city-state contract. |
+| **`assets/city-time.js`** | Pure wear (`recent` / `faded` / `mossed`), ruin, reference-date, and seasonal palette rules. | Changing how public time metadata affects the city. |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
 | **`assets/repo-portal.js`** | Pure username/repository parser, route precedence, public projection, canonical Portal URL, and owner-town expansion link. | Changing `?repo=`, accepted GitHub inputs, public traffic truth, or target share links. |
@@ -39,7 +41,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`assets/town-growth.js`** | Pure repo-creation timeline, year snapshot, and Growth Replay share-link logic. | Changing historical cutoffs, unknown-date policy, or `?growth=` links. |
 | **`assets/town-creator.js`** | Pure allowlisted public-profile + town-repo summary for Creator Hall. | Changing creator facts, badges, signature-repo ranking, or avatar safety. |
 | **`assets/twin-towns.js`** | Pure public-repo comparison and reversible Twin Towns link builder. | Changing the two-person referral bridge or its URL contract. |
-| **`scripts/build_repos.py`** | Rebuilds `repos.json` from `data/logs/*` traffic + `gh api`. | Refreshing the city data locally. |
+| **`scripts/build_repos.py`** | Rebuilds `repos.json` and `data/city-state.json` from `data/logs/*` traffic + `gh api`. | Refreshing the city data locally. |
 | **`scripts/smoke.mjs`** | Hermetic static and behavioral regression guards for the city runtime. | Any client feature, navigation, or generated-module integration change. |
 | **`.github/workflows/refresh.yml`** | "Refresh Repolis data" — daily Action that regenerates `repos.json` and pushes `chore: refresh`. | CI / data-refresh changes. |
 | **`scripts/build-contribution-library.mjs` + `assets/contribution-library.json`** | Generates the in-app **Contribution Library** JSON from the sibling `Hyeonsang-AI-Contributions` README (KO/EN); `index.html` fetches it at runtime. JSON is **generated — do not hand-edit.** Daily via `.github/workflows/update-contribution-library.yml`. | Changing the library landmark's data/source. |
@@ -66,9 +68,11 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 # 1) Run the city (static)
 python3 -m http.server 8000
 
-# 2) Rebuild repos.json from the owner's public repos + committed traffic logs (needs gh CLI, logged in)
+# 2) Rebuild repos.json + data/city-state.json from public repos and committed traffic logs
 gh auth login
-GTM_DIR=data python3 scripts/build_repos.py     # regenerates repos.json (do not hand-edit)
+GTM_DIR=data python3 scripts/build_repos.py     # generated artifacts; do not hand-edit
+# Optional reproducible clock override (the daily workflow supplies its UTC run day):
+CITY_STATE_AS_OF=2026-08-23T00:00:00Z GTM_DIR=data python3 scripts/build_repos.py
 
 # 3) Rebuild the Contribution Library JSON from the sibling Hyeonsang-AI-Contributions README (KO/EN)
 node scripts/build-contribution-library.mjs     # regenerates assets/contribution-library.json (deterministic)
@@ -78,6 +82,11 @@ node scripts/build-contribution-library.mjs     # regenerates assets/contributio
 `repo, desc, lang, topics[], url, home, stars, forks, fork, views, visitors, clones, size, open_issues,
 license, archived, default_branch, release_tag, release_date, created, pushed, tracked, first_seen,
 social, social_custom, score, rank`. Full meaning: [`docs/domain-model.md`](docs/domain-model.md).
+
+`data/city-state.json` is a deterministic projection of that public catalog. It carries `schema`,
+`version`, `era`, `season`, honest aggregate `stats`, `last_sap_flow`, and archived-only `roots`.
+The daily workflow injects its UTC run day; local builds without that input use the newest
+reproducible public source timestamp.
 
 ---
 
@@ -109,6 +118,9 @@ zero LLM, zero cost — so run them freely:
 node council/test.mjs        # deterministic Council crosscheck
 node council/test-live.mjs   # live guards + state machine
 node scripts/smoke.mjs       # city/runtime static + behavioral regression guards
+python3 scripts/test_city_state.py
+python3 scripts/validate_city_state.py
+node scripts/test-city-time.mjs
 node --check scholars.js
 node --check cloudflare-taxi/src/grounded.js
 node --check assets/repo-route.js

--- a/assets/city-time.js
+++ b/assets/city-time.js
@@ -1,0 +1,70 @@
+export const CITY_STATE_SCHEMA = 'repolis.city-state';
+export const CITY_STATE_VERSION = 1;
+export const CITY_SEASONS = Object.freeze(['spring', 'summer', 'autumn', 'winter']);
+export const WEAR_THRESHOLDS_DAYS = Object.freeze({ recent: 90, faded: 365 });
+
+const DAY_MS = 86400000;
+const PALETTES = Object.freeze({
+  spring: Object.freeze({ sky:0xe3c4d0, fog:0xd5e6d5, light:0xffeed2, building:0xd7e4cb, skyMix:.055, fogMix:.12, lightMix:.08, buildingMix:.055 }),
+  summer: Object.freeze({ sky:0x8fc9e5, fog:0xd9e4c8, light:0xffe4ad, building:0xf0dfbd, skyMix:.025, fogMix:.05, lightMix:.04, buildingMix:.025 }),
+  autumn: Object.freeze({ sky:0xd49a79, fog:0xdec5a7, light:0xffc985, building:0xd7b184, skyMix:.07, fogMix:.13, lightMix:.09, buildingMix:.065 }),
+  winter: Object.freeze({ sky:0x9fb7cf, fog:0xcbd7dc, light:0xdde9f2, building:0xc8d2d5, skyMix:.075, fogMix:.15, lightMix:.1, buildingMix:.06 })
+});
+
+function timestamp(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = Date.parse(value.length === 10 ? `${value}T00:00:00Z` : value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function resolveCitySeason(cityState, override = '') {
+  if (CITY_SEASONS.includes(override)) return override;
+  const value = cityState?.schema === CITY_STATE_SCHEMA && cityState?.version === CITY_STATE_VERSION
+    ? cityState?.season?.value : '';
+  return CITY_SEASONS.includes(value) ? value : 'summer';
+}
+
+export function seasonPalette(season) {
+  return PALETTES[CITY_SEASONS.includes(season) ? season : 'summer'];
+}
+
+export function cityReferenceTimestamp(cityState, repositories = [], fallback = Date.now()) {
+  const stateCandidates = [
+    cityState?.last_sap_flow,
+    cityState?.season?.inputs?.reference_date,
+    cityState?.era?.as_of
+  ];
+  for (const value of stateCandidates) {
+    const parsed = timestamp(value);
+    if (parsed !== null) return parsed;
+  }
+  const repositoryCandidates = repositories.flatMap(repo => [repo?.pushed, repo?.created])
+    .map(timestamp).filter(value => value !== null);
+  return repositoryCandidates.length ? Math.max(...repositoryCandidates) : fallback;
+}
+
+export function classifyBuildingWear(repo, referenceTimestamp, override = '') {
+  const pushedAt = timestamp(repo?.pushed);
+  const daysSincePush = pushedAt === null ? null : Math.max(0, Math.floor((referenceTimestamp - pushedAt) / DAY_MS));
+  let state = daysSincePush === null || daysSincePush > WEAR_THRESHOLDS_DAYS.faded
+    ? 'mossed'
+    : daysSincePush > WEAR_THRESHOLDS_DAYS.recent ? 'faded' : 'recent';
+  if (['recent', 'faded', 'mossed'].includes(override)) state = override;
+  return Object.freeze({
+    state,
+    daysSincePush,
+    archived: Boolean(repo?.archived),
+    referenceDate: new Date(referenceTimestamp).toISOString().slice(0, 10)
+  });
+}
+
+export function projectCityTime(repo, cityState, repositories = [], options = {}) {
+  const referenceTimestamp = options.referenceTimestamp
+    ?? cityReferenceTimestamp(cityState, repositories, options.fallbackTimestamp);
+  const wear = classifyBuildingWear(repo, referenceTimestamp, options.wear);
+  return Object.freeze({
+    ...wear,
+    archived: options.archived === true || wear.archived,
+    season: resolveCitySeason(cityState, options.season)
+  });
+}

--- a/data/city-state.json
+++ b/data/city-state.json
@@ -1,0 +1,104 @@
+{
+  "era": {
+    "as_of": "2026-08-23",
+    "basis": "Oldest creation date among the public repositories included in repos.json.",
+    "city_age_days": 3499,
+    "city_age_years": 9.58,
+    "city_year": 10,
+    "founded_on": "2017-01-23",
+    "oldest_repository": "vertx-embedded-springboot"
+  },
+  "last_sap_flow": "2026-08-23T00:00:00Z",
+  "roots": [],
+  "schema": "repolis.city-state",
+  "season": {
+    "fallback": {
+      "rule": "When fewer than six prior latest-push signals span at least three 30-day buckets, use the share of repositories whose latest push is in the recent 30-day window: spring >= 0.35, summer >= 0.12, autumn > 0, otherwise winter.",
+      "used": false
+    },
+    "inputs": {
+      "active_repository_share": 0.29411764705882354,
+      "activity_signal": "latest_push_per_repository",
+      "historical_average": 1.333,
+      "historical_bucket_counts": [
+        5,
+        1,
+        0,
+        1,
+        1,
+        0
+      ],
+      "historical_bucket_days": 30,
+      "recent_active_repositories": 20,
+      "recent_to_historical_ratio": 15.0,
+      "recent_window_days": 30,
+      "reference_date": "2026-08-23",
+      "repositories_with_push_date": 68
+    },
+    "reason": "Recent latest-push count is 15.00x the average of the prior 6 30-day buckets.",
+    "value": "spring"
+  },
+  "stats": {
+    "active_repository_count": 68,
+    "archived_repository_count": 0,
+    "commit_history": {
+      "available": false,
+      "limitation": "The build input exposes each repository's latest push timestamp, not complete commit history; no commit total is inferred.",
+      "total": null
+    },
+    "language_distribution": [
+      {
+        "language": "Python",
+        "repositories": 26
+      },
+      {
+        "language": "Jupyter Notebook",
+        "repositories": 14
+      },
+      {
+        "language": "Other",
+        "repositories": 6
+      },
+      {
+        "language": "Shell",
+        "repositories": 6
+      },
+      {
+        "language": "Java",
+        "repositories": 4
+      },
+      {
+        "language": "JavaScript",
+        "repositories": 4
+      },
+      {
+        "language": "Dockerfile",
+        "repositories": 2
+      },
+      {
+        "language": "HTML",
+        "repositories": 2
+      },
+      {
+        "language": "TypeScript",
+        "repositories": 2
+      },
+      {
+        "language": "PHP",
+        "repositories": 1
+      },
+      {
+        "language": "PowerShell",
+        "repositories": 1
+      }
+    ],
+    "latest_push_signal": {
+      "recent_30d_repositories": 20,
+      "repositories_with_push_date": 68
+    },
+    "repository_count": 68,
+    "total_forks": 135,
+    "total_stars": 564
+  },
+  "version": 1
+}

--- a/data/city-state.schema.json
+++ b/data/city-state.schema.json
@@ -1,0 +1,333 @@
+{
+  "$id": "https://hyeonsangjeon.github.io/Repolis/data/city-state.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "era": {
+      "additionalProperties": false,
+      "properties": {
+        "as_of": {
+          "format": "date",
+          "type": "string"
+        },
+        "basis": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "city_age_days": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "city_age_years": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "city_year": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "founded_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "oldest_repository": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "founded_on",
+        "oldest_repository",
+        "as_of",
+        "city_age_days",
+        "city_age_years",
+        "city_year",
+        "basis"
+      ],
+      "type": "object"
+    },
+    "last_sap_flow": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "roots": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "achievement": {
+            "maxLength": 180,
+            "minLength": 1,
+            "type": "string"
+          },
+          "active_years": {
+            "additionalProperties": false,
+            "properties": {
+              "count": {
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "from": {
+                "minimum": 1970,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "to": {
+                "minimum": 1970,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "from",
+              "to",
+              "count"
+            ],
+            "type": "object"
+          },
+          "repo": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo",
+          "active_years",
+          "achievement"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "schema": {
+      "const": "repolis.city-state",
+      "type": "string"
+    },
+    "season": {
+      "additionalProperties": false,
+      "properties": {
+        "fallback": {
+          "additionalProperties": false,
+          "properties": {
+            "rule": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "used": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "used",
+            "rule"
+          ],
+          "type": "object"
+        },
+        "inputs": {
+          "additionalProperties": false,
+          "properties": {
+            "active_repository_share": {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            "activity_signal": {
+              "const": "latest_push_per_repository",
+              "type": "string"
+            },
+            "historical_average": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "historical_bucket_counts": {
+              "items": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "maxItems": 6,
+              "minItems": 6,
+              "type": "array"
+            },
+            "historical_bucket_days": {
+              "const": 30,
+              "type": "integer"
+            },
+            "recent_active_repositories": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "recent_to_historical_ratio": {
+              "minimum": 0,
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "recent_window_days": {
+              "const": 30,
+              "type": "integer"
+            },
+            "reference_date": {
+              "format": "date",
+              "type": "string"
+            },
+            "repositories_with_push_date": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "reference_date",
+            "activity_signal",
+            "recent_window_days",
+            "recent_active_repositories",
+            "historical_bucket_days",
+            "historical_bucket_counts",
+            "historical_average",
+            "recent_to_historical_ratio",
+            "active_repository_share",
+            "repositories_with_push_date"
+          ],
+          "type": "object"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "value": {
+          "enum": [
+            "spring",
+            "summer",
+            "autumn",
+            "winter"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "inputs",
+        "reason",
+        "fallback"
+      ],
+      "type": "object"
+    },
+    "stats": {
+      "additionalProperties": false,
+      "properties": {
+        "active_repository_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "archived_repository_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "commit_history": {
+          "additionalProperties": false,
+          "properties": {
+            "available": {
+              "const": false,
+              "type": "boolean"
+            },
+            "limitation": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "total": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "available",
+            "total",
+            "limitation"
+          ],
+          "type": "object"
+        },
+        "language_distribution": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "language": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "repositories": {
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "language",
+              "repositories"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "latest_push_signal": {
+          "additionalProperties": false,
+          "properties": {
+            "recent_30d_repositories": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "repositories_with_push_date": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "repositories_with_push_date",
+            "recent_30d_repositories"
+          ],
+          "type": "object"
+        },
+        "repository_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_forks": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_stars": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "repository_count",
+        "active_repository_count",
+        "archived_repository_count",
+        "total_stars",
+        "total_forks",
+        "language_distribution",
+        "latest_push_signal",
+        "commit_history"
+      ],
+      "type": "object"
+    },
+    "version": {
+      "const": 1,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema",
+    "version",
+    "era",
+    "season",
+    "stats",
+    "last_sap_flow",
+    "roots"
+  ],
+  "title": "Repolis deterministic city state",
+  "type": "object"
+}

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -47,10 +47,10 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | `size` | number | Repo size (KB). |
 | `open_issues` | number | Shown as a live badge on the repo card. |
 | `license` | string | Shown as a badge. |
-| `archived` | boolean | Archived repos render muted. |
+| `archived` | boolean | Archived repos remain in place as warm, gentle ruins with their identity intact. |
 | `default_branch` | string | e.g. `main`. |
 | `release_tag` / `release_date` | string | Latest release badge. |
-| `created` / `pushed` | string | Timestamps; `pushed` feeds night-glow recency. |
+| `created` / `pushed` | string | Timestamps; `pushed` feeds night-glow recency and deterministic building wear. |
 | `tracked` / `first_seen` | string | When the house was "built" (drives the *since YYYY-MM-DD* note). |
 | `social` / `social_custom` | string/bool | Social-preview image for the card. |
 | `score` | number | Ranking score (see §3). |
@@ -70,6 +70,8 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | 📈 views | **garden** · fence |
 | ⭐ stars | **gold-star** roof ornaments |
 | 🌙 recent push · clones · views | **window glow** at night |
+| 🕰 latest push | **wear**: recent (≤90d), faded (91–365d), or mossed (>365d/unknown) |
+| 🏛 archived | a named **gentle ruin** with moss, vines, and wildflowers |
 
 `score` / `rank` are computed in `scripts/build_repos.py` from these signals. Rank chooses the house tier
 (`cabin → cottage → house → villa → manor → portico mansion`), while the client-side deterministic
@@ -99,11 +101,36 @@ github-traffic-monitor (private, daily)        Repolis (public)
   └ cumulative traffic → data/logs/*.csv ──┐
                                            ├─▶ .github/workflows/refresh.yml (daily)
   gh api: owner's public repos (+ committed forks) ─┘  └ scripts/build_repos.py
-                                                          └─▶ repos.json ──▶ index.html (3D city)
+                                                         ├─▶ repos.json ──────────┐
+                                                         └─▶ data/city-state.json ┴─▶ index.html
 ```
 
 - Only **public** repos appear (created repos + forks you actually committed to; mirror forks skipped).
+- Both outputs are generated together; `data/city-state.json` is validated against
+  `data/city-state.schema.json` and fixture-tested before the refresh can commit.
 - The daily Action commits `chore: refresh` to `main` — **always rebase before pushing** (see AGENTS.md rule 2).
+
+### 4.1 Deterministic city state
+
+`data/city-state.json` records the city's public, reproducible time state:
+
+- `era` is founded on the oldest public repository creation date. The daily workflow injects its UTC
+  run day as `as_of`, so quiet repositories continue to age; local builds without that explicit input
+  fall back to the newest reproducible public source timestamp.
+- `season` compares repositories pushed in the latest 30-day window with six preceding 30-day
+  buckets. Sparse histories use the recorded recent-active share fallback. The value is one of
+  `spring`, `summer`, `autumn`, or `winter`, with its inputs and reason stored beside it.
+- `stats` contains only aggregates defensible from the current public catalog. Complete commit
+  history is unavailable, so `commit_history.total` stays `null` rather than being estimated.
+- `last_sap_flow` is that explicit UTC batch day or, for local fallback builds, the latest reproducible
+  source timestamp. It is never an implicit wall-clock read inside the generator.
+- `roots` contains archived public repositories only, with active years and a one-line achievement
+  derived from public metadata. It is correctly empty when the catalog has no archived repos.
+
+The owner town uses this state for a restrained static sky/fog/light palette. Other public towns use
+the neutral summer palette because no owner-specific city-state artifact is fetched for them.
+Buildings derive wear from the same reference date, while archived buildings preserve their footprint,
+silhouette, nameplate, collision, and card identity. These effects require no runtime GitHub or LLM call.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -275,6 +275,11 @@
   #modal.show { display: flex; }
   .card { background: #fffaf2; border-radius: 22px; width: 420px; max-width: 100%; overflow: hidden; position: relative;
     box-shadow: 0 24px 70px rgba(40,22,8,.4); animation: pop .22s cubic-bezier(.2,.9,.3,1.3); }
+  .card:focus { outline: 3px solid rgba(111,143,102,.55); outline-offset: 3px; }
+  .timeTrace { margin: 0 18px 12px; padding: 9px 11px; border-radius: 11px; background: #edf2e6; color: #486044;
+    font-size: 12px; line-height: 1.45; font-weight: 700; }
+  .srOnly { position: absolute !important; width: 1px !important; height: 1px !important; padding: 0 !important; margin: -1px !important;
+    overflow: hidden !important; clip: rect(0,0,0,0) !important; white-space: nowrap !important; border: 0 !important; }
   @keyframes pop { from { transform: scale(.9) translateY(10px); opacity: 0; } to { transform: none; opacity: 1; } }
   .card .top { padding: 22px 24px; color: #fff; }
   .card .top .lang { font-size: 12px; font-weight: 700; opacity: .92; letter-spacing: .03em; }
@@ -1190,7 +1195,7 @@
   }
   /* ---- respect prefers-reduced-motion: keep every bit of info, drop the looping motion ---- */
   @media (prefers-reduced-motion: reduce) {
-    #trainOverlay .rail, #trainOverlay .train, .msg .tdots i, a.libitem, .postcardSpinner { animation: none !important; }
+    #trainOverlay .rail, #trainOverlay .train, .msg .tdots i, a.libitem, .postcardSpinner, .card { animation: none !important; }
     .msg .tdots i { opacity: .6; }
     a.libitem { opacity: 1; }
   }
@@ -1326,6 +1331,7 @@
     <div id="mapHint" class="mapHint"></div>
   </div>
 </div>
+<div id="ruinNameplates" class="srOnly" role="list" data-i18n-aria="ruinListAria" aria-label="아카이브 레포 이름 명패"></div>
 
 <div id="station" class="hidden">
   <button class="sclose" id="stationClose" type="button" aria-label="닫기">✕</button>
@@ -1521,8 +1527,8 @@
   <div class="stActions"><button id="repoRouteHudRide" type="button"></button></div>
 </div>
 
-<div id="modal">
-  <div class="card">
+<div id="modal" role="dialog" aria-modal="true" aria-labelledby="cardName" aria-describedby="cardDesc cardTimeTrace" aria-hidden="true">
+  <div class="card" tabindex="-1">
     <img id="cardImg" class="hero" alt="repo social preview" />
     <div class="sociallabel" id="cardSocialTag">🎨 <span data-i18n="socialPreview">소셜 프리뷰</span></div>
     <div class="top" id="cardTop">
@@ -1531,6 +1537,7 @@
       <div class="stars" id="cardStars"></div>
     </div>
     <div class="chips" id="cardChips"></div>
+    <div class="timeTrace" id="cardTimeTrace" role="status"></div>
     <div class="since" id="cardSince"></div>
     <div class="body"><p id="cardDesc"></p></div>
     <div class="metricnote" id="cardMetricNote" data-i18n="metricNote">🏠 건물은 지표로 자라요 — 👁 방문자 = 높이 · ⑂ fork = 너비 · ⬇ clone = 화려함 · 📈 조회수 = 마당 · ★ = 금별 · 🌙 밤엔 창문 밝기 = 작업량(활동).</div>
@@ -1763,6 +1770,7 @@ import { createRepolisHero, REPOLIS_FACTORY_REVISION } from './assets/world-tree
 import { CAMERA_OBSTRUCTION_DEFAULTS, CAMERA_ARRIVAL_OFFSETS, resolveCameraObstruction, stepCameraResolvedDistance, chooseCameraArrivalYaw } from './assets/camera-obstruction.js?v=clearsight-v1';
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from './assets/canal-ferry.js?v=petite-venise-ferry-v1';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from './assets/rain-garden.js?v=weather-bell-v1';
+import { CITY_STATE_SCHEMA, CITY_STATE_VERSION, cityReferenceTimestamp, projectCityTime, resolveCitySeason, seasonPalette } from './assets/city-time.js?v=world-tree-phase1-v1';
 import { analyzeTownFrame, composeTownPostcard, createTownPostcardIdentity, createTownReadmePortal, flipPixelRows, postcardCanvasToBlob, postcardCaptureSize, postcardFormatForViewport, summarizeTownRepos } from './assets/town-postcard.js?v=town-postcard-v2';
 import { summarizePublicTown } from './assets/public-town-proof.js?v=personal-ready-v1';
 import { createTwinTownLink, createTwinTownMatch } from './assets/twin-towns.js?v=twin-towns-v1';
@@ -1780,7 +1788,7 @@ import { CONTRIBUTION_QUEST_LIMITS, createContributionQuestSearchUrl, selectCont
    The owner city stays the premium / full-data experience. ================ */
 const OWNER = window.REPOLIS_CONFIG?.town?.owner || 'hyeonsangjeon';
 document.title = `Repolis · ${OWNER}'s City of Repos`;
-let REPOS = [];
+let REPOS = [], CITY_STATE = null;
 
 /* --- which town are we in? --- */
 const GH_LOGIN_RE = GITHUB_LOGIN_RE;
@@ -1915,6 +1923,17 @@ function _ownerSnapshot(){
   });
   return _ownerSnapshotPromise;
 }
+let _cityStatePromise=null;
+function _cityStateSnapshot(){
+  if(_cityStatePromise) return _cityStatePromise;
+  _cityStatePromise=fetch('data/city-state.json',{cache:'no-cache'}).then(async res=>{
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    const data=await res.json();
+    if(data?.schema!==CITY_STATE_SCHEMA||data?.version!==CITY_STATE_VERSION) throw new Error('unsupported city-state schema');
+    return data;
+  });
+  return _cityStatePromise;
+}
 function _ownerRepos(data){
   return (Array.isArray(data)?data:[]).map(repo=>Object.assign({},repo,{_owner:OWNER,trafficKnown:true,trafficSource:'owner-snapshot'}));
 }
@@ -1976,7 +1995,8 @@ track('page_load');
 trackPortal('feature_seen',{entry:repoPortalRequested?'link':'intro',device:_repoPortalDevice(),lang:_repoPortalLang()});
 
 if(cityMode === 'owner'){
-  try { REPOS=_ownerRepos(await _ownerSnapshot()); }
+  const cityStateLoad=_cityStateSnapshot().catch(error=>{ console.warn('city-state.json load failed',error); return null; });
+  try { REPOS=_ownerRepos(await _ownerSnapshot()); CITY_STATE=await cityStateLoad; }
   catch(e){ cityError={status:0,reason:'data_load'}; console.error('repos.json load failed', e); }
   track(REPOS.length ? 'city_data_load_success' : 'city_data_load_fail', { repoCount:REPOS.length });
 } else if(cityMode === 'public') {
@@ -2002,6 +2022,9 @@ if(cityMode === 'owner'){
   }
   trackPortal('feature_started',{entry:'link',device:_repoPortalDevice(),lang:_repoPortalLang(),result:repoPortalResult.result,
     latency:repoPortalLatencyBucket((typeof performance!=='undefined'?performance.now():Date.now())-repoPortalStartedAt)});
+}
+if(!CITY_STATE&&currentUser.toLowerCase()===OWNER.toLowerCase()&&(cityMode==='owner'||dataSource==='owner-snapshot')){
+  try{ CITY_STATE=await _cityStateSnapshot(); }catch(error){ console.warn('city-state.json load failed',error); }
 }
 const TOWN_GROWTH=buildTownGrowthTimeline(REPOS);
 
@@ -2129,6 +2152,10 @@ const I18N = {
     rainName:'비정원 날씨 종', rainReached:' — 종을 울려 36초 동안 햇빛 소나기를 불러요. <span class="key">Enter</span> 또는 클릭으로 울리기', rainReachedWet:' — 소나기가 내려요. <span class="key">Enter</span> 또는 클릭으로 맑게 하기', rainStarted:'🌦️ 날씨 종이 울렸어요! 구름이 모이고 주민들이 우산을 펼쳐요', rainStopped:'☀️ 종소리를 따라 소나기가 걷혔어요', rainEnded:'🌤️ 짧은 소나기가 지나가고 마을이 다시 맑아졌어요', lmDriveRain:'🌦️ 비정원의 날씨 종으로 갑니다…', lmArriveRain:'🚕 <b>비정원</b>에 도착했어요! 종을 울려 햇빛 소나기를 불러보세요 🌦️',
     festAllStamps:'🎆 마을을 모두 둘러봤어요! 모든 명소 스탬프 완성 — 축제를 즐겨요!', festRepos:'🎆 레포 {n}곳 방문 달성! 불꽃이 터져요.',
     metricNote:'🏠 건물은 지표로 자라요 — 👁 방문자 = 높이 · ⑂ fork = 너비 · ⬇ clone = 화려함 · 📈 조회수 = 마당 · ★ = 금별 · 🌙 밤엔 창문 밝기 = 작업량(활동).',
+    seasonSpring:'봄', seasonSummer:'여름', seasonAutumn:'가을', seasonWinter:'겨울', seasonCity:'도시 계절',
+    wearRecent:'최근 손길', wearFaded:'빛바랜 흔적', wearMossed:'이끼 낀 시간',
+    ruinStatus:'들꽃이 핀 온화한 폐허', ruinNote:'이 공개 레포는 아카이브되어 잠들었지만, 건물의 실루엣과 이름 명패는 도시의 기억으로 남아 있어요.',
+    ruinListAria:'아카이브 레포 이름 명패',
     cityOfRepos:'레포들의 도시',
     introSub:'핀 6개 제한은 잊으세요.<br>내 모든 레포가 사는 도시를 걸으며,<br>깃버에게 물어보면 그 레포까지 데려다줘요.',
     introSubPublic:'{user} 님의 공개 레포로 지은 도시예요.<br>함께 걸으며 둘러보고,<br>🚉 역에서 또 다른 마을로 떠날 수 있어요.',
@@ -2424,6 +2451,10 @@ const I18N = {
     rainName:'Rain Garden Weather Bell', rainReached:' — ring for one 36-second sunshower. Press <span class="key">Enter</span> or click to ring', rainReachedWet:' — the sunshower is falling. Press <span class="key">Enter</span> or click to clear it', rainStarted:'🌦️ The Weather Bell rang! Clouds gather and the residents open their umbrellas', rainStopped:'☀️ The sunshower clears with the bell', rainEnded:'🌤️ The brief shower passes and the town brightens again', lmDriveRain:'🌦️ Off to the Rain Garden Weather Bell…', lmArriveRain:"🚕 We've reached the <b>Rain Garden</b>! Ring the bell to call a sunshower 🌦️",
     festAllStamps:'🎆 You\'ve explored the whole village! Every landmark stamped — enjoy the festival!', festRepos:'🎆 {n} repos visited! Fireworks light up the sky.',
     metricNote:'🏠 Buildings grow from metrics — 👁 visitors = height · ⑂ forks = width · ⬇ clones = decoration · 📈 views = yard · ★ = gold star · 🌙 at night, window glow = repo activity.',
+    seasonSpring:'Spring', seasonSummer:'Summer', seasonAutumn:'Autumn', seasonWinter:'Winter', seasonCity:'City season',
+    wearRecent:'Recently tended', wearFaded:'Faded traces', wearMossed:'Mossed by time',
+    ruinStatus:'Gentle ruin with wildflowers', ruinNote:'This public repository is archived and resting, while its original silhouette and accessible nameplate remain part of the city memory.',
+    ruinListAria:'Archived repository nameplates',
     cityOfRepos:'the city of repos',
     introSub:"Forget the 6-pin limit.<br>Stroll a living city where all my repos live —<br>ask Gitber and it'll drive you right to any repo.",
     introSubPublic:"A city built from {user}'s public repos.<br>Stroll around and explore —<br>or hop the train at 🚉 Station to visit another town.",
@@ -2672,16 +2703,32 @@ function applyLang(){
   if(_mapReady && typeof syncMapChrome==='function') syncMapChrome();
   if(typeof window.__updateLiveTitle==='function') window.__updateLiveTitle();
   if(typeof _refreshRepositoryAtelierLanguage==='function') _refreshRepositoryAtelierLanguage();
+  if(typeof refreshTimeTraceLabels==='function') refreshTimeTraceLabels();
 }
 
 const _maxClones = Math.max(1, ...REPOS.map(r=>r.clones||0));
 const _maxVis    = Math.max(1, ...REPOS.map(r=>r.visitors||0));
 const _maxViews  = Math.max(1, ...REPOS.map(r=>r.views||0));
-const _now = Date.now();
-REPOS.forEach(repo=>{
+const _CITY_SEASON_OVERRIDE=_DBG?_QUERY.get('citySeason')||'':'';
+const _CITY_TIME_FIXTURES=_DBG&&_QUERY.get('cityTimeFixtures')==='1';
+const CITY_SEASON=resolveCitySeason(CITY_STATE,_CITY_SEASON_OVERRIDE);
+const CITY_SEASON_STYLE=seasonPalette(CITY_SEASON);
+const _now=CITY_STATE?cityReferenceTimestamp(CITY_STATE,REPOS,Date.now()):Date.now();
+const _cityTint=(color,target,amount)=>new THREE.Color(color).lerp(new THREE.Color(target),amount).getHex();
+REPOS.forEach((repo,index)=>{
   const p = pal(repo.lang);
+  const sampleWear=_CITY_TIME_FIXTURES&&index<3?['recent','faded','mossed'][index]:'';
+  const cityTime=projectCityTime(repo,CITY_STATE,REPOS,{referenceTimestamp:_now,season:CITY_SEASON,
+    wear:sampleWear,archived:_CITY_TIME_FIXTURES&&index===3});
+  repo._wearState=cityTime.state; repo._wearDays=cityTime.daysSincePush; repo._ruin=cityTime.archived;
   repo.label = labelOf(repo.repo);
-  repo.wall = p.wall; repo.roof = p.roof; repo.accent = p.accent; repo.color = hexstr(p.accent);
+  repo.wall=_cityTint(p.wall,CITY_SEASON_STYLE.building,CITY_SEASON_STYLE.buildingMix);
+  repo.roof=_cityTint(p.roof,CITY_SEASON_STYLE.building,CITY_SEASON_STYLE.buildingMix*.65);
+  repo.accent=_cityTint(p.accent,CITY_SEASON_STYLE.building,CITY_SEASON_STYLE.buildingMix*.45);
+  if(repo._wearState==='faded'){ repo.wall=_cityTint(repo.wall,0xb7aa96,.14); repo.roof=_cityTint(repo.roof,0xa98370,.1); repo.accent=_cityTint(repo.accent,0x87918b,.1); }
+  else if(repo._wearState==='mossed'){ repo.wall=_cityTint(repo.wall,0x90977a,.17); repo.roof=_cityTint(repo.roof,0x718064,.16); repo.accent=_cityTint(repo.accent,0x718a6b,.12); }
+  if(repo._ruin){ repo.wall=_cityTint(repo.wall,0xa49e88,.24); repo.roof=_cityTint(repo.roof,0x68775c,.28); repo.accent=_cityTint(repo.accent,0x72865f,.26); }
+  repo.color = hexstr(repo.accent);
   repo.live = repo.home || ''; repo.vuniq = repo.visitors;
   const days = repo.pushed ? Math.max(0,(_now - new Date(repo.pushed).getTime())/86400000) : 3650;
   const recency = Math.exp(-days/120);
@@ -2708,10 +2755,11 @@ REPOS.forEach(repo=>{
       + 0.3*(Math.log1p(repo.clones||0)/Math.log1p(_maxClones))
       + 0.1*(Math.log1p(repo.views||0)/Math.log1p(_maxViews)));
   }
+  if(repo._ruin) repo._activity=Math.min(repo._activity,0.08);
   repo._downtown = (repo.rank||0) < 14;
   // data-driven town events: a recent release throws a party (garland + confetti); open issues fire up a busy workshop (chimney smoke)
   repo._relDays = repo.release_date ? Math.max(0,(_now - new Date(repo.release_date).getTime())/86400000) : null;
-  repo._fresh = repo._relDays!=null && repo._relDays<=60;
+  repo._fresh = !repo._ruin && repo._relDays!=null && repo._relDays<=60;
   repo._issues = repo.open_issues||0;
   repo._busy = Math.min(1, repo._issues/12);
 });
@@ -2809,7 +2857,7 @@ const DETAIL = IS_MOBILE ? (LOW_END ? 0.5 : 0.72) : (LOW_END ? 0.82 : 1);   // s
 const detail = n => Math.max(0, Math.round(n*DETAIL));                       // scale a per-instance count by the device tier
 
 const scene = new THREE.Scene();
-scene.fog = new THREE.Fog(0xd9e4c8, 150, 460);
+scene.fog = new THREE.Fog(CITY_SEASON_STYLE.fog, 150, 460);
 const camera = new THREE.PerspectiveCamera(54, innerWidth/innerHeight, 0.1, 760);
 const _cappedTargetDpr=(cap,maxPixels)=>Math.min(renderer.getPixelRatio(),cap,Math.sqrt(maxPixels/Math.max(1,innerWidth*innerHeight)));
 const _treeEmissiveTargetDpr=()=>_cappedTargetDpr(_desktopFrameDropGuard()?0.55:0.75,_desktopFrameDropGuard()?700000:1200000);
@@ -3974,7 +4022,7 @@ function zoneOf(repo){
   const aff=ZLANG[repo.lang]||{}; for(const z in aff) s[z]+=aff[z];
   const best=Math.max(s.ai,s.infra,s.web,s.data,s.library);
   const junk=/\b(temp|tmp|test ?bed|xmas|christmas|competition|myipynb|scratch|playground|sandbox)\b/i.test(repo.repo+' '+(repo.desc||''));
-  const age=repo.pushed?Math.max(0,(Date.now()-new Date(repo.pushed).getTime())/86400000):3650;
+  const age=repo.pushed?Math.max(0,(_now-new Date(repo.pushed).getTime())/86400000):3650;
   if(junk || (best<=1 && (repo.stars||0)<=1 && age>420 && (repo.rank||0)>=40)) return 'ruins';
   const order=['ai','infra','library','data','web']; let bz='commons', bs=0;
   for(const z of order){ if(s[z]>bs){ bs=s[z]; bz=z; } }
@@ -4756,6 +4804,8 @@ const GEO_STEM=new THREE.CylinderGeometry(0.03,0.03,0.42,5), GEO_FLOWER=new THRE
       GEO_TRUNK=new THREE.CylinderGeometry(0.12,0.16,0.9,6), GEO_CROWN=new THREE.SphereGeometry(0.7,10,8);
 const MAT_STEM=toon(0x5aa048), MAT_TRUNK=toon(0x7a5230), MAT_CROWN=toon(0x5aa048);
 const FLOWER_MATS=[0xff6f91,0xffd23f,0xff8c42,0xb06fe0,0xffffff].map(c=>basic(c));
+const RUIN_MOSS_GEO=new THREE.SphereGeometry(0.32,8,6), RUIN_MOSS_MAT=toon(0x688354),
+      RUIN_FLOWER_MAT=new THREE.MeshBasicMaterial({color:0xffffff});
 // 🐕 chow-chow — clean rounded shape in 3 coat colors (아이보리 / 갈색 / 검정)
 const CHOW_COATS=[
   { fur:0xe9dcc0, fur2:0xd6c2a0, snout:0xfff3e0, nose:0x2a2018, eye:0x2a2018 },   // ivory
@@ -4936,6 +4986,20 @@ function addRoofTech(g,w,topH){
   sky.rotation.x=-Math.PI/2; sky.position.set(w*0.22,St+0.03,w*0.22); g.add(sky);
   const hv=rbox(w*0.2,0.42,w*0.2,0xbcc3cb,0.03); hv.position.set(-w*0.24,St+0.22,-w*0.22); outline(hv,0.03); g.add(hv);
 }
+function addGentleRuin(g,repo,w,h,d,yr,topH){
+  if(!repo._ruin) return;
+  const seed=hashStr(repo.repo),sample=i=>((Math.imul((seed^(i*0x9e3779b9))>>>0,2654435761)>>>0)/4294967296);
+  const mossN=LOW_END?5:9,moss=new THREE.InstancedMesh(RUIN_MOSS_GEO,RUIN_MOSS_MAT,mossN),dummy=new THREE.Object3D();
+  for(let i=0;i<mossN;i++){ const roof=i>=mossN-2,x=(sample(i)-.5)*w*.72,y=roof?topH+.22:h*(.18+sample(i+13)*.7),z=roof?(sample(i+23)-.5)*d*.55:d*.5+.14;
+    dummy.position.set(x,y,z); dummy.scale.set(.7+sample(i+31)*.9,.22+sample(i+41)*.28,.52+sample(i+53)*.62); dummy.rotation.set(sample(i+61)*.5,sample(i+71)*Math.PI,.12); dummy.updateMatrix(); moss.setMatrixAt(i,dummy.matrix); }
+  moss.name=`RuinMoss_${repo.repo}`; moss.castShadow=false; moss.receiveShadow=true; g.add(moss);
+  const flowerN=LOW_END?4:7,flowers=new THREE.InstancedMesh(GEO_FLOWER,RUIN_FLOWER_MAT,flowerN),colors=[0xf0d56d,0xe7a3bd,0xb9a7dd,0xf7eee1];
+  for(let i=0;i<flowerN;i++){ const side=i%2?-1:1,x=side*(.7+sample(i+83)*Math.max(1,yr*.55)),z=d*.5+.82+sample(i+97)*1.5;
+    dummy.position.set(x,.18+sample(i+109)*.18,z); const s=.8+sample(i+127)*.8; dummy.scale.setScalar(s); dummy.rotation.set(0,sample(i+139)*Math.PI,0); dummy.updateMatrix();
+    flowers.setMatrixAt(i,dummy.matrix); flowers.setColorAt(i,new THREE.Color(colors[i%colors.length])); }
+  flowers.name=`RuinWildflowers_${repo.repo}`; flowers.castShadow=false; g.add(flowers);
+  repo._ruinDetails={moss:mossN,flowers:flowerN,draws:2};
+}
 function makeBuilding(repo){
   repo._cat = repoCategory(repo);
   const typ = typology(repo);
@@ -4996,7 +5060,8 @@ function makeBuilding(repo){
     addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, wx); addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, -wx); }
   // central roof
   repo._lodSpec={kind,roof:typ.roof,tier:typ.tier,w,h,d,topH,topW,wall:repo.wall,roofColor:repo.roof,accent:repo.accent,entranceColor:(CATS[repo._cat]||CATS.Software).color,
-    yardRadius:yr,yardColor:repo._downtown?0xcbb888:0x86c069,hedgeColor:repo._downtown?0xb7a274:0x5d9e46,rich,fancy,flags,stars:repo.stars||0};
+    yardRadius:yr,yardColor:repo._downtown?0xcbb888:0x86c069,hedgeColor:repo._downtown?0xb7a274:0x5d9e46,rich,fancy,flags,stars:repo.stars||0,
+    wear:repo._wearState,ruin:repo._ruin};
   const cameraRoofRadius=topW*({flat:.73,hip:.9,gambrel:.96,mansard:1,aframe:.82,shed:.76,barrel:.74}[typ.roof]||.95);
   const cameraRoofRise=typ.roof==='flat'?1.1:typ.roof==='hip'?1.75:typ.roof==='gambrel'?2.35:typ.roof==='mansard'?2.32:
     typ.roof==='aframe'?2.22:typ.roof==='shed'?1.55:typ.roof==='barrel'?topW*.52+0.12:2.65;
@@ -5013,8 +5078,8 @@ function makeBuilding(repo){
   const roof=makeRoof(typ.roof, topW, topH, repo.roof); g.add(roof); repo._roof=roof;
   const flatTop = (typ.roof==='flat');
   if(typ.roof!=='flat' && typ.roof!=='aframe'){ const chim=rbox(0.55,1.2,0.55,0x6e4a32,0.08); chim.position.set(w*0.32,topH+1.4,d*0.22); outline(chim,0.04); g.add(chim);
-    if(rich>0.18 || repo._busy>0) addSmoke(g, w*0.32, topH+2.3, d*0.22, repo._busy); }
-  else if(repo._busy>0){ const chim=rbox(0.55,1.2,0.55,0x6e4a32,0.08); chim.position.set(w*0.32,topH+0.9,d*0.22); outline(chim,0.04); g.add(chim);
+    if(!repo._ruin&&(rich>0.18 || repo._busy>0)) addSmoke(g, w*0.32, topH+2.3, d*0.22, repo._busy); }
+  else if(!repo._ruin&&repo._busy>0){ const chim=rbox(0.55,1.2,0.55,0x6e4a32,0.08); chim.position.set(w*0.32,topH+0.9,d*0.22); outline(chim,0.04); g.add(chim);
     addSmoke(g, w*0.32, topH+1.8, d*0.22, repo._busy); }   // busy workshop still smokes even under a flat/aframe roof
   if(kind==='tower'){ const tank=new THREE.Mesh(new THREE.CylinderGeometry(w*0.16,w*0.16,0.9,10), toon(0x8a98a6)); tank.position.set(w*0.2,h+1.0,-d*0.18); outline(tank,0.04); g.add(tank); }
   if(kind==='house' && typ.roof!=='shed' && typ.roof!=='aframe'){ addDormer(g,d,topH+0.55); }
@@ -5040,7 +5105,7 @@ function makeBuilding(repo){
     const fr=rbox(1.18,1.30,0.16,0xeadfca,0.05); fr.position.set(wx,wy,d/2+0.01); g.add(fr);
     const sill=rbox(1.32,0.16,0.30,0xe0d2b4,0.04); sill.position.set(wx,wy-0.74,d/2+0.10); g.add(sill);
     const gl=new THREE.Mesh(new THREE.PlaneGeometry(0.96,1.06), new THREE.MeshBasicMaterial({map:_winTex,transparent:true,color:DAY_GLASS}));
-    gl.position.set(wx,wy,d/2+0.11); gl.userData={ lit: Math.random()<(0.3+0.55*repo._activity), j:0.82+Math.random()*0.32 }; g.add(gl); repo._windows.push(gl);
+    gl.position.set(wx,wy,d/2+0.11); gl.userData={ lit: !repo._ruin&&Math.random()<(0.3+0.55*repo._activity), j:0.82+Math.random()*0.32 }; g.add(gl); repo._windows.push(gl);
     // operable shutters flank windows on traditional pitched-roof homes — Provence pastel (lavender/sage/blue)
     if(typ.tier>=2 && typ.roof!=='flat' && typ.roof!=='shed' && kind!=='tower'){ const shCol=shade(repo.accent,-6), off=0.72;
       [-1,1].forEach(s=>{ const sx=wx+s*off; if(Math.abs(sx)+0.16 > w*0.5-0.05) return;
@@ -5065,11 +5130,13 @@ function makeBuilding(repo){
   if(kind==='manor'||kind==='mansion'){ signW=3.5; signH=1.19; signY=3.66; signZ=d/2+1.72; }  // on the portico frieze, in front of the columns
   else if(kind==='house'){ signY=3.24; signZ=d/2+0.46; }                                       // above the porch roof
   else if(kind==='shop'){ signY=3.04; signZ=d/2+0.36; }                                        // above the shop awning
-  const board=new THREE.Mesh(new THREE.PlaneGeometry(signW,signH), new THREE.MeshBasicMaterial({map:signTexture(repo.label,(CATS[repo._cat]||CATS.Software).color),transparent:true}));
+  const boardAccent=repo._ruin?0x6d8257:(CATS[repo._cat]||CATS.Software).color;
+  const board=new THREE.Mesh(new THREE.PlaneGeometry(signW,signH), new THREE.MeshBasicMaterial({map:signTexture(repo.label,boardAccent),transparent:true}));
   board.position.set(0,signY,signZ); g.add(board); repo._sign=board;
   // category emblem high on the front, facing street
   const emb=new THREE.Mesh(new THREE.PlaneGeometry(1.1,1.1), new THREE.MeshBasicMaterial({map:emblemTexture(repo._cat),transparent:true,depthWrite:false}));
   emb.position.set(0, h+(typ.roof==='flat'?0.62:1.05), d/2+0.06); g.add(emb); repo._emblem=emb;
+  addGentleRuin(g,repo,w,h,d,yr,topH);
   // destination ring on the plot
   const ring=new THREE.Mesh(new THREE.RingGeometry(Math.max(2,yr-1.4),Math.max(2.7,yr-0.8),40),
     new THREE.MeshBasicMaterial({color:repo.color,transparent:true,opacity:.42,side:THREE.DoubleSide}));
@@ -5083,6 +5150,24 @@ function makeBuilding(repo){
   repo._group=g; repo._pos=new THREE.Vector3(repo._x,0,repo._z); repo._visited=false; buildings.push(repo);
 }
 REPOS.forEach(makeBuilding);
+function _seasonCopyKey(){ return {spring:'seasonSpring',summer:'seasonSummer',autumn:'seasonAutumn',winter:'seasonWinter'}[CITY_SEASON]||'seasonSummer'; }
+function _wearCopyKey(repo){ return {recent:'wearRecent',faded:'wearFaded',mossed:'wearMossed'}[repo?._wearState]||'wearMossed'; }
+function refreshRepoCardTimeTrace(repo){
+  if(!repo) return;
+  const wear=document.getElementById('cardWearChip'),season=document.getElementById('cardSeasonChip'),archive=document.getElementById('cardArchiveChip'),note=document.getElementById('cardTimeTrace');
+  if(wear) wear.textContent=({recent:'✨',faded:'☀️',mossed:'🌿'}[repo._wearState]||'🌿')+' '+t(_wearCopyKey(repo));
+  if(season) season.textContent='◌ '+t(_seasonCopyKey())+' · '+t('seasonCity');
+  if(archive){ archive.hidden=!repo._ruin; archive.textContent='🌼 '+t('ruinStatus'); }
+  if(note){ note.hidden=!repo._ruin; note.textContent=repo._ruin?t('ruinNote'):''; }
+}
+function refreshTimeTraceLabels(){
+  for(const repo of REPOS){ if(!repo._sign) continue; const accent=repo._ruin?0x6d8257:(CATS[repo._cat]||CATS.Software).color,old=repo._sign.material.map;
+    repo._sign.material.map=signTexture(repo.label,accent); repo._sign.material.needsUpdate=true; if(old) old.dispose(); }
+  const list=document.getElementById('ruinNameplates'); if(list){ list.setAttribute('aria-label',t('ruinListAria'));
+    list.replaceChildren(...REPOS.filter(repo=>repo._ruin).map(repo=>{ const item=document.createElement('span'); item.setAttribute('role','listitem'); item.textContent=repo.label+' — '+t('ruinStatus'); return item; })); }
+  const active=REPOS.find(repo=>repo.repo===(document.getElementById('modal')?._repoKey||'')); if(active) refreshRepoCardTimeTrace(active);
+}
+refreshTimeTraceLabels();
 
 /*BUILDING_LOD_PROTOTYPE:START*/
 const BUILDING_LOD_NIGHT={value:0};
@@ -5210,6 +5295,9 @@ function _buildingLodReadabilityGeometry(repo){
   const banners=Math.min(3,Math.max(0,Number(spec.flags)||0)); for(let i=0;i<banners;i++) addBox(.18,.48,.08,(i-(banners-1)*.5)*.5,spec.h-.42,front+.14,i%2?accent:entrance,'metric-banner');
   const gardenN=(spec.rich??0)>.66?3:(spec.rich??0)>.22?2:1; for(let i=0;i<gardenN;i++){ const side=i%2?-1:1,x=side*(1.45+Math.floor(i/2)*.48);
     addBox(.72,.18,.54,x,.12,front+1.4,hedgeColor,'garden-bed'); addBox(.16,.28,.16,x,.31,front+1.4,i%2?accent:warm,'garden-bloom'); }
+  if(spec.ruin){ addBox(spec.w*.66,.18,.18,-spec.w*.08,spec.h*.72,front+.17,0x688354,'ruin-ivy');
+    addBox(spec.w*.38,.16,.2,spec.w*.2,spec.topH+.16,0,0x718064,'ruin-roof-moss');
+    for(let i=-1;i<=1;i++) addBox(.16,.26,.16,i*.54,.22,front+1.12,i===0?0xe7a3bd:0xf0d56d,'ruin-wildflower'); }
   const geometry=new THREE.BufferGeometry(); geometry.setIndex(indices);
   geometry.setAttribute('position',new THREE.Float32BufferAttribute(positions,3)); geometry.setAttribute('color',new THREE.Float32BufferAttribute(colors,3));
   geometry.computeBoundingBox(); geometry.computeBoundingSphere(); geometry.userData={sources:[...sources],kind:spec.kind,roof:spec.roof}; return geometry;
@@ -6556,8 +6644,10 @@ const SKY_KEYS=[
   {t:0.50, top:0x3f93d6,mid:0xa9d4ea,bot:0xf8e4bf, sunI:1.50,sunC:0xffd89a, hemiI:0.85,hemiC:0xe0ecda,hemiG:0x8e9a66, fog:0xd9e4c8, exp:1.08, rimC:0xcfeaff,rimS:0.16,rimP:2.8, sunUp:0.95,sunA:0.0, sunOp:1.0},
   {t:0.75, top:0x2a3a6e,mid:0xc2697e,bot:0xffa862, sunI:0.85,sunC:0xff985a, hemiI:0.62,hemiC:0xc88a78,hemiG:0x6a5848, fog:0xc8845a, exp:1.08, rimC:0xffb088,rimS:0.26,rimP:2.4, sunUp:0.08,sunA:1.35, sunOp:0.9},
 ];
-SKY_KEYS.forEach(k=>{ k.cTop=new THREE.Color(k.top); k.cMid=new THREE.Color(k.mid); k.cBot=new THREE.Color(k.bot);
-  k.cSun=new THREE.Color(k.sunC); k.cHemi=new THREE.Color(k.hemiC); k.cHemiG=new THREE.Color(k.hemiG); k.cFog=new THREE.Color(k.fog); k.cRim=new THREE.Color(k.rimC); });
+const _seasonSky=new THREE.Color(CITY_SEASON_STYLE.sky),_seasonFog=new THREE.Color(CITY_SEASON_STYLE.fog),_seasonLight=new THREE.Color(CITY_SEASON_STYLE.light);
+SKY_KEYS.forEach(k=>{ k.cTop=new THREE.Color(k.top).lerp(_seasonSky,CITY_SEASON_STYLE.skyMix); k.cMid=new THREE.Color(k.mid).lerp(_seasonSky,CITY_SEASON_STYLE.skyMix*.72); k.cBot=new THREE.Color(k.bot).lerp(_seasonSky,CITY_SEASON_STYLE.skyMix*.48);
+  k.cSun=new THREE.Color(k.sunC).lerp(_seasonLight,CITY_SEASON_STYLE.lightMix); k.cHemi=new THREE.Color(k.hemiC).lerp(_seasonLight,CITY_SEASON_STYLE.lightMix);
+  k.cHemiG=new THREE.Color(k.hemiG).lerp(_seasonFog,CITY_SEASON_STYLE.fogMix*.45); k.cFog=new THREE.Color(k.fog).lerp(_seasonFog,CITY_SEASON_STYLE.fogMix); k.cRim=new THREE.Color(k.rimC); });
 
 // paint sky gradient / lights / fog / sun-disc for a continuous time-of-day t∈[0,1)
 function applySky(t,forceShadow=false){
@@ -6603,13 +6693,13 @@ function setNightState(night){
   npcFaces.forEach(m=>m.emissive.setHex(night?0x4a3a24:0x000000));   // softer than the player so the hero still reads brightest
   buildings.forEach(b=>{
     (b._windows||[]).forEach(w=>{ const m=w.material;
-      if(night){ if(w.userData.lit){ m.map=_roomTex; m.color.copy(_cRoom).multiplyScalar((0.5+0.5*b._activity)*w.userData.j); }
+      if(night){ if(!b._ruin&&w.userData.lit){ m.map=_roomTex; m.color.copy(_cRoom).multiplyScalar((0.5+0.5*b._activity)*w.userData.j); }
                  else { m.map=_winTex; m.color.setHex(0x2b3442); } }
       else { m.map=_winTex; m.color.setHex(DAY_GLASS); }
       m.needsUpdate=true; });
-    if(b._body){ if(night) b._body.material.emissive.setRGB(0.5,0.32,0.12).multiplyScalar(0.45*b._activity);
+    if(b._body){ if(night&&!b._ruin) b._body.material.emissive.setRGB(0.5,0.32,0.12).multiplyScalar(0.45*b._activity);
                  else b._body.material.emissive.setHex(0x000000); }
-    if(b._glowPool) b._glowPool.material.opacity = night ? (0.06+0.5*b._activity) : 0;
+    if(b._glowPool) b._glowPool.material.opacity = night&&!b._ruin ? (0.06+0.5*b._activity) : 0;
   });
   libNightBoost.forEach(o=>{ o.material.opacity = night ? o._n : o._d; });
   if(LIB&&LIB._group) LIB._group.traverse(o=>{ if(o.userData&&o.userData.libGlow!==undefined&&o.material&&o.material.emissive) o.material.emissive.setHex(night?o.userData.libGlow:0x000000); });
@@ -9143,7 +9233,8 @@ window.addEventListener('hashchange',()=>{ if(_repoHashGuard) return; const k=re
 
 function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
   starTrailVisit(repo); lanternWatchVisit(repo); courseMark('repo',repo.repo);
-  modalOpen=true; modal.classList.add('show'); modal._repoKey=repo.repo||null; setRepoHash(repo);
+  if(!modal.classList.contains('show')) modal._previousFocus=document.activeElement;
+  modalOpen=true; modal.classList.add('show'); modal.setAttribute('aria-hidden','false'); modal._repoKey=repo.repo||null; setRepoHash(repo);
   repoRouteVisit(repo);
   document.getElementById('cardTop').style.background=repo.color;
   document.getElementById('cardLang').textContent=repo.lang.toUpperCase();
@@ -9165,7 +9256,9 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
     (repo.open_issues?`<span class="chip">◎ <b>${repo.open_issues}</b> issues</span>`:'')+
     (repo.license?`<span class="chip">⚖ <b>${repo.license}</b></span>`:'')+
     (repo.release_tag?`<span class="chip" title="${repo.release_date||''}">🏷 <b>${repo.release_tag}</b></span>`:'')+
-    (repo.archived?`<span class="chip">📦 ${LANG==='ko'?'보관됨':'archived'}</span>`:'');
+    `<span class="chip" id="cardWearChip"></span><span class="chip" id="cardSeasonChip"></span>`+
+    `<span class="chip" id="cardArchiveChip"${repo._ruin?'':' hidden'}></span>`;
+  refreshRepoCardTimeTrace(repo);
   const mnote=document.getElementById('cardMetricNote');
   if(mnote) mnote.textContent = repo.trafficKnown===false ? t('publicMetricNote') : t('metricNote');
   const since=document.getElementById('cardSince');
@@ -9196,8 +9289,9 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
   const liveBtn=act.querySelector('a.live'); if(liveBtn) liveBtn.onclick=()=>track('live_demo_click',{repo:repo.repo});
   track('repo_card_open',{repo:repo.repo});
   renderCardAsk(repo);
-  markVisited(repo); }
-function closeCard(){ modalOpen=false; modal.classList.remove('show'); modal._repoKey=null; clearRepoHash(); flushStarNudge(); }
+  markVisited(repo); setTimeout(()=>{ const close=document.getElementById('closeBtn'); if(close) close.focus(); },0); }
+function closeCard(){ const previous=modal._previousFocus; modalOpen=false; modal.classList.remove('show'); modal.setAttribute('aria-hidden','true'); modal._repoKey=null; modal._previousFocus=null; clearRepoHash(); flushStarNudge();
+  if(previous&&previous.isConnected&&typeof previous.focus==='function') previous.focus(); }
 /* ───────── 🚕 Repo-card actions — reuse the existing taxi/chat flow (no new backend) ───────── */
 function _taxiNpc(){ return (typeof NPCS!=='undefined'&&NPCS)?(NPCS.find(n=>n.kind==='taxi')||activeNpc||NPCS[0]):activeNpc; }
 function askInChat(q){ if(!q) return; const npc=_taxiNpc(); closeCard();   // routes through taxi → localIntent/grounded, same as typing it
@@ -9265,6 +9359,10 @@ function renderCardAsk(repo){ const box=document.getElementById('cardAsk'); if(!
   const sb=box.querySelector('[data-ca="similar"]'); if(sb) sb.onclick=()=>{ track('card_ask',{repo:repo.repo,kind:'similar'}); cardSimilar(repo); };
   box.querySelectorAll('.caChip').forEach(el=>{ el.onclick=()=>{ track('card_ask',{repo:repo.repo,kind:'chip'}); askInChat(el.dataset.caq); }; }); }
 modal.addEventListener('click',e=>{ if(e.target===modal) closeCard(); });
+modal.addEventListener('keydown',e=>{ if(e.key==='Escape'){ e.preventDefault(); closeCard(); return; } if(e.key!=='Tab') return;
+  const items=[...modal.querySelectorAll('button:not([disabled]),a[href]')].filter(item=>!item.hidden); if(!items.length) return;
+  const first=items[0],last=items[items.length-1]; if(e.shiftKey&&document.activeElement===first){ e.preventDefault(); last.focus(); }
+  else if(!e.shiftKey&&document.activeElement===last){ e.preventDefault(); first.focus(); } });
 
 /* ---- Contribution Library panel ---- */
 const libModal=document.getElementById('libModal');
@@ -9425,8 +9523,9 @@ creatorShare.onclick=async()=>{ const ok=await _copyPostcardText(_postcardShareU
 creatorStar.onclick=()=>{ track('project_star_click',{source:'creator_hall'}); _starNudgeClose('clicked'); };
 window.__creatorLangRefresh=()=>renderCreatorHall();
 
-/* a visited house lights up for good — every window lit + a warm lantern glow above it (day & night) */
+/* a visited house lights up for good — active windows glow while ruins keep their quiet, unlit identity */
 function lightVisitedHouse(repo, defer){ if(!repo||repo._litVisited) return; repo._litVisited=true;
+  if(repo._ruin){ (repo._windows||[]).forEach(w=>{ w.userData.lit=false; }); _syncBuildingLodFacade(repo); return; }
   (repo._windows||[]).forEach(w=>{ w.userData.lit=true; });
   _syncBuildingLodFacade(repo);
   if(repo._group && !repo._visitMark){ const h=repo._h||6;
@@ -12151,7 +12250,10 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__ride=()=>ride?ride.phase:null; window.__taxiPos=()=>({x:+taxi.position.x.toFixed(1),z:+taxi.position.z.toFixed(1),vis:model.visible});
   window.__ask=(q)=>{ const r=localIntent(q); return r&&r.repo?r.repo.repo:null; };
   window.__taxi=(name)=>{ const r=repoByKey(name)||(name&&REPOS.find(x=>x.label===name)); if(r&&r._pos){ taxiTo(r); return true; } return false; };
-  window.__repos=()=>REPOS.map(r=>({repo:r.repo,d:Math.round(Math.hypot(r._x,r._z)),rank:r.rank,custom:!!r.social_custom}));
+  window.__repos=()=>REPOS.map(r=>({repo:r.repo,d:Math.round(Math.hypot(r._x,r._z)),rank:r.rank,custom:!!r.social_custom,wear:r._wearState,ruin:!!r._ruin}));
+  window.__cityTime=()=>({schema:CITY_STATE?.schema||null,version:CITY_STATE?.version||null,season:CITY_SEASON,reference:new Date(_now).toISOString(),
+    fallback:!!CITY_STATE?.season?.fallback?.used,wear:REPOS.reduce((out,repo)=>{ out[repo._wearState]=(out[repo._wearState]||0)+1; return out; },{}),
+    ruins:REPOS.filter(repo=>repo._ruin).map(repo=>({repo:repo.repo,details:repo._ruinDetails||null})),roots:CITY_STATE?.roots?.length||0,fixture:_CITY_TIME_FIXTURES});
   window.__card=(name)=>{ const r=repoByKey(name); if(r){ openCard(r); return {repo:r.repo,license:r.license,open_issues:r.open_issues,release_tag:r.release_tag,archived:r.archived,chips:[...document.querySelectorAll('#cardChips .chip')].map(c=>c.textContent.trim())}; } return null; };
   window.__modal=()=>modalOpen;
   window.__rt=()=>({peers:peers.size, live:liveCountEl.textContent, total:allCountEl.textContent, entriesToday:entryCountEl?entryCountEl.textContent:null, entriesTotal:entryTotalCountEl?entryTotalCountEl.textContent:null, ws:rtSock?rtSock.readyState:-1,join:_lastRealtimeJoinPose});

--- a/repos.json
+++ b/repos.json
@@ -75,7 +75,7 @@
 "views": 4022,
 "visitors": 781,
 "clones": 7266,
-"size": 17804,
+"size": 23622,
 "open_issues": 0,
 "license": "MIT",
 "archived": false,
@@ -83,7 +83,7 @@
 "release_tag": "gdpval-sandbox-v1.0.0",
 "release_date": "2026-07-10",
 "created": "2026-02-24",
-"pushed": "2026-08-22",
+"pushed": "2026-08-23",
 "tracked": true,
 "first_seen": "2026-02-26",
 "social": "https://repository-images.githubusercontent.com/1165924985/01ea1813-25a2-4604-87dd-f71bf795447a",
@@ -136,7 +136,7 @@
 "pushed": "2026-08-22",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/d588c4465bdc5d5102cac0e9f246550019541af01bfe4d8ff748618f47f79bcd/hyeonsangjeon/computing-Korean-STT-error-rates",
+"social": "https://opengraph.githubassets.com/2b3ab75af1858d23c3508ff5ede02fcb88110f67b7a87e5fc09fdc7c8ab6d864/hyeonsangjeon/computing-Korean-STT-error-rates",
 "social_custom": false,
 "score": 15.364,
 "rank": 2
@@ -168,8 +168,8 @@
 "views": 457,
 "visitors": 207,
 "clones": 3025,
-"size": 53237,
-"open_issues": 0,
+"size": 50102,
+"open_issues": 6,
 "license": "MIT",
 "archived": false,
 "default_branch": "main",
@@ -229,7 +229,7 @@
 "pushed": "2026-08-06",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/69f8f4963db9ca1ebe5e243cbbfa2c3ace3bcea705e56feca4e287977b553468/hyeonsangjeon/PDF2LLM-Tuning-Studio",
+"social": "https://opengraph.githubassets.com/cb4a8e7dd9300ac9162dbd0d546b1c42238a087723b3fd3c60a6d8d747a5f775/hyeonsangjeon/PDF2LLM-Tuning-Studio",
 "social_custom": false,
 "score": 12.1,
 "rank": 4
@@ -306,7 +306,7 @@
 "pushed": "2026-07-13",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/ee4316c1b47f2e11ffe2c8b710ba663b6904cd2d0234029c8d6b0809895fde64/hyeonsangjeon/Hyperparameters-Optimization",
+"social": "https://opengraph.githubassets.com/2bcd828444dc95084ce16bc1fbc40481de2a3e6ac0202916e66895512a6932d5/hyeonsangjeon/Hyperparameters-Optimization",
 "social_custom": false,
 "score": 11.558,
 "rank": 6
@@ -352,7 +352,7 @@
 "pushed": "2026-08-05",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/deb0c8ea391873bb3e09ecb789e7e8f8cda60e25f4176d7df26d21dddb2d167a/hyeonsangjeon/gotty-docker",
+"social": "https://opengraph.githubassets.com/9719f9bc00dae4799bf8108bc78cff78c7935b73e4ece12efdd98c4a573fdb92/hyeonsangjeon/gotty-docker",
 "social_custom": false,
 "score": 11.215,
 "rank": 7
@@ -531,7 +531,7 @@
 "pushed": "2026-08-12",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/634d341e6162941213728b92da90fa08bd8be23644bf0d27093be33a912969a5/hyeonsangjeon/AIsketcher",
+"social": "https://opengraph.githubassets.com/180f6512b6c71c991affbb82579544b14fe28779ffe45b5946afbae451bbd3ea/hyeonsangjeon/AIsketcher",
 "social_custom": false,
 "score": 10.153,
 "rank": 11
@@ -625,7 +625,7 @@
 "pushed": "2025-06-16",
 "tracked": true,
 "first_seen": "2025-07-03",
-"social": "https://opengraph.githubassets.com/6b2a286c9c32a0992078fc9844fe92b903d7ca2fadafb357b6ba0f8db56c1ef2/hyeonsangjeon/AWS-LLM-SageMaker",
+"social": "https://opengraph.githubassets.com/bf774150f8f8453566dfd860337cfcf172f8b37d8da388928e1b64a3f8de0d3f/hyeonsangjeon/AWS-LLM-SageMaker",
 "social_custom": false,
 "score": 9.31,
 "rank": 13
@@ -664,7 +664,7 @@
 "pushed": "2026-08-12",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/9a66837759af056f8cebc5bd1c44fd941ce6a6ab3837ef63075be9ef8a60ed44/hyeonsangjeon/pronunciation-mapper",
+"social": "https://opengraph.githubassets.com/59d7ef30c1baab8f62144a4ff4ce0ba2b76b30626c724709859472171e956d17/hyeonsangjeon/pronunciation-mapper",
 "social_custom": false,
 "score": 9.18,
 "rank": 14
@@ -694,17 +694,17 @@
 "visitors": 31,
 "clones": 1874,
 "size": 3488,
-"open_issues": 5,
+"open_issues": 6,
 "license": "MIT",
 "archived": false,
 "default_branch": "main",
 "release_tag": "",
 "release_date": "",
 "created": "2026-06-25",
-"pushed": "2026-08-22",
+"pushed": "2026-08-23",
 "tracked": true,
 "first_seen": "2026-07-14",
-"social": "https://opengraph.githubassets.com/eb3cc56fc46fb45bc66f9459086f17a60bc6ffc940677e0a37b8c0a715831f0b/hyeonsangjeon/foundry-cost-aware-model-routing",
+"social": "https://opengraph.githubassets.com/a14d04d43f9c87165091b678f509c2b82c7c0e206e0400875069a2dfb19ae730/hyeonsangjeon/foundry-cost-aware-model-routing",
 "social_custom": false,
 "score": 8.741,
 "rank": 15
@@ -733,7 +733,7 @@
 "pushed": "2025-06-04",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/f2f50d90442f4aa7ba632c91ed8d39f1feee5e893856dee28f0c8911ddc45e11/hyeonsangjeon/Amazon-Bedrock-Guardrails-Toolkit",
+"social": "https://opengraph.githubassets.com/02a0773678ce143581c7d27222760763800a3c85e4c8835708abf0bfbd555300/hyeonsangjeon/Amazon-Bedrock-Guardrails-Toolkit",
 "social_custom": false,
 "score": 8.718,
 "rank": 16
@@ -783,7 +783,7 @@
 "pushed": "2026-07-17",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/16bcfbee4f58b315661c872598495afbd80b28743affc86a3cd2115288e55b69/hyeonsangjeon/disparity-based-space-vagriant-image-deblurring",
+"social": "https://opengraph.githubassets.com/08b5af2ba67804b77e97b49abe07495fc83b07e647d3caa5a121266b678be7f9/hyeonsangjeon/disparity-based-space-vagriant-image-deblurring",
 "social_custom": false,
 "score": 8.503,
 "rank": 17
@@ -873,7 +873,7 @@
 "pushed": "2025-11-03",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/fcd4d5e5b4228bbe8fa5cd1b1945d7cbbae0b6afbd3e7b1e58c0237bf55fa5ce/hyeonsangjeon/strands-bedrock-agents-cookbook",
+"social": "https://opengraph.githubassets.com/d61d6372d6788b78f15dbead2d23de29492e9e28e9e43a535e23b84175836c11/hyeonsangjeon/strands-bedrock-agents-cookbook",
 "social_custom": false,
 "score": 7.697,
 "rank": 19
@@ -911,7 +911,7 @@
 "pushed": "2019-11-07",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/4fb4ad92a22e3d1f1e549906946d5a786e436f0ea3d9f16d4416dce6192da952/hyeonsangjeon/dataplatform",
+"social": "https://opengraph.githubassets.com/68e6434695cab3a90d033b73181c2871fa4fa2d2be2aa4ec9520226874a5e8bd/hyeonsangjeon/dataplatform",
 "social_custom": false,
 "score": 7.629,
 "rank": 20
@@ -940,7 +940,7 @@
 "pushed": "2026-07-03",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/5b19c001db9c39569696300df803b52c1efbf3877eee200432343b7a1b2c4677/hyeonsangjeon/Hyeonsang-AI-Contributions",
+"social": "https://opengraph.githubassets.com/33093b84cf52d9c81e043670ad8226d670ac439f5be56e29d624b822ee77a387/hyeonsangjeon/Hyeonsang-AI-Contributions",
 "social_custom": false,
 "score": 7.484,
 "rank": 21
@@ -982,7 +982,7 @@
 "pushed": "2026-08-12",
 "tracked": true,
 "first_seen": "2026-07-16",
-"social": "https://opengraph.githubassets.com/dd5d44372e87bebd594e0254d3d5becf46ea69ccc05d8fb3979979c3c75a3221/hyeonsangjeon/foundry-stream-lab",
+"social": "https://opengraph.githubassets.com/ff014799859c9205923f18f26f04ea895423048429ee04ad153cd01c46f6310f/hyeonsangjeon/foundry-stream-lab",
 "social_custom": false,
 "score": 7.109,
 "rank": 22
@@ -1019,7 +1019,7 @@
 "pushed": "2026-08-19",
 "tracked": true,
 "first_seen": "2026-07-25",
-"social": "https://opengraph.githubassets.com/f398d6632ef38e3d33e5b78e6e689b9376893a2cac0f3e291e82d04e98ac9803/hyeonsangjeon/multilingual-oss-map",
+"social": "https://opengraph.githubassets.com/e1cc9e068d885e9ec2443d11699275e7e52b4743b9e52e9dc60db84ea3c2b978/hyeonsangjeon/multilingual-oss-map",
 "social_custom": false,
 "score": 6.857,
 "rank": 23
@@ -1048,7 +1048,7 @@
 "pushed": "2019-05-24",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/395cfb4be50f578c64250923b455cff79faf810dade5b7e3bcdeba612e78c046/hyeonsangjeon/mariadb-galera-cluster",
+"social": "https://opengraph.githubassets.com/4eece9c23052bdff218e1925b89a1e8360ebc7b7581f6f9fabad9e516c106c83/hyeonsangjeon/mariadb-galera-cluster",
 "social_custom": false,
 "score": 6.831,
 "rank": 24
@@ -1077,7 +1077,7 @@
 "pushed": "2026-03-08",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/a88d4c9f44bae0b1dec62cd71063bb68717d4b95e1cb251bd6f64dd9c831d07d/hyeonsangjeon/FSI-Gameday-General-Immersion-Day",
+"social": "https://opengraph.githubassets.com/f8b4971d7a787bb905006c223c26c32e431684f31693c0b419b488196011abc0/hyeonsangjeon/FSI-Gameday-General-Immersion-Day",
 "social_custom": false,
 "score": 6.495,
 "rank": 25
@@ -1106,7 +1106,7 @@
 "pushed": "2025-03-07",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/179760fe792da299bb007ecaa299b0ec763273f3e3f38399bb496a349f68d457/hyeonsangjeon/aws-llm-dashboard",
+"social": "https://opengraph.githubassets.com/013b6e385f977d4b6413a442b0450f5836bfc1ec0c350e9a763178b2f4a29f0c/hyeonsangjeon/aws-llm-dashboard",
 "social_custom": false,
 "score": 6.49,
 "rank": 26
@@ -1173,7 +1173,7 @@
 "pushed": "2026-08-17",
 "tracked": true,
 "first_seen": "2026-07-10",
-"social": "https://opengraph.githubassets.com/7143ab45c9f26b1aac95d572140e2e5cb7967d0cd806501e66523610c14ba602/hyeonsangjeon/polaris-agent",
+"social": "https://opengraph.githubassets.com/b2425cbd6473baa6177d2419e60e10b517392f080aa79d8aab3ecae587a5dccf/hyeonsangjeon/polaris-agent",
 "social_custom": false,
 "score": 6.293,
 "rank": 28
@@ -1208,7 +1208,7 @@
 "pushed": "2019-06-03",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/d4258ad65d8274da2f6333d4c6be9aeec878711ab9d8ab8406ad6ece8a5fd62d/hyeonsangjeon/springboot-properties-docker",
+"social": "https://opengraph.githubassets.com/63403d67bf504b473f9dd67ae0e13d004db526ab77cb1033d9346b6ac71ea1e4/hyeonsangjeon/springboot-properties-docker",
 "social_custom": false,
 "score": 6.238,
 "rank": 29
@@ -1253,7 +1253,7 @@
 "pushed": "2019-02-15",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/489ab231ae0f72ef3ee17da77f2e5621475a3b79ae2f86b7f1d1c8a4b5089c71/hyeonsangjeon/springboot-examples",
+"social": "https://opengraph.githubassets.com/ff62277b3219218a52bcb85a3c2ceff29ba91fe403dc485d293eb00de46679c8/hyeonsangjeon/springboot-examples",
 "social_custom": false,
 "score": 6.107,
 "rank": 30
@@ -1282,7 +1282,7 @@
 "pushed": "2024-04-17",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/c518e0506f861f232bdb7775f0d485ca92385ca420fef65ff990548b3c2eea35/hyeonsangjeon/PEFT-Huggingface-LoRA-Korean-Data",
+"social": "https://opengraph.githubassets.com/f84e5076135401a9a9473a197892070c2f2e68311d71bfb2e0c8563386770769/hyeonsangjeon/PEFT-Huggingface-LoRA-Korean-Data",
 "social_custom": false,
 "score": 6.012,
 "rank": 31
@@ -1320,7 +1320,7 @@
 "pushed": "2019-05-17",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/d78eb83479bd8281cd26eb45b6a364f4d3ff7cdbec3c7b7562b7e0315d6c51f1/hyeonsangjeon/vagrant-rancher2.0",
+"social": "https://opengraph.githubassets.com/086fa7f71911bc09de021d91a63a53c616473675616c7f5148f316f6ada65912/hyeonsangjeon/vagrant-rancher2.0",
 "social_custom": false,
 "score": 5.577,
 "rank": 32
@@ -1358,7 +1358,7 @@
 "pushed": "2019-05-17",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/619a41156504774b7d1ecabdedbb8758a373809cb322861e6767013a63e69a02/hyeonsangjeon/alpine-nginx-perl",
+"social": "https://opengraph.githubassets.com/adbed0236324341a80510cc58e0e23dc9d83e6129d232436a6052c1c35e51877/hyeonsangjeon/alpine-nginx-perl",
 "social_custom": false,
 "score": 5.448,
 "rank": 33
@@ -1387,7 +1387,7 @@
 "pushed": "2023-08-10",
 "tracked": true,
 "first_seen": "2025-07-02",
-"social": "https://opengraph.githubassets.com/49697f9d3ed45c0b7c188ac740e9420b4065bad2694059b8c2f92ed9e2c53a76/hyeonsangjeon/aws-korea-2023-coding-school",
+"social": "https://opengraph.githubassets.com/c2ab0dba5580d1adb575d7b140eb33543a9059fda82b91f038e6c7a5ad531966/hyeonsangjeon/aws-korea-2023-coding-school",
 "social_custom": false,
 "score": 5.433,
 "rank": 34
@@ -1424,7 +1424,7 @@
 "pushed": "2026-08-14",
 "tracked": true,
 "first_seen": "2026-08-09",
-"social": "https://opengraph.githubassets.com/6d378de6e4a791c43b9eef5c1a75e8f0ebc4ddb434661a0eacf535d66cb31cd2/hyeonsangjeon/im-not-ai-en",
+"social": "https://opengraph.githubassets.com/6bc67dd8bf456c69364baf9c8411f07607a82ca1a21fc610c238b0930e18779f/hyeonsangjeon/im-not-ai-en",
 "social_custom": false,
 "score": 5.175,
 "rank": 35
@@ -1461,7 +1461,7 @@
 "pushed": "2026-08-22",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/4cd4cd4e92b12391ca7abc3f902fb25ba9c60b6621e9e7c8b7c2d0b45652cc5f/hyeonsangjeon/job-transcribe",
+"social": "https://opengraph.githubassets.com/e4c2ffb04f858a14b1734fd36bfa08b919107360a03857fd72e957b62df1775b/hyeonsangjeon/job-transcribe",
 "social_custom": false,
 "score": 5.168,
 "rank": 36
@@ -1497,7 +1497,7 @@
 "pushed": "2019-04-29",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/dcd9e8e92fce2a93cfa09ff0db6fc20db0e81d4a9d31d3dce932c18d49bb6fc5/hyeonsangjeon/kubernetes-dashboard-nodeport",
+"social": "https://opengraph.githubassets.com/3f9202cedb3cb17c753ec8b39c58274d870e2016147f245ada9e43415d855b93/hyeonsangjeon/kubernetes-dashboard-nodeport",
 "social_custom": false,
 "score": 5.164,
 "rank": 37
@@ -1534,7 +1534,7 @@
 "pushed": "2020-02-04",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/16f3f049c1bb6adc249e6c3216d02940a9e762942528acb4d0642443504f5cf9/hyeonsangjeon/ISO-3166-alpha2-alpha3-korean",
+"social": "https://opengraph.githubassets.com/25d1927802393b7a26a40e6246ac959fab796b26566c4b15220b958be4a548db/hyeonsangjeon/ISO-3166-alpha2-alpha3-korean",
 "social_custom": false,
 "score": 4.893,
 "rank": 38
@@ -1573,7 +1573,7 @@
 "pushed": "2023-08-21",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/e490f6b3f3de1d2509f31757ef21950f2a2cfe7857b01e1ac965bbd14ec7da38/hyeonsangjeon/yesno",
+"social": "https://opengraph.githubassets.com/131a9aa294597f3111891cb41de8dfc53c219d148e7e32ec9c5039561dfbb235/hyeonsangjeon/yesno",
 "social_custom": false,
 "score": 4.556,
 "rank": 39
@@ -1612,7 +1612,7 @@
 "pushed": "2018-06-12",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/9dab842fb545c9026b2e52e28aee860f74c56a0553cc78015df56c812f146e21/hyeonsangjeon/jenkins-dind",
+"social": "https://opengraph.githubassets.com/1a35e6dce6c58b58a5960eac4521e97012e115f4222e2f2bfada86276bc6ac6f/hyeonsangjeon/jenkins-dind",
 "social_custom": false,
 "score": 4.439,
 "rank": 40
@@ -1648,7 +1648,7 @@
 "pushed": "2018-09-22",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/89b02eef1ddb76042120ebd03eeb4e5eb13b13158739e808ec2df34b580df20d/hyeonsangjeon/python-threads-queue",
+"social": "https://opengraph.githubassets.com/b571e8f7f95f614067023c03c78f8c9b7173890a61ebb9cc3d191240c1f2e495/hyeonsangjeon/python-threads-queue",
 "social_custom": false,
 "score": 4.269,
 "rank": 41
@@ -1693,7 +1693,7 @@
 "pushed": "2023-04-10",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/b363e35eb610317b05c25d899833a43bf032cd9ed36b329921ab597d9e0eba74/hyeonsangjeon/colab-tensorflow-tpu-example",
+"social": "https://opengraph.githubassets.com/70a42062d00d831c5aaf740c9264364b1a315e000e694e230f02440564d9b0e9/hyeonsangjeon/colab-tensorflow-tpu-example",
 "social_custom": false,
 "score": 4.113,
 "rank": 42
@@ -1722,7 +1722,7 @@
 "pushed": "2020-06-05",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/600356914c226ad3b9af4a6ebaa6574cc7a4e4ed8cf04a4ddaaf8b484d683c79/hyeonsangjeon/Deep-Learning-Hyperparameter-optimization",
+"social": "https://opengraph.githubassets.com/d38b0de75e24436a86224daecf601d79dc4e4e0505dbe4d175fec64b4a00ffe7/hyeonsangjeon/Deep-Learning-Hyperparameter-optimization",
 "social_custom": false,
 "score": 4.072,
 "rank": 43
@@ -1751,7 +1751,7 @@
 "pushed": "2022-05-24",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/102c33b062401728c5acab8ef2be7c600add998c9635e65af2f1054f1d111a3f/hyeonsangjeon/ECS-Immersion-Day",
+"social": "https://opengraph.githubassets.com/45c89945a521f8cadc70d08e9caf37d861563f30b5431fffb95270ca8176d458/hyeonsangjeon/ECS-Immersion-Day",
 "social_custom": false,
 "score": 3.895,
 "rank": 44
@@ -1813,7 +1813,7 @@
 "pushed": "2019-12-23",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/0940fb087ffdd225223a561a68abab45c4ba7464c48c4f33c4d11573717f2579/hyeonsangjeon/python-xmas-tree",
+"social": "https://opengraph.githubassets.com/f54d607ea51c439d7d71d8d600ac87cda554f54fe6504e05c76be48a4ff8ca96/hyeonsangjeon/python-xmas-tree",
 "social_custom": false,
 "score": 3.496,
 "rank": 46
@@ -1842,7 +1842,7 @@
 "pushed": "2026-06-16",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/e15dd54399371e7c8cf2167679df3d7d2107f8d5a281cc8f0cbb5e0cf0cb088f/hyeonsangjeon/sysmon",
+"social": "https://opengraph.githubassets.com/7034dc21c46b7ccd3bee49b1c609dc72b775d86f5b7c6c8e746c7fd7eabe5b51/hyeonsangjeon/sysmon",
 "social_custom": false,
 "score": 3.432,
 "rank": 47
@@ -1871,7 +1871,7 @@
 "pushed": "2023-06-19",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/a947dc6abbf801e8b470cb4c9316c73622a23bc9754c15957bf576462894eabb/hyeonsangjeon/ChatGPT-API-JS",
+"social": "https://opengraph.githubassets.com/9490c73a3d20f384de8dfd4c92e5ed1f1d312991f4d061873dad9d502076c410/hyeonsangjeon/ChatGPT-API-JS",
 "social_custom": false,
 "score": 3.202,
 "rank": 48
@@ -1904,7 +1904,7 @@
 "pushed": "2018-08-20",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/6490564cf8de30b395b5377a853c070342614c74bc06f50e667e50fa84d516a2/hyeonsangjeon/ubuntu-dind",
+"social": "https://opengraph.githubassets.com/a363ff46068a5b4d07aae15a56bf5c4450306aa3a99abebe1411f7f3631602bb/hyeonsangjeon/ubuntu-dind",
 "social_custom": false,
 "score": 3.062,
 "rank": 49
@@ -1933,7 +1933,7 @@
 "pushed": "2021-05-03",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/1c740d4060d699f9432d6bf03af8f96bfcb96b2a54c0e38b68a2c4216552dda0/hyeonsangjeon/competition",
+"social": "https://opengraph.githubassets.com/7fe10c7324a764799188366dad23a53b6f1b26094c8c94f386c36ae63c5f8ada/hyeonsangjeon/competition",
 "social_custom": false,
 "score": 2.855,
 "rank": 50
@@ -1970,7 +1970,7 @@
 "pushed": "2020-01-14",
 "tracked": true,
 "first_seen": "2026-06-18",
-"social": "https://opengraph.githubassets.com/0940fb087ffdd225223a561a68abab45c4ba7464c48c4f33c4d11573717f2579/hyeonsangjeon/morgan-winston-dailylog",
+"social": "https://opengraph.githubassets.com/f54d607ea51c439d7d71d8d600ac87cda554f54fe6504e05c76be48a4ff8ca96/hyeonsangjeon/morgan-winston-dailylog",
 "social_custom": false,
 "score": 2.627,
 "rank": 51
@@ -1999,7 +1999,7 @@
 "pushed": "2021-11-02",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/a2d3d4c1a9ccbb50301ddee2816f46e69ce24d53f6ca61d8a5767632db2e584c/hyeonsangjeon/EMRSparkNotebook",
+"social": "https://opengraph.githubassets.com/58bb9d3abf18151327e6414bf33142eb4227ef41082e4b4d60b1e162680714fa/hyeonsangjeon/EMRSparkNotebook",
 "social_custom": false,
 "score": 2.489,
 "rank": 52
@@ -2028,7 +2028,7 @@
 "pushed": "2021-10-14",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/0aff9527b5d338fbfaf395640df664982299abb2b0ecd88ee763f69b75e566aa/hyeonsangjeon/flask-sentiment-detector",
+"social": "https://opengraph.githubassets.com/f8fb847d06e72e40c52c251e4de54aac3da7e93529e7af9fd8e2d19039faba14/hyeonsangjeon/flask-sentiment-detector",
 "social_custom": false,
 "score": 2.489,
 "rank": 53
@@ -2057,7 +2057,7 @@
 "pushed": "2019-04-29",
 "tracked": true,
 "first_seen": "2026-06-19",
-"social": "https://opengraph.githubassets.com/c66bbf39d07b73ebbc852f0f3445760b7738944a124683be9dffe8ce7e16d56f/hyeonsangjeon/minikube-dev-env",
+"social": "https://opengraph.githubassets.com/b9a2388f352e1af6af25c18344d6d9e4b80c131b94922dda9cb05155a66cc3d0/hyeonsangjeon/minikube-dev-env",
 "social_custom": false,
 "score": 2.478,
 "rank": 54
@@ -2086,7 +2086,7 @@
 "pushed": "2022-06-27",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/b67060880023e192fd867075b36fd7b9b70beb1ac691380b1ab852e83fba7325/hyeonsangjeon/ent-boost-aiml-b05-ch08",
+"social": "https://opengraph.githubassets.com/2ccdf0d8146d42a1686505afc11dd64da2df975f9ca68cd6189f956a5a219a9a/hyeonsangjeon/ent-boost-aiml-b05-ch08",
 "social_custom": false,
 "score": 2.448,
 "rank": 55
@@ -2115,7 +2115,7 @@
 "pushed": "2023-03-23",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/33a34ae1a7e42b7e960b03a8a2263a620891141e5f2197d4ff6f42c52411dece/hyeonsangjeon/myipynb",
+"social": "https://opengraph.githubassets.com/c7e1b9817869717ca886b6b34a53a612fc37e74a1a28910b2f128adaf0b2899e/hyeonsangjeon/myipynb",
 "social_custom": false,
 "score": 2.281,
 "rank": 56
@@ -2144,7 +2144,7 @@
 "pushed": "2022-04-19",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/9ce2bf37765519a58f09be77f87133c4703f462a74441e274582c86d02cf584b/hyeonsangjeon/General-Immersion-Day",
+"social": "https://opengraph.githubassets.com/59679b7daf7d2e84123605bc887b7cae530f01866b346595f5d0136e26ac9295/hyeonsangjeon/General-Immersion-Day",
 "social_custom": false,
 "score": 2.131,
 "rank": 57
@@ -2173,7 +2173,7 @@
 "pushed": "2025-11-11",
 "tracked": true,
 "first_seen": "2026-06-20",
-"social": "https://opengraph.githubassets.com/b2da2d8d187bd9b3c3c4e7be572c6a62613afe1c35f7c769fcfe86a881e91568/hyeonsangjeon/rag-faq-streamlit",
+"social": "https://opengraph.githubassets.com/83318c9657b81e4e93a49f776a0c75fd2e9b2c7094eca9916e30253f470f25ac/hyeonsangjeon/rag-faq-streamlit",
 "social_custom": false,
 "score": 2.097,
 "rank": 58

--- a/scripts/build_repos.py
+++ b/scripts/build_repos.py
@@ -2,8 +2,8 @@
 """Repolis data builder.
 
 Aggregates the GitHub traffic history collected by ``scripts/collect_traffic.py``
-(stored in ``data/logs/``) with live repo metadata, and writes ``repos.json`` —
-the data that powers the Repolis 3D city (one building per repo).
+(stored in ``data/logs/``) with live repo metadata, and writes ``repos.json`` and
+``data/city-state.json`` — the data that powers the Repolis 3D city.
 
 Only PUBLIC repos are included, so the public site never exposes private
 repository names: every repo the owner created, plus any fork the owner has
@@ -16,6 +16,9 @@ Env vars:
   GTM_DIR     Directory holding the collected logs/ tree. Defaults to data for
               upstream and data/towns/<owner> for every other owner.
   OUT         Output path (default: repos.json)
+  CITY_STATE_AS_OF  Optional ISO-8601 city reference time. The daily workflow
+                   supplies its UTC run day; local builds fall back to the
+                   newest reproducible public source timestamp.
   GH_TOKEN    Token used by `gh` (PAT that can list the repos)
 """
 import csv
@@ -24,6 +27,8 @@ import math
 import os
 import subprocess
 from pathlib import Path
+
+from city_state import build_city_state, write_city_state
 
 def resolve_owner():
     configured = os.environ.get("REPO_OWNER", "").strip()
@@ -47,6 +52,8 @@ GTM_DIR = Path(_configured_gtm) if _configured_gtm else (
     Path("data") if OWNER.lower() == UPSTREAM_OWNER else Path("data") / "towns" / OWNER
 )
 OUT = Path(os.environ.get("OUT", "repos.json"))
+CITY_STATE_OUT = Path(os.environ.get("CITY_STATE_OUT", "data/city-state.json"))
+CITY_STATE_AS_OF = os.environ.get("CITY_STATE_AS_OF", "").strip() or None
 
 
 def gh_api(path):
@@ -158,6 +165,7 @@ def build():
     repos = gh_api(f"/users/{OWNER}/repos?per_page=100&type=owner&sort=full_name")
     social = social_map(OWNER)
     out = []
+    source_timestamps = {}
     for r in repos:
         if r.get("private"):
             continue
@@ -178,6 +186,10 @@ def build():
         if lic_name in ("NOASSERTION", "NONE"):
             lic_name = ""
         rel = latest_release(full)
+        source_timestamps[name] = max(
+            (value for value in (r.get("updated_at"), r.get("pushed_at"), r.get("created_at")) if value),
+            default="",
+        )
         score = (
             math.log1p(visitors) * 1.0
             + math.log1p(clones) * 0.7
@@ -220,11 +232,17 @@ def build():
         o["rank"] = i
 
     OUT.write_text(json.dumps(out, ensure_ascii=False, indent=0) + "\n", encoding="utf-8")
+    city_state = build_city_state(out, source_timestamps, as_of=CITY_STATE_AS_OF)
+    write_city_state(CITY_STATE_OUT, city_state)
 
     downtown = sum(1 for o in out if o["rank"] < 14)
     tracked_n = sum(1 for o in out if o["tracked"])
     forks_n = sum(1 for o in out if o.get("fork"))
     print(f"wrote {OUT} with {len(out)} public repos ({forks_n} forks I committed to)")
+    print(
+        f"wrote {CITY_STATE_OUT} schema={city_state['version']} "
+        f"season={city_state['season']['value']} roots={len(city_state['roots'])}"
+    )
     print(f"  downtown(rank<14)={downtown} hometown={len(out) - downtown} tracked={tracked_n}")
 
 

--- a/scripts/city_state.py
+++ b/scripts/city_state.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Deterministic city-state projection from public repository metadata."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+
+SCHEMA_NAME = "repolis.city-state"
+SCHEMA_VERSION = 1
+SEASONS = ("spring", "summer", "autumn", "winter")
+RECENT_WINDOW_DAYS = 30
+HISTORICAL_BUCKETS = 6
+
+
+def _parse_datetime(value):
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        if len(text) == 10:
+            return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _iso_z(value):
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _repo_name(repo):
+    return str(repo.get("repo") or repo.get("name") or "").strip()
+
+
+def _public_repositories(repositories):
+    projected = []
+    for repo in repositories or []:
+        if not isinstance(repo, dict) or repo.get("private") is True:
+            continue
+        name = _repo_name(repo)
+        if not name:
+            continue
+        projected.append(repo)
+    return sorted(projected, key=lambda repo: (_repo_name(repo).casefold(), _repo_name(repo)))
+
+
+def _reference_time(repositories, source_timestamps, as_of=None):
+    if as_of is not None:
+        parsed = _parse_datetime(as_of)
+        if not parsed:
+            raise ValueError("city-state as_of must be an ISO-8601 date or timestamp")
+        return parsed
+    candidates = []
+    for value in (source_timestamps or {}).values():
+        parsed = _parse_datetime(value)
+        if parsed:
+            candidates.append(parsed)
+    if not candidates:
+        for repo in repositories:
+            for key in ("updated_at", "pushed", "pushed_at", "created", "created_at"):
+                parsed = _parse_datetime(repo.get(key))
+                if parsed:
+                    candidates.append(parsed)
+                    break
+    return max(candidates) if candidates else datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _season(repositories, reference_day):
+    pushed_days = []
+    for repo in repositories:
+        pushed = _parse_datetime(repo.get("pushed") or repo.get("pushed_at"))
+        if pushed:
+            pushed_days.append(pushed.date())
+
+    recent_start = reference_day - timedelta(days=RECENT_WINDOW_DAYS - 1)
+    recent_count = sum(recent_start <= pushed <= reference_day for pushed in pushed_days)
+    historical_counts = []
+    for bucket in range(HISTORICAL_BUCKETS):
+        end = reference_day - timedelta(days=RECENT_WINDOW_DAYS * (bucket + 1))
+        start = end - timedelta(days=RECENT_WINDOW_DAYS - 1)
+        historical_counts.append(sum(start <= pushed <= end for pushed in pushed_days))
+
+    historical_average = sum(historical_counts) / HISTORICAL_BUCKETS
+    populated_buckets = sum(count > 0 for count in historical_counts)
+    history_sufficient = sum(historical_counts) >= HISTORICAL_BUCKETS and populated_buckets >= 3
+    ratio = recent_count / historical_average if historical_average > 0 else None
+    active_share = recent_count / len(repositories) if repositories else 0
+
+    fallback_rule = (
+        "When fewer than six prior latest-push signals span at least three 30-day buckets, "
+        "use the share of repositories whose latest push is in the recent 30-day window: "
+        "spring >= 0.35, summer >= 0.12, autumn > 0, otherwise winter."
+    )
+    if history_sufficient:
+        if ratio >= 1.35:
+            value = "spring"
+        elif ratio >= 0.85:
+            value = "summer"
+        elif ratio >= 0.45:
+            value = "autumn"
+        else:
+            value = "winter"
+        reason = (
+            f"Recent latest-push count is {ratio:.2f}x the average of the prior "
+            f"{HISTORICAL_BUCKETS} 30-day buckets."
+        )
+        fallback_used = False
+    else:
+        if recent_count == 0:
+            value = "winter"
+        elif active_share >= 0.35:
+            value = "spring"
+        elif active_share >= 0.12:
+            value = "summer"
+        else:
+            value = "autumn"
+        reason = (
+            "Historical latest-push coverage is insufficient; "
+            f"{recent_count} of {len(repositories)} repositories are recent."
+        )
+        fallback_used = True
+
+    return {
+        "value": value,
+        "inputs": {
+            "reference_date": reference_day.isoformat(),
+            "activity_signal": "latest_push_per_repository",
+            "recent_window_days": RECENT_WINDOW_DAYS,
+            "recent_active_repositories": recent_count,
+            "historical_bucket_days": RECENT_WINDOW_DAYS,
+            "historical_bucket_counts": historical_counts,
+            "historical_average": round(historical_average, 3),
+            "recent_to_historical_ratio": round(ratio, 3) if ratio is not None else None,
+            "active_repository_share": active_share,
+            "repositories_with_push_date": len(pushed_days),
+        },
+        "reason": reason,
+        "fallback": {
+            "used": fallback_used,
+            "rule": fallback_rule,
+        },
+    }
+
+
+def _achievement(repo):
+    text = re.sub(r"\s+", " ", str(repo.get("desc") or repo.get("description") or "")).strip()
+    if not text:
+        language = str(repo.get("lang") or repo.get("language") or "public").strip()
+        text = f"A public {language} repository preserved as part of the city's history."
+    return text if len(text) <= 180 else text[:177].rstrip() + "..."
+
+
+def _root(repo):
+    created = _parse_datetime(repo.get("created") or repo.get("created_at"))
+    pushed = _parse_datetime(repo.get("pushed") or repo.get("pushed_at"))
+    start_year = created.year if created else None
+    end_year = (pushed or created).year if (pushed or created) else None
+    count = (end_year - start_year + 1) if start_year is not None and end_year is not None else None
+    return {
+        "repo": _repo_name(repo),
+        "active_years": {
+            "from": start_year,
+            "to": end_year,
+            "count": max(1, count) if count is not None else None,
+        },
+        "achievement": _achievement(repo),
+    }
+
+
+def build_city_state(repositories, source_timestamps=None, *, as_of=None):
+    public = _public_repositories(repositories)
+    reference_time = _reference_time(public, source_timestamps, as_of)
+    reference_day = reference_time.date()
+    dated = [
+        (parsed.date(), _repo_name(repo))
+        for repo in public
+        if (parsed := _parse_datetime(repo.get("created") or repo.get("created_at")))
+    ]
+    founded_on, oldest_repo = min(dated) if dated else (reference_day, "")
+    age_days = max(0, (reference_day - founded_on).days)
+
+    languages = Counter(str(repo.get("lang") or repo.get("language") or "Other") for repo in public)
+    language_distribution = [
+        {"language": language, "repositories": count}
+        for language, count in sorted(languages.items(), key=lambda item: (-item[1], item[0].casefold(), item[0]))
+    ]
+    archived = [repo for repo in public if bool(repo.get("archived"))]
+    push_count = sum(bool(_parse_datetime(repo.get("pushed") or repo.get("pushed_at"))) for repo in public)
+
+    state = {
+        "schema": SCHEMA_NAME,
+        "version": SCHEMA_VERSION,
+        "era": {
+            "founded_on": founded_on.isoformat(),
+            "oldest_repository": oldest_repo,
+            "as_of": reference_day.isoformat(),
+            "city_age_days": age_days,
+            "city_age_years": round(age_days / 365.2425, 2),
+            "city_year": math.floor(age_days / 365.2425) + 1,
+            "basis": "Oldest creation date among the public repositories included in repos.json.",
+        },
+        "season": _season(public, reference_day),
+        "stats": {
+            "repository_count": len(public),
+            "active_repository_count": len(public) - len(archived),
+            "archived_repository_count": len(archived),
+            "total_stars": sum(max(0, int(repo.get("stars") or 0)) for repo in public),
+            "total_forks": sum(max(0, int(repo.get("forks") or 0)) for repo in public),
+            "language_distribution": language_distribution,
+            "latest_push_signal": {
+                "repositories_with_push_date": push_count,
+                "recent_30d_repositories": 0,
+            },
+            "commit_history": {
+                "available": False,
+                "total": None,
+                "limitation": (
+                    "The build input exposes each repository's latest push timestamp, not complete commit history; "
+                    "no commit total is inferred."
+                ),
+            },
+        },
+        "last_sap_flow": _iso_z(reference_time),
+        "roots": [_root(repo) for repo in archived],
+    }
+    state["stats"]["latest_push_signal"]["recent_30d_repositories"] = state["season"]["inputs"][
+        "recent_active_repositories"
+    ]
+    return state
+
+
+def serialize_city_state(state):
+    return json.dumps(state, allow_nan=False, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def write_city_state(path, state):
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(serialize_city_state(state), encoding="utf-8")

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -61,6 +61,13 @@ import {
   projectContributionQuest,
   selectContributionQuests
 } from '../assets/contribution-quests.js';
+import {
+  WEAR_THRESHOLDS_DAYS,
+  classifyBuildingWear,
+  cityReferenceTimestamp,
+  resolveCitySeason,
+  seasonPalette
+} from '../assets/city-time.js';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -94,6 +101,12 @@ const TOWN_GROWTH_SRC = readFileSync(join(ROOT, 'assets/town-growth.js'), 'utf8'
 const REPO_PORTAL_SRC = readFileSync(join(ROOT, 'assets/repo-portal.js'), 'utf8');
 const REPO_ROUTE_SRC = readFileSync(join(ROOT, 'assets/repo-route.js'), 'utf8');
 const CONTRIBUTION_QUEST_SRC = readFileSync(join(ROOT, 'assets/contribution-quests.js'), 'utf8');
+const CITY_TIME_SRC = readFileSync(join(ROOT, 'assets/city-time.js'), 'utf8');
+const CITY_STATE = JSON.parse(readFileSync(join(ROOT, 'data/city-state.json'), 'utf8'));
+const CITY_STATE_SCHEMA = JSON.parse(readFileSync(join(ROOT, 'data/city-state.schema.json'), 'utf8'));
+const CITY_REPOS = JSON.parse(readFileSync(join(ROOT, 'repos.json'), 'utf8'));
+const CITY_STATE_BUILDER = readFileSync(join(ROOT, 'scripts/city_state.py'), 'utf8');
+const CITY_STATE_VALIDATOR = readFileSync(join(ROOT, 'scripts/validate_city_state.py'), 'utf8');
 
 let pass = 0, fail = 0; const fails = [];
 function ok(cond, msg) { if (cond) { pass++; } else { fail++; fails.push(msg); console.log('  ✗ ' + msg); } }
@@ -238,6 +251,79 @@ ok(/GTM_DIR=data\/towns\/\$REPO_OWNER/.test(REFRESH_WORKFLOW)
 ok(/\/users\/\{OWNER\}\/repos\?per_page=100&type=owner/.test(REPO_BUILDER)
   &&/Public owner endpoint works with the built-in Actions token/.test(REPO_BUILDER), 'builder lists public owner repos without requiring an authenticated user endpoint');
 ok(/Path\("data"\) \/ "towns" \/ OWNER/.test(REPO_BUILDER), 'manual non-upstream builds default to an owner-scoped traffic root');
+
+group('deterministic city state — generated time, wear, ruins, and season');
+ok(CITY_STATE.schema==='repolis.city-state' && CITY_STATE.version===1
+  &&['era','season','stats','last_sap_flow','roots'].every(key=>key in CITY_STATE),
+  'generated city state exposes the versioned minimum contract');
+ok(CITY_STATE_SCHEMA.$id==='https://hyeonsangjeon.github.io/Repolis/data/city-state.schema.json'
+  &&CITY_STATE_SCHEMA.additionalProperties===false
+  &&CITY_STATE_SCHEMA.required.every(key=>key in CITY_STATE),
+  'city-state schema is strict and matches the checked-in artifact');
+const archivedCityRepos=CITY_REPOS.filter(repo=>repo.archived);
+ok(CITY_STATE.stats.repository_count===CITY_REPOS.length
+  &&CITY_STATE.stats.active_repository_count+CITY_STATE.stats.archived_repository_count===CITY_REPOS.length
+  &&CITY_STATE.stats.archived_repository_count===archivedCityRepos.length,
+  'city-state repository totals reconcile with repos.json');
+ok(CITY_STATE.stats.total_stars===CITY_REPOS.reduce((sum,repo)=>sum+(repo.stars||0),0)
+  &&CITY_STATE.stats.total_forks===CITY_REPOS.reduce((sum,repo)=>sum+(repo.forks||0),0),
+  'city-state public star and fork totals reconcile with repos.json');
+ok(CITY_STATE.stats.commit_history.available===false
+  &&CITY_STATE.stats.commit_history.total===null
+  &&/not complete commit history/i.test(CITY_STATE.stats.commit_history.limitation),
+  'unavailable commit history is explicit and never estimated');
+ok(CITY_STATE.roots.length===archivedCityRepos.length
+  &&CITY_STATE.roots.every(root=>archivedCityRepos.some(repo=>repo.repo===root.repo)),
+  'roots contain every and only archived public repository');
+ok(/sort_keys=True/.test(CITY_STATE_BUILDER)
+  &&/schema_path/.test(CITY_STATE_VALIDATOR)
+  &&/CITY_STATE_AS_OF=\$\(date -u \+%FT00:00:00Z\)/.test(REFRESH_WORKFLOW)
+  &&/scripts\/test_city_state\.py/.test(REFRESH_WORKFLOW)
+  &&/scripts\/validate_city_state\.py/.test(REFRESH_WORKFLOW)
+  &&/scripts\/test-city-time\.mjs/.test(REFRESH_WORKFLOW),
+  'stable serialization, schema validation, and fixture tests gate daily refresh');
+const cityReference=cityReferenceTimestamp(CITY_STATE,CITY_REPOS);
+const cityReferenceDate=new Date(cityReference).toISOString().slice(0,10);
+const cityDateBefore=days=>new Date(cityReference-days*86400000).toISOString().slice(0,10);
+ok(cityReferenceDate===CITY_STATE.season.inputs.reference_date
+  &&cityReferenceDate===CITY_STATE.era.as_of,
+  'runtime reference date agrees with the generated artifact');
+ok(WEAR_THRESHOLDS_DAYS.recent===90 && WEAR_THRESHOLDS_DAYS.faded===365
+  &&classifyBuildingWear({pushed:cityDateBefore(0)},cityReference).state==='recent'
+  &&classifyBuildingWear({pushed:cityDateBefore(120)},cityReference).state==='faded'
+  &&classifyBuildingWear({pushed:cityDateBefore(500)},cityReference).state==='mossed'
+  &&classifyBuildingWear({pushed:cityDateBefore(0),archived:true},cityReference).archived,
+  'wear thresholds and archived ruin state are deterministic');
+ok(resolveCitySeason(CITY_STATE)===CITY_STATE.season.value
+  &&resolveCitySeason({...CITY_STATE,season:{...CITY_STATE.season,value:'spring'}})==='spring'
+  &&resolveCitySeason({...CITY_STATE,season:{...CITY_STATE.season,value:'winter'}})==='winter'
+  &&resolveCitySeason({season:{value:'not-a-season'}})==='summer'
+  &&seasonPalette('spring').sky!==seasonPalette('winter').sky,
+  'season accepts four generated values, falls back neutrally, and has distinct fixture palettes');
+ok(!/\bfetch\s*\(|api\.github|workers\.dev|\/taxi\b/i.test(CITY_TIME_SRC),
+  'city-time projection is local and adds no runtime API, LLM, or backend call');
+ok(/fetch\('data\/city-state\.json',\{cache:'no-cache'\}\)/.test(HTML)
+  &&/cityStateLoad/.test(HTML)
+  &&/scene\.fog = new THREE\.Fog\(CITY_SEASON_STYLE\.fog/.test(HTML)
+  &&/SKY_KEYS\.forEach\(k=>/.test(HTML)
+  &&/projectCityTime\(repo,CITY_STATE,REPOS/.test(HTML),
+  'owner runtime loads static city state before applying season and wear');
+ok(/function addGentleRuin\(g,repo,w,h,d,yr,topH\)/.test(HTML)
+  &&/repo\._wearState=cityTime\.state/.test(HTML)
+  &&/wear:repo\._wearState,ruin:repo\._ruin/.test(HTML)
+  &&/spec\.ruin/.test(HTML)
+  &&/RUIN_FLOWER_MAT=new THREE\.MeshBasicMaterial\(\{color:0xffffff\}\)/.test(HTML),
+  'gentle ruin identity survives full and LOD building paths');
+ok(/if\(repo\._ruin\)\{ \(repo\._windows\|\|\[\]\)\.forEach\(w=>\{ w\.userData\.lit=false; \}\); _syncBuildingLodFacade\(repo\); return; \}/.test(HTML),
+  'visiting a ruin cannot relight its full, mid, or far LOD windows');
+ok((HTML.match(/wearRecent:/g)||[]).length===2
+  &&(HTML.match(/wearFaded:/g)||[]).length===2
+  &&(HTML.match(/wearMossed:/g)||[]).length===2
+  &&(HTML.match(/ruinNote:/g)||[]).length===2
+  &&(HTML.match(/seasonSpring:/g)||[]).length===2,
+  'wear, ruin, and season copy is bilingual');
+ok(/citySeason/.test(HTML)&&/cityTimeFixtures/.test(HTML)&&/prefers-reduced-motion:reduce/.test(HTML),
+  'debug fixtures and the existing reduced-motion contract cover static time treatments');
 
 group('Repo Portal — one repository becomes the first shareable destination');
 const portalUser=parseRepoPortalInput('@Octo-Cat');
@@ -900,9 +986,9 @@ ok(/current public issues ranked for approachability, each connected to its real
   'READMEs, domain model, limitations, manifest, LLM index, and scored BOLT decision make the contribution loop discoverable');
 
 const runtimeLocalFiles = [
-  'index.html','repolis.config.js','scholars.js','repos.json','assets/contribution-library.json',
+  'index.html','repolis.config.js','scholars.js','repos.json','data/city-state.json','assets/contribution-library.json',
   'assets/world-tree/createRepolisHero.js','assets/camera-obstruction.js','assets/canal-ferry.js',
-  'assets/public-town-proof.js','assets/rain-garden.js','assets/town-postcard.js','assets/twin-towns.js','assets/town-creator.js','assets/town-growth.js','assets/repo-portal.js','assets/repo-route.js','assets/contribution-quests.js',
+  'assets/public-town-proof.js','assets/rain-garden.js','assets/town-postcard.js','assets/twin-towns.js','assets/town-creator.js','assets/town-growth.js','assets/repo-portal.js','assets/repo-route.js','assets/contribution-quests.js','assets/city-time.js',
   'council/council.config.json','council/engine.js','council/fixtures.js','council/guards.js','council/live.js'
 ];
 const runtimeLocalBytes = runtimeLocalFiles.reduce((sum,file)=>sum+readFileSync(join(ROOT,file)).length,0);
@@ -1435,6 +1521,8 @@ const zcSrc = (HTML.match(/\/\*ZONECLASSIFIER:START\*\/([\s\S]*?)\/\*ZONECLASSIF
 ok(zcSrc.length > 0, 'ZONECLASSIFIER block extractable from index.html');
 ok(/const ZONE_CAT\s*=\s*\[/.test(zcSrc), 'ZONE_CAT district catalog exists');
 ok(/function zoneOf\(repo\)/.test(zcSrc), 'zoneOf() classifier exists');
+ok(/_now-new Date\(repo\.pushed\)/.test(zcSrc)&&!/Date\.now\(\)/.test(zcSrc),
+  'district age uses the generated city reference instead of the viewer clock');
 ok(/const ZONE_SYN\s*=\s*\{/.test(HTML), 'ZONE_SYN travel-synonym namespace exists (separate from repoByKey)');
 ok(/function districtNav\(q\)\{/.test(HTML) && /const dz=districtNav\(q\);/.test(HTML), 'districtNav wired into _coreIntent (every taxi mode)');
 ok(/function zoneOf\(repo\)/.test(HTML) && /REPOS\.forEach\(r=>\{\s*r\._zone\s*=\s*zoneOf\(r\)/.test(HTML), 'every repo is assigned r._zone at build');
@@ -1450,7 +1538,7 @@ if (zcSrc && normSrc) {
   try {
     const rj = JSON.parse(readFileSync(join(ROOT, 'repos.json'), 'utf8'));
     repos = Array.isArray(rj) ? rj : (rj.repos || []);
-    const built = new Function(`${zcSrc}\nreturn { ZONE_CAT, zoneOf };`)();
+    const built = new Function('_now', `${zcSrc}\nreturn { ZONE_CAT, zoneOf };`)(cityReference);
     CAT = built.ZONE_CAT; zoneOf = built.zoneOf;
   } catch (e) { console.log('  ✗ zoneOf harness: ' + e.message); }
   ok(!!(zoneOf && CAT && repos.length), 'zoneOf + ZONE_CAT + repos.json loaded for behavioral check');

--- a/scripts/test-city-time.mjs
+++ b/scripts/test-city-time.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import {
+  CITY_STATE_SCHEMA,
+  CITY_STATE_VERSION,
+  cityReferenceTimestamp,
+  classifyBuildingWear,
+  projectCityTime,
+  resolveCitySeason,
+  seasonPalette
+} from '../assets/city-time.js';
+
+const cityState = {
+  schema: CITY_STATE_SCHEMA,
+  version: CITY_STATE_VERSION,
+  last_sap_flow: '2026-06-30T12:00:00Z',
+  season: { value: 'autumn', inputs: { reference_date: '2026-06-30' } }
+};
+const reference = cityReferenceTimestamp(cityState);
+
+assert.equal(new Date(reference).toISOString(), '2026-06-30T12:00:00.000Z');
+assert.equal(classifyBuildingWear({ pushed:'2026-06-01' }, reference).state, 'recent');
+assert.equal(classifyBuildingWear({ pushed:'2026-01-01' }, reference).state, 'faded');
+assert.equal(classifyBuildingWear({ pushed:'2024-01-01' }, reference).state, 'mossed');
+assert.equal(classifyBuildingWear({}, reference).state, 'mossed');
+assert.equal(projectCityTime({ pushed:'2026-06-01', archived:true }, cityState).archived, true);
+assert.equal(projectCityTime({ pushed:'2026-06-01' }, cityState, [], { wear:'mossed', archived:true }).state, 'mossed');
+assert.equal(resolveCitySeason(cityState), 'autumn');
+assert.equal(resolveCitySeason(cityState, 'winter'), 'winter');
+assert.equal(resolveCitySeason({}), 'summer');
+assert.notDeepEqual(seasonPalette('spring'), seasonPalette('winter'));
+
+console.log('ALL GREEN - city time wear, ruin, and season fixtures');

--- a/scripts/test_city_state.py
+++ b/scripts/test_city_state.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Hermetic city-state generation and schema regression tests."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from city_state import build_city_state, serialize_city_state
+from validate_city_state import load_and_validate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "data" / "city-state.schema.json"
+
+
+def repo(name, created, pushed, *, archived=False, private=False, stars=0, language="Python", desc=""):
+    return {
+        "repo": name,
+        "created": created,
+        "pushed": pushed,
+        "archived": archived,
+        "private": private,
+        "stars": stars,
+        "forks": stars // 2,
+        "lang": language,
+        "desc": desc,
+    }
+
+
+class CityStateTests(unittest.TestCase):
+    def validate_state(self, state):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "city-state.json"
+            target.write_text(serialize_city_state(state), encoding="utf-8")
+            self.assertEqual(load_and_validate(target, SCHEMA), [])
+
+    def test_projection_is_public_safe_honest_and_schema_valid(self):
+        repos = [
+            repo("active", "2020-01-02", "2026-06-28", stars=7, desc="A useful public tool."),
+            repo("memory", "2018-03-04", "2022-04-05", archived=True, stars=3, desc="Archived public work."),
+            repo("secret", "2017-01-01", "2026-06-30", private=True, stars=999),
+        ]
+        state = build_city_state(repos, {"active": "2026-06-30T12:00:00Z"})
+        self.validate_state(state)
+        self.assertEqual(state["era"]["oldest_repository"], "memory")
+        self.assertEqual(state["stats"]["repository_count"], 2)
+        self.assertEqual(state["stats"]["total_stars"], 10)
+        self.assertIsNone(state["stats"]["commit_history"]["total"])
+        self.assertFalse(state["stats"]["commit_history"]["available"])
+        self.assertEqual([root["repo"] for root in state["roots"]], ["memory"])
+        self.assertEqual(state["roots"][0]["active_years"], {"from": 2018, "to": 2022, "count": 5})
+        self.assertNotIn("secret", serialize_city_state(state))
+
+    def test_identical_inputs_are_byte_stable_and_order_independent(self):
+        repos = [
+            repo("zeta", "2020-01-01", "2026-05-20", stars=2),
+            repo("alpha", "2019-01-01", "2026-06-29", stars=4),
+        ]
+        timestamps = {"zeta": "2026-06-30T08:00:00Z", "alpha": "2026-06-29T09:00:00Z"}
+        first = serialize_city_state(build_city_state(repos, timestamps, as_of="2026-06-30T00:00:00Z"))
+        second = serialize_city_state(build_city_state(
+            list(reversed(repos)),
+            dict(reversed(list(timestamps.items()))),
+            as_of="2026-06-30T00:00:00Z",
+        ))
+        self.assertEqual(first, second)
+        self.assertEqual(first, serialize_city_state(json.loads(first)))
+
+    def test_explicit_as_of_advances_a_quiet_city(self):
+        state = build_city_state(
+            [repo("quiet", "2020-01-01", "2020-01-01")],
+            {"quiet": "2020-01-01T12:00:00Z"},
+            as_of="2026-06-30T00:00:00Z",
+        )
+        self.assertEqual(state["era"]["as_of"], "2026-06-30")
+        self.assertEqual(state["era"]["city_age_days"], 2372)
+        self.assertEqual(state["season"]["value"], "winter")
+        self.assertEqual(state["season"]["inputs"]["recent_active_repositories"], 0)
+        self.assertEqual(state["last_sap_flow"], "2026-06-30T00:00:00Z")
+
+    def test_moving_average_selects_distinct_spring_and_winter_fixtures(self):
+        spring = [
+            repo(f"recent-{index}", "2020-01-01", f"2026-06-{27 + index:02d}") for index in range(4)
+        ]
+        spring += [
+            repo(f"history-{index}", "2020-01-01", pushed)
+            for index, pushed in enumerate(("2026-05-20", "2026-04-20", "2026-03-20", "2026-02-20", "2026-01-20", "2025-12-20"))
+        ]
+        winter = [
+            repo(f"history-{index}", "2020-01-01", pushed)
+            for index, pushed in enumerate(("2026-05-20", "2026-04-20", "2026-03-20", "2026-02-20", "2026-01-20", "2025-12-20"))
+        ]
+        source = {"source": "2026-06-30T12:00:00Z"}
+        spring_state = build_city_state(spring, source)
+        winter_state = build_city_state(winter, source)
+        self.assertEqual(spring_state["season"]["value"], "spring")
+        self.assertEqual(winter_state["season"]["value"], "winter")
+        self.assertFalse(spring_state["season"]["fallback"]["used"])
+        self.assertFalse(winter_state["season"]["fallback"]["used"])
+        self.validate_state(spring_state)
+        self.validate_state(winter_state)
+
+    def test_sparse_history_uses_documented_fallback(self):
+        state = build_city_state(
+            [repo("recent", "2026-01-01", "2026-06-30"), repo("quiet", "2020-01-01", "2020-01-02")],
+            {"source": "2026-06-30T12:00:00Z"},
+        )
+        self.assertEqual(state["season"]["value"], "spring")
+        self.assertTrue(state["season"]["fallback"]["used"])
+        self.assertIn("insufficient", state["season"]["reason"])
+
+    def test_fallback_records_the_exact_share_used_for_the_decision(self):
+        repos = [
+            repo(f"recent-{index}", "2020-01-01", "2026-06-30")
+            for index in range(11)
+        ]
+        repos += [
+            repo(f"quiet-{index}", "2020-01-01", "2020-01-01")
+            for index in range(81)
+        ]
+        state = build_city_state(repos, {"source": "2026-06-30T00:00:00Z"})
+        share = state["season"]["inputs"]["active_repository_share"]
+        self.assertEqual(share, 11 / 92)
+        self.assertLess(share, 0.12)
+        self.assertEqual(state["season"]["value"], "autumn")
+
+    def test_invalid_explicit_as_of_fails_loudly(self):
+        with self.assertRaisesRegex(ValueError, "ISO-8601"):
+            build_city_state([], as_of="not-a-date")
+
+    def test_validator_rejects_date_without_time_for_last_sap_flow(self):
+        state = build_city_state([], as_of="2026-06-30T00:00:00Z")
+        state["last_sap_flow"] = "2026-06-30"
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "city-state.json"
+            target.write_text(serialize_city_state(state), encoding="utf-8")
+            self.assertIn("$.last_sap_flow: invalid date-time", load_and_validate(target, SCHEMA))
+
+    def test_non_finite_numbers_cannot_reach_the_browser(self):
+        state = build_city_state([], as_of="2026-06-30T00:00:00Z")
+        state["season"]["inputs"]["active_repository_share"] = float("nan")
+        with self.assertRaisesRegex(ValueError, "JSON compliant"):
+            serialize_city_state(state)
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "city-state.json"
+            target.write_text(json.dumps(state), encoding="utf-8")
+            self.assertIn("non-finite number NaN", load_and_validate(target, SCHEMA)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_city_state.py
+++ b/scripts/validate_city_state.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate city-state.json against its checked-in JSON Schema without dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from datetime import date, datetime
+from pathlib import Path
+
+
+TYPE_MAP = {
+    "array": list,
+    "boolean": bool,
+    "integer": int,
+    "null": type(None),
+    "number": (int, float),
+    "object": dict,
+    "string": str,
+}
+
+
+def _matches_type(value, expected):
+    allowed = expected if isinstance(expected, list) else [expected]
+    for item in allowed:
+        py_type = TYPE_MAP[item]
+        if item in ("integer", "number") and isinstance(value, bool):
+            continue
+        if isinstance(value, py_type):
+            return True
+    return False
+
+
+def _format_ok(value, fmt):
+    try:
+        if fmt == "date":
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value) is None:
+                return False
+            date.fromisoformat(value)
+        elif fmt == "date-time":
+            if re.fullmatch(
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})",
+                value,
+            ) is None:
+                return False
+            if datetime.fromisoformat(value.replace("Z", "+00:00")).tzinfo is None:
+                return False
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def validate(instance, schema, path="$"):
+    errors = []
+    expected = schema.get("type")
+    if expected is not None and not _matches_type(instance, expected):
+        return [f"{path}: expected {expected}, got {type(instance).__name__}"]
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected constant {schema['const']!r}")
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']!r}")
+
+    if isinstance(instance, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                errors.append(f"{path}: missing required property {key!r}")
+        properties = schema.get("properties", {})
+        for key, value in instance.items():
+            child = properties.get(key)
+            if child is None:
+                if schema.get("additionalProperties") is False:
+                    errors.append(f"{path}: unexpected property {key!r}")
+                continue
+            errors.extend(validate(value, child, f"{path}.{key}"))
+
+    if isinstance(instance, list):
+        if len(instance) < schema.get("minItems", 0):
+            errors.append(f"{path}: expected at least {schema['minItems']} items")
+        if "maxItems" in schema and len(instance) > schema["maxItems"]:
+            errors.append(f"{path}: expected at most {schema['maxItems']} items")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, value in enumerate(instance):
+                errors.extend(validate(value, item_schema, f"{path}[{index}]"))
+
+    if isinstance(instance, str):
+        if len(instance) < schema.get("minLength", 0):
+            errors.append(f"{path}: string is shorter than {schema['minLength']}")
+        if "maxLength" in schema and len(instance) > schema["maxLength"]:
+            errors.append(f"{path}: string is longer than {schema['maxLength']}")
+        if "pattern" in schema and re.search(schema["pattern"], instance) is None:
+            errors.append(f"{path}: does not match {schema['pattern']!r}")
+        if "format" in schema and not _format_ok(instance, schema["format"]):
+            errors.append(f"{path}: invalid {schema['format']}")
+
+    if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+        if not math.isfinite(instance):
+            return [f"{path}: number must be finite"]
+        if "minimum" in schema and instance < schema["minimum"]:
+            errors.append(f"{path}: must be >= {schema['minimum']}")
+        if "maximum" in schema and instance > schema["maximum"]:
+            errors.append(f"{path}: must be <= {schema['maximum']}")
+    return errors
+
+
+def load_and_validate(data_path, schema_path):
+    def reject_non_finite(value):
+        raise ValueError(f"non-finite number {value}")
+
+    try:
+        data = json.loads(
+            Path(data_path).read_text(encoding="utf-8"),
+            parse_constant=reject_non_finite,
+        )
+    except (json.JSONDecodeError, ValueError) as error:
+        return [f"$: invalid JSON: {error}"]
+    schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
+    return validate(data, schema)
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("data", nargs="?", default=root / "data" / "city-state.json", type=Path)
+    parser.add_argument("--schema", default=root / "data" / "city-state.schema.json", type=Path)
+    args = parser.parse_args()
+    errors = load_and_validate(args.data, args.schema)
+    if errors:
+        for error in errors:
+            print(error)
+        raise SystemExit(1)
+    print(f"valid city state: {args.data}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate and schema-validate a byte-stable `data/city-state.json` from the existing public repository inputs during daily refresh
- classify buildings as `recent`, `faded`, or `mossed` from a generated reference clock, preserve archived buildings as gentle named ruins, and carry the state through full/mid/far LOD
- apply restrained generated seasons to sky, fog, lighting, and building color while preserving readability, reduced-motion behavior, residents, collisions, and the zero-build runtime
- document the public-data limits and keep unavailable commit-history totals explicitly `null`

Closes #83

## Deterministic artifact
- schema: `repolis.city-state`, version `1`
- generated reference: `2026-08-23T00:00:00Z`
- public repositories: 68; wear distribution: 24 recent / 6 faded / 38 mossed
- archived roots: 0 because the current public input has no archived repository
- runtime GitHub API calls: 0; runtime LLM calls: 0; new services/dependencies: 0

## Validation
- `scripts/test_city_state.py`: 9 passed
- `scripts/validate_city_state.py data/city-state.json`: valid
- `scripts/test-city-time.mjs`: all wear, ruin, reference-clock, and season fixtures green
- `council/test.mjs`: 130 passed
- `council/test-live.mjs`: 56 passed
- `scripts/smoke.mjs`: 1,200 passed
- syntax checks: `scholars.js` and `cloudflare-taxi/src/grounded.js`
- desktop 1440x900: nonblank WebGL, 0 console errors, no viewport overflow, collisions resolved, 6 residents moved
- mobile 390x844 at DPR 3: LOW_END active, nonblank WebGL, 0 console errors, no clipped controls/overflow, collisions resolved, 7 residents moved; 866 calls / 317,361 triangles
- spring and winter fixture renders compared; a visited ruin remains unlit in full/mid/far facade state
- cache-empty cold load: **1,805,553 bytes** across 35 requests (<5 MiB)

## Limits and Phase 2 handoff
- repository-level public metadata cannot support an honest all-time commit count, so `stats.commits.total` remains `null` with its limitation encoded in the artifact and docs
- the refresh workflow supplies the UTC run day; local generation deterministically falls back to the newest reproducible public source timestamp
- this PR intentionally does not implement Phase 2 issue #82

## Visual evidence

**Desktop · spring fixture · 1440x900**

![Desktop spring city-state render](https://github.com/user-attachments/assets/7f282feb-2651-4732-afca-baa6d64946fb)

**Mobile LOW_END · winter fixture · 390x844**

![Mobile winter city-state render](https://github.com/user-attachments/assets/ade0d051-5be1-4ba3-851a-dbfdfbe97f09)

## Deployment and live QA

- squash merge: `9b3667e96fd9a8e826b8895f751e95d31c6e01c2`
- [Pages build and deployment](https://github.com/hyeonsangjeon/Repolis/actions/runs/32626110898): success (build, status report, and deploy)
- live desktop 1440x900: nonblank WebGL, 0 console errors, no overflow, collision resolved, 8 residents moved
- live mobile 390x844 / DPR 3: nonblank WebGL, 0 console errors, no clipped controls or overflow, LOW_END retained at 908 calls / 324,917 triangles, 8 residents moved
- deployed `repolis.city-state` version 1 reports spring at `2026-08-23T00:00:00Z` with 68 public repositories and no fabricated commit total
