### PR TITLE
fix: keep ambient resident AI hard off

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -365,7 +365,7 @@ to best-effort accounting.
 | Var | Default | Meaning |
 |---|---|---|
 | `NPC_AI_ENABLED` | `false` | Top-level env ceiling. Anything except `"true"` means **never** a resident model call. KV cannot override it on. |
-| `NPC_AMBIENT_ENABLED` | `false` | Env ceiling for model-powered ambient turns (also requires `NPC_AI_ENABLED`). |
+| `NPC_AMBIENT_ENABLED` | `false` | Env ceiling for model-powered ambient turns (also requires `NPC_AI_ENABLED`). The canonical Phase 3 deployment keeps this `false`; ambient town life is scripted and costs $0. |
 | `NPC_PLAYER_CHAT_ENABLED` | `false` | Env ceiling for model-powered player chat (also requires `NPC_AI_ENABLED`). |
 | `NPC_LIVE_TOGGLE` | `false` | Enables per-request `NPC_FLAGS` kill switches. When off, KV is ignored. |
 | `NPC_MODEL_DEFAULT` | `gpt-5.4-mini` | Azure OpenAI deployment name for resident turns. |

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -86,10 +86,10 @@ NPC_MAX_COMPLETION_TOKENS = "120"
 NPC_BUDGET_TIMEOUT_MS = "3000"
 NPC_DAILY_ATTEMPT_MAX = "5000"
 NPC_RESERVATION_LEASE_MS = "60000"
-# Deployment ceilings permit the owner-only KV switches to turn resident AI on.
-# Live mode still requires explicit KV "true" values; missing keys fail closed.
+# Explicit visitor dialogue may be enabled by the owner-only KV switches. Model-powered
+# ambient chatter stays hard-off so background town life is always scripted and $0.
 NPC_AI_ENABLED = "true"
-NPC_AMBIENT_ENABLED = "true"
+NPC_AMBIENT_ENABLED = "false"
 NPC_PLAYER_CHAT_ENABLED = "true"
 # 31-day worst case = $4.65 for resident Azure model calls.
 NPC_DAY_CAP_USD = "0.15"

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2237,6 +2237,9 @@ ok(/test_resident_profiles\.py/.test(REFRESH_WORKFLOW)
   && /validate_resident_profiles\.py/.test(REFRESH_WORKFLOW)
   && /scan_public_artifacts\.py/.test(REFRESH_WORKFLOW),
   'daily publication is gated by resident determinism, schema, and public-safety checks');
+ok(/NPC_AMBIENT_ENABLED = "false"/.test(TAXI_WRANGLER)
+  && /scriptedAmbient:true/.test(npcBlock),
+  'canonical ambient town life is scripted and zero-cost; only explicit resident dialogue may reach a model');
 
 group('AURI market oracle — grounded market KB + read-only crypto MCP');
 const marketActionSrc=(HTML.match(/function marketActionQuestion\(q\)\{[\s\S]*?(?=\nfunction marketQuestion)/)||[''])[0];


### PR DESCRIPTION
## Summary

- set the canonical `NPC_AMBIENT_ENABLED` deployment ceiling to `false`
- preserve scripted ambient conversations, movement, gatherings, and explicit player dialogue
- lock the explicit-action-only cost contract with a smoke guard

## Why

Live Phase 3 QA exposed that the prior canonical config still allowed automatic `npcAmbientTurn` model calls. The browser was switched offline immediately after identification. Phase 3 requires paid resident calls only after an explicit visitor send, so ambient model traffic must remain hard-off at the deployment ceiling.

## Validation

- `node scripts/smoke.mjs`: 1,238 passed
- Worker syntax and public-artifact scan: green
- Wrangler dry-run: `NPC_AMBIENT_ENABLED ("false")`
- no provider request is needed to validate this fix

Follow-up to #86 / #80.