### PR TITLE
feat: add ephemeral session footprints

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -64,6 +64,7 @@ jobs:
           python3 scripts/scan_public_artifacts.py
           node scripts/validate-lore-fragments.mjs
           node scripts/test-city-time.mjs
+          node scripts/test-session-footprints.mjs
           node scripts/smoke.mjs
 
       - name: Commit if changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`assets/city-time.js`** | Pure wear (`recent` / `faded` / `mossed`), ruin, reference-date, and seasonal palette rules. | Changing how public time metadata affects the city. |
 | **`data/lore/fragments.json` + `assets/lore-fragments.js`** | Hand-authored KO/EN elder fragments plus strict validation, deterministic active-roster allocation, and session-bounded delivery. | Changing The Silence fragments or their rarity/allocation contract. Never generate or overwrite the JSON. |
 | **`assets/taxi-voice.js`** | Pure local taxi Shared-state answers, household redirect, and once-per-ride seasonal/district observations. | Changing travel voice without adding a backend call. |
+| **`assets/session-footprints.js`** | Pure bounded current-tab footprint ring: movement threshold, lifetime, LOW_END/reduced-motion policy, and teardown. | Changing the local player's ephemeral walking trace. |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
 | **`assets/world-tree/world-tree-state.js`** | Pure Phase 2 projection for Chronicle, Roots, sap-flow freshness/mode, and bounded star/repo growth. | Changing how generated city state reaches the silent World Tree. |
@@ -125,6 +126,7 @@ node scripts/smoke.mjs       # city/runtime static + behavioral regression guard
 python3 scripts/test_city_state.py
 python3 scripts/validate_city_state.py
 node scripts/test-city-time.mjs
+node scripts/test-session-footprints.mjs
 node scripts/validate-lore-fragments.mjs
 node --check scholars.js
 node --check cloudflare-taxi/src/grounded.js
@@ -175,6 +177,7 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 | Change Town Gazette / return-visit freshness | `/*FRESHNESS*/` + Passport render/start flow in `index.html`; keep snapshots local, bounded, per-town, and explicit-read only. |
 | Change resident homes, styles, gardens, routines, moods, friendships, haunts, or Shared Joy | The resident social layer + Starlight Row blocks in `index.html`; preserve the resident style map, 3 roof batches, 10/6 desktop/LOW_END detail-batch cap, 42-unit reserve, entrance gap, quarter colliders, home/work truth, owned porch seats, and social ownership guards. |
 | Change elder lore, newcomer voice/scaffolding, or taxi travel observations | `data/lore/fragments.json`, `assets/lore-fragments.js`, `assets/taxi-voice.js`, `assets/city-time.js`, and the Phase 4 blocks in `index.html`; preserve the nine-resident active roster, World Tree silence, local-only delivery, and one observation per ride. |
+| Change session footprints | `assets/session-footprints.js` + `/*SESSION_FOOTPRINTS*/` in `index.html` + the Phase 5 group in `scripts/smoke.mjs`; preserve current-tab memory only, local post-collision walking truth, one fixed instanced pool, zero storage/network/analytics/sync, and no colliders. |
 | Fix / improve a scholar's answer or references | `cloudflare-taxi/src/grounded.js` (server) + the trace panel in `index.html`. |
 | Add a new scholar NPC | `scholars.js` + `scholarConfig`/`MCP_NPCS` in `cloudflare-taxi/src/grounded.js`; choose KB-backed or direct MCP deliberately; document in `SCHOLARS.md`. |
 | Tune the taxi's repo search/intent routing | `index.html` (Local search: inverted index + intent agent). |

--- a/assets/session-footprints.js
+++ b/assets/session-footprints.js
@@ -1,0 +1,145 @@
+export const SESSION_FOOTPRINT_LIMITS = Object.freeze({
+  desktop: Object.freeze({ capacity: 36, spacing: 1.35, lifetime: 5.2, fadeStart: 0.58 }),
+  lowEnd: Object.freeze({ capacity: 18, spacing: 1.8, lifetime: 4.0, fadeStart: 0.52 }),
+  reduced: Object.freeze({ capacity: 8, spacing: 3.0, lifetime: 1.2, fadeStart: 1 }),
+  teleportDistance: 6,
+  lateralOffset: 0.14,
+  surfaceOffset: 0.035,
+  width: 0.11,
+  length: 0.25,
+});
+
+function finite(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export function resolveSessionFootprintConfig({ lowEnd = false, reducedMotion = false } = {}) {
+  const tier = reducedMotion
+    ? SESSION_FOOTPRINT_LIMITS.reduced
+    : lowEnd ? SESSION_FOOTPRINT_LIMITS.lowEnd : SESSION_FOOTPRINT_LIMITS.desktop;
+  return Object.freeze({
+    ...tier,
+    lowEnd: Boolean(lowEnd),
+    reducedMotion: Boolean(reducedMotion),
+    teleportDistance: SESSION_FOOTPRINT_LIMITS.teleportDistance,
+    lateralOffset: SESSION_FOOTPRINT_LIMITS.lateralOffset,
+    surfaceOffset: SESSION_FOOTPRINT_LIMITS.surfaceOffset,
+    width: SESSION_FOOTPRINT_LIMITS.width,
+    length: SESSION_FOOTPRINT_LIMITS.length,
+  });
+}
+
+export function createSessionFootprintState(options = {}) {
+  const config = resolveSessionFootprintConfig(options);
+  const capacity = config.capacity;
+  return {
+    config,
+    elapsed: 0,
+    cursor: 0,
+    activeCount: 0,
+    totalSpawned: 0,
+    hasAnchor: false,
+    anchorX: 0,
+    anchorZ: 0,
+    disposed: false,
+    active: new Uint8Array(capacity),
+    x: new Float32Array(capacity),
+    y: new Float32Array(capacity),
+    z: new Float32Array(capacity),
+    heading: new Float32Array(capacity),
+    born: new Float32Array(capacity),
+  };
+}
+
+export function clearSessionFootprints(state, { resetTotals = false } = {}) {
+  state.active.fill(0);
+  state.activeCount = 0;
+  state.cursor = 0;
+  state.hasAnchor = false;
+  if (resetTotals) state.totalSpawned = 0;
+}
+
+function setAnchor(state, x, z) {
+  state.anchorX = x;
+  state.anchorZ = z;
+  state.hasAnchor = true;
+}
+
+function expireSessionFootprints(state) {
+  const { active, born } = state;
+  for (let index = 0; index < active.length; index += 1) {
+    if (active[index] && state.elapsed - born[index] >= state.config.lifetime) {
+      active[index] = 0;
+      state.activeCount -= 1;
+    }
+  }
+}
+
+export function stepSessionFootprints(state, sample = {}) {
+  if (!state || state.disposed) return -1;
+  state.elapsed += Math.max(0, Math.min(0.25, finite(sample.dt)));
+  expireSessionFootprints(state);
+
+  const x = finite(sample.x, NaN), z = finite(sample.z, NaN);
+  if (!Number.isFinite(x) || !Number.isFinite(z)) return -1;
+  if (sample.resetAnchor) {
+    setAnchor(state, x, z);
+    return -1;
+  }
+  if (!state.hasAnchor) {
+    setAnchor(state, x, z);
+    return -1;
+  }
+
+  const dx = x - state.anchorX, dz = z - state.anchorZ;
+  const distance = Math.hypot(dx, dz);
+  if (distance > state.config.teleportDistance) {
+    setAnchor(state, x, z);
+    return -1;
+  }
+  if (!sample.walking || distance < state.config.spacing) return -1;
+
+  const heading = Number.isFinite(sample.heading) ? sample.heading : Math.atan2(dx, dz);
+  const side = state.totalSpawned % 2 === 0 ? -1 : 1;
+  const lateralX = Math.cos(heading) * state.config.lateralOffset * side;
+  const lateralZ = -Math.sin(heading) * state.config.lateralOffset * side;
+  const slot = state.cursor;
+  if (!state.active[slot]) state.activeCount += 1;
+  state.active[slot] = 1;
+  state.x[slot] = x + lateralX;
+  state.y[slot] = finite(sample.y) + state.config.surfaceOffset;
+  state.z[slot] = z + lateralZ;
+  state.heading[slot] = heading;
+  state.born[slot] = state.elapsed;
+  state.cursor = (slot + 1) % state.config.capacity;
+  state.totalSpawned += 1;
+  setAnchor(state, x, z);
+  return slot;
+}
+
+export function sessionFootprintScale(state, index) {
+  if (!state.active[index]) return 0;
+  if (state.config.reducedMotion) return 1;
+  const progress = Math.max(0, (state.elapsed - state.born[index]) / state.config.lifetime);
+  if (progress <= state.config.fadeStart) return 1;
+  return Math.max(0, 1 - (progress - state.config.fadeStart) / (1 - state.config.fadeStart));
+}
+
+export function sessionFootprintSnapshot(state) {
+  return Object.freeze({
+    capacity: state.config.capacity,
+    spacing: state.config.spacing,
+    lifetime: state.config.lifetime,
+    lowEnd: state.config.lowEnd,
+    reducedMotion: state.config.reducedMotion,
+    active: state.activeCount,
+    cursor: state.cursor,
+    spawned: state.totalSpawned,
+    disposed: state.disposed,
+  });
+}
+
+export function teardownSessionFootprints(state) {
+  clearSessionFootprints(state);
+  state.disposed = true;
+}

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -19,6 +19,7 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | **Resident** | generated `data/residents/` profile + bounded roster in `index.html` | A townsperson bound to one public repo building, with a Starlight cottage, social life, and server-authorized Bound memory. |
 | **Elder fragment** | hand-authored `data/lore/fragments.json` | A short bilingual recollection allocated only to the oldest eligible 20% of the nine-resident active roster and delivered rarely in local life contexts. |
 | **Exploration state** | browser `localStorage` | Passport visits, district progress, daily Village Chronicle, Town Gazette baselines, constellation completion, and the Maintainers' Night Watch stamp. |
+| **Session footprint** | current-tab memory + one instanced mesh | A short local-player walking trace; never persisted, synchronized, or derived from residents/peers. |
 | **Scholar (NPC)** | `scholars.js` (`window.SCHOLARS`) | A named star + myth + exactly one MCP knowledge source. |
 | **Taxi** | the POLARIS scholar (`kind: taxi`) | The only all-district traveler; finds a repo, drives there, knows Shared city state, and redirects household memory to that home. |
 | **Grounding Worker** | `cloudflare-taxi/` (`repolis-taxi`) | Server brain: KB retrieval + in-persona chat. |

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -99,6 +99,10 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
   current repo description, topics, public metrics, lifecycle dates, and available traffic. It does not clone
   source files, reconstruct old metrics, or simulate build/runtime behavior. Explicit Gitber questions use
   the currently selected chat mode and its existing Local or backend fallback.
+- **Session footprints are deliberately forgetful.** Only post-collision movement by the local exterior avatar
+  can create them. A fixed 36/18/8-slot desktop/LOW_END/reduced-motion pool fades or expires in memory; taxi,
+  rides, teleports, hidden tabs, Growth Replay, Atelier movement, reloads, and navigation do not become a trail.
+  No footprint is stored, synchronized, analyzed, or attached to a visitor, resident, or peer identity.
 - **Resident Shared Joy is bounded and session-local.** At most one pair takes a scripted excursion at a
   time; it is not remembered across reloads and does not use a model. Stargazing starts autonomously only
   while stars are visible, and visitor/chat/festival ownership intentionally interrupts an outing.

--- a/docs/world-tree-phase5-decisions.md
+++ b/docs/world-tree-phase5-decisions.md
@@ -1,0 +1,34 @@
+# World Tree Phase 5 experiment decisions
+
+Decision date: 2026-08-24. Parent backlog: [#81](https://github.com/hyeonsangjeon/Repolis/issues/81).
+
+Phase 5 is a decision gate, not a promise to build every idea. The current generated snapshot has 68
+public repo houses, nine active residents, nine included public forks, and zero archived repositories.
+The controlled Chrome cold baseline is 3,001,294 decoded bytes and 42 requests against the 5 MiB ceiling.
+
+| Candidate | Decision | World-model value | Current evidence | Data source | Privacy | Runtime / network cost | Cold-load / draw-call cost | Accessibility | Removability |
+|---|---|---|---|---|---|---|---|---|---|
+| Session footprints | **SHIP** | Makes walking leave a brief, mortal trace without adding explanatory UI. | The local avatar already has authoritative post-collision `moving` and position state. | Current-tab, in-memory local avatar samples only. | No storage, identity, peer/resident replay, analytics, socket, or backend. | Zero requests; bounded typed-array ring updated only for the local exterior walk. | One small module and one instanced draw; caps are 36 desktop, 18 LOW_END, and 8 reduced-motion. | No copy required; reduced motion uses wider spacing, a short static lifetime, and the smallest cap. | `assets/session-footprints.js`, one runtime block, and its tests can be removed together. |
+| Public fork lineage | **SHIP** | Gives an honest origin detail to houses that are already known forks without claiming authorship or kinship. | 9/68 current houses are committed-to forks; all nine expose an accessible public canonical source. | Daily build only: bounded lookup for included public forks, then generated `repos.json`. | Public `owner/name` and canonical GitHub URL only; inaccessible or malformed sources become no lineage. | Runtime GitHub API remains zero; current build delta is at most nine REST reads. | A tiny generated field plus one shared batched crest palette; no source-specific texture/material. | Exact source appears as KO/EN text and a normal focusable `noopener` link in the repo card. | Generator helper, generated field, crest batch, card row, and lineage tests form one boundary. |
+| Returnee event | **DEFER** | A real return could deepen the half-mortal model, but inventing one would weaken it. | Archived repositories are currently 0, with no observed public archived-to-active transition. | No truthful transition source is committed today. | A future design must remain public and snapshot-based. | Unknown until a deterministic daily transition contract exists. | Zero now: no runtime event, field, fixture placeholder, or UI was added. | Must define non-motion meaning and avoid implying restored Bound memory. | Re-enter only after daily snapshots prove the transition deterministically and a real case or explicit fixture contract exists. |
+| Contributor windows | **DEFER** | Contributor count does not currently justify replacing a stronger existing city meaning. | Night window glow already means repository activity; visit lighting is separately owned. | Accurate bounded contributors and bot filtering are not available in the current batch contract. | Public counts still risk misleading identity/credit implications. | Per-repo contributor reads and filtering would expand the 68-repo API budget. | A separate visual grammar and batching budget are not defined. | A non-color-only explanation would be required without overloading the card. | Re-enter only with a bounded public source, explicit bot rule, API budget, and a distinct visual channel that preserves activity glow. |
+
+## Session-footprint ship evidence
+
+- Cold boot: 3,010,884 decoded bytes and 43 requests, a direct delta of **+9,590 bytes / +1 request**.
+- Frozen-pose desktop active-cap A/B: **+1 draw, +216 triangles, -0.81% render median**.
+- Frozen-pose LOW_END active-cap A/B: **+1 draw, +108 triangles, 0.00% render median**.
+- Desktop/LOW_END/reduced-motion caps observed as 36/18/8. Reload starts at zero; taxi, teleport,
+  Growth Replay, hidden/non-walking frames, and Atelier movement created zero footprints.
+- The footprint boundary contains no storage, cookie, analytics, network, WebSocket, peer/resident,
+  identity, or collider path. Page navigation clears or tears down the one pool.
+
+## Guardrails for the two approved experiments
+
+- Each experiment ships in its own branch, commit, PR, test boundary, merge, Pages deployment, and live QA.
+- Runtime external API requests remain unchanged; neither experiment calls a Worker, model, analytics sink, or
+  recurring service.
+- World Tree silence, Shared/Bound authority, ambient-AI hard-off, activity-window meaning, resident movement,
+  fork-safe local behavior, and the zero-build runtime remain unchanged.
+- A visible frame-time regression above 5%, cold decoded load at or above 5 MiB, or an unbounded scene/allocation
+  path rejects the experiment instead of weakening those contracts.

--- a/index.html
+++ b/index.html
@@ -1896,6 +1896,7 @@ import { CONTRIBUTION_QUEST_LIMITS, createContributionQuestSearchUrl, selectCont
 import { bindResidentSlots, createResidentProfileStore, loadResidentManifest, residentLocalResponse, residentNewcomerLine } from './assets/resident-profiles.js?v=world-tree-phase4-v1';
 import { allocateElderFragments, createLoreDeliveryState, loadLoreFragments } from './assets/lore-fragments.js?v=world-tree-phase4-v1';
 import { taxiHouseholdHandoff, taxiRideObservation, taxiSharedResponse } from './assets/taxi-voice.js?v=world-tree-phase4-v1';
+import { clearSessionFootprints, createSessionFootprintState, sessionFootprintScale, sessionFootprintSnapshot, stepSessionFootprints, teardownSessionFootprints } from './assets/session-footprints.js?v=world-tree-phase5-footprints-v1';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -8556,6 +8557,52 @@ faceMat=head.material;
 player.position.set(2.6,0,-3.2);   // spawn beside the plaza fountain (not inside the basin)
 disableDynamicShadowCasters(model);
 scene.add(player);
+/*SESSION_FOOTPRINTS:START*/
+const SESSION_FOOTPRINT_STATE=createSessionFootprintState({lowEnd:LOW_END,reducedMotion:REDUCED});
+const SESSION_FOOTPRINT_GEO=new THREE.CircleGeometry(1,6); SESSION_FOOTPRINT_GEO.rotateX(-Math.PI/2);
+const SESSION_FOOTPRINT_MAT=new THREE.MeshBasicMaterial({color:0x715f48,transparent:true,opacity:.28,depthWrite:false,polygonOffset:true,polygonOffsetFactor:-1,polygonOffsetUnits:-1});
+const SESSION_FOOTPRINT_MESH=new THREE.InstancedMesh(SESSION_FOOTPRINT_GEO,SESSION_FOOTPRINT_MAT,SESSION_FOOTPRINT_STATE.config.capacity);
+SESSION_FOOTPRINT_MESH.name='SessionFootprints'; SESSION_FOOTPRINT_MESH.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+SESSION_FOOTPRINT_MESH.castShadow=false; SESSION_FOOTPRINT_MESH.receiveShadow=false; SESSION_FOOTPRINT_MESH.frustumCulled=false; SESSION_FOOTPRINT_MESH.renderOrder=1;
+const SESSION_FOOTPRINT_DUMMY=new THREE.Object3D(), SESSION_FOOTPRINT_SAMPLE={x:player.position.x,y:player.position.y,z:player.position.z,heading:0,dt:0,walking:false,resetAnchor:false};
+let SESSION_FOOTPRINT_ATTACHED=true;
+function _syncSessionFootprints(){
+  const state=SESSION_FOOTPRINT_STATE, cfg=state.config;
+  for(let i=0;i<cfg.capacity;i++){ const scale=sessionFootprintScale(state,i);
+    SESSION_FOOTPRINT_DUMMY.position.set(state.x[i],state.y[i],state.z[i]); SESSION_FOOTPRINT_DUMMY.rotation.set(0,state.heading[i],0);
+    SESSION_FOOTPRINT_DUMMY.scale.set(cfg.width*scale,1,cfg.length*scale); SESSION_FOOTPRINT_DUMMY.updateMatrix(); SESSION_FOOTPRINT_MESH.setMatrixAt(i,SESSION_FOOTPRINT_DUMMY.matrix); }
+  SESSION_FOOTPRINT_MESH.instanceMatrix.needsUpdate=true; SESSION_FOOTPRINT_MESH.visible=SESSION_FOOTPRINT_ATTACHED&&state.activeCount>0;
+}
+function _updateSessionFootprints(dt,walking,suspended=false){
+  const sample=SESSION_FOOTPRINT_SAMPLE; sample.x=player.position.x; sample.y=player.position.y; sample.z=player.position.z; sample.heading=model.rotation.y; sample.dt=dt;
+  sample.walking=walking&&!suspended&&!document.hidden; sample.resetAnchor=suspended||document.hidden;
+  const before=SESSION_FOOTPRINT_STATE.activeCount,slot=stepSessionFootprints(SESSION_FOOTPRINT_STATE,sample);
+  if(before||SESSION_FOOTPRINT_STATE.activeCount||slot>=0) _syncSessionFootprints();
+}
+function _clearSessionFootprintScene(){
+  clearSessionFootprints(SESSION_FOOTPRINT_STATE); _syncSessionFootprints();
+  if(SESSION_FOOTPRINT_MESH.parent) SESSION_FOOTPRINT_MESH.parent.remove(SESSION_FOOTPRINT_MESH); SESSION_FOOTPRINT_ATTACHED=false;
+}
+function _teardownSessionFootprintScene(){
+  if(SESSION_FOOTPRINT_STATE.disposed) return; _clearSessionFootprintScene(); teardownSessionFootprints(SESSION_FOOTPRINT_STATE);
+  SESSION_FOOTPRINT_GEO.dispose(); SESSION_FOOTPRINT_MAT.dispose();
+}
+scene.add(SESSION_FOOTPRINT_MESH); _syncSessionFootprints();
+addEventListener('pagehide',event=>{ if(event.persisted) _clearSessionFootprintScene(); else _teardownSessionFootprintScene(); });
+addEventListener('pageshow',event=>{ if(event.persisted&&!SESSION_FOOTPRINT_STATE.disposed){ clearSessionFootprints(SESSION_FOOTPRINT_STATE,{resetTotals:true});
+  if(!SESSION_FOOTPRINT_MESH.parent) scene.add(SESSION_FOOTPRINT_MESH); SESSION_FOOTPRINT_ATTACHED=true; _syncSessionFootprints(); } });
+function _sessionFootprintDebug(){ const snapshot=sessionFootprintSnapshot(SESSION_FOOTPRINT_STATE); return {...snapshot,
+  drawCalls:SESSION_FOOTPRINT_MESH.visible?1:0,triangles:snapshot.capacity*6,sceneChildren:scene.children.filter(child=>child===SESSION_FOOTPRINT_MESH).length,
+  allocations:{geometries:1,materials:1,steadyState:0},colliders:0,stored:false,synced:false}; }
+if(_DBG){
+  window.__footprints=()=>_sessionFootprintDebug();
+  window.__footprintReset=()=>{ clearSessionFootprints(SESSION_FOOTPRINT_STATE,{resetTotals:true}); _syncSessionFootprints(); return _sessionFootprintDebug(); };
+  window.__footprintStep=(x,z,walking=true,suspended=false,dt=.2)=>{ const sample=SESSION_FOOTPRINT_SAMPLE;
+    sample.x=Number(x)||0; sample.y=0; sample.z=Number(z)||0; sample.heading=Math.atan2(sample.x-SESSION_FOOTPRINT_STATE.anchorX,sample.z-SESSION_FOOTPRINT_STATE.anchorZ);
+    sample.dt=dt; sample.walking=walking===true&&!suspended; sample.resetAnchor=suspended===true; stepSessionFootprints(SESSION_FOOTPRINT_STATE,sample); _syncSessionFootprints(); return _sessionFootprintDebug(); };
+  window.__footprintTeardown=()=>{ _teardownSessionFootprintScene(); return _sessionFootprintDebug(); };
+}
+/*SESSION_FOOTPRINTS:END*/
 // ✦ player aura — 서원이도 별빛을 두른다 (따뜻한 금빛, 밤에 더 밝게)
 { const pa1=new THREE.Sprite(new THREE.SpriteMaterial({map:GLOW_TEX,color:0xffe6b8,transparent:true,opacity:0.09,depthWrite:false,fog:false,blending:THREE.AdditiveBlending})); pa1.scale.set(3.6,3.6,1); pa1.position.y=1.35; model.add(pa1);
   const pa2=new THREE.Sprite(new THREE.SpriteMaterial({map:GLOW_TEX,color:0xfff4dd,transparent:true,opacity:0.15,depthWrite:false,fog:false,blending:THREE.AdditiveBlending})); pa2.scale.set(2.1,2.1,1); pa2.position.y=1.25; model.add(pa2);
@@ -12059,6 +12106,7 @@ function _renderRepositoryAtelier(){
 }
 function _repositoryAtelierFrame(dt){
   const mode=_repositoryAtelierTransition(dt); if(!mode) return false;
+  _updateSessionFootprints(dt,false,true);
   if(mode==='interior'){ _updateRepositoryAtelier(dt); _renderRepositoryAtelier(); }
   else { _beginRenderMetrics(true); _renderWorldTreeFrame(); _endRenderMetrics(); }
   return true;
@@ -12138,6 +12186,7 @@ function animate(){
   const userInput = keys['Space']||keys['KeyW']||keys['KeyS']||keys['KeyA']||keys['KeyD']||keys['ArrowUp']||keys['ArrowDown']||keys['ArrowLeft']||keys['ArrowRight']||Math.abs(stickVec.x)>0.02||Math.abs(stickVec.y)>0.02;
   if(tour&&tour.active&&!tour.waiting&&!ride&&userInput){ endTour(false); }
   const cameraOwner=_cameraOwnerAtFrameStart();
+  const footprintTransit=!!(ride||ferris||carousel||canalFerryRide||GROWTH_REPLAY.active);
   let moving=false;
   if(ride){
     { // ride no longer auto-cancels on key input — exit only via the hold-to-get-off button
@@ -12186,6 +12235,7 @@ function animate(){
       resolveColliders(player.position);
       model.rotation.y=lerpA(model.rotation.y,Math.atan2(mv.x,mv.z),0.2); walk+=dt*10; }
   }
+  _updateSessionFootprints(dt,moving,footprintTransit);
   if(!moving) walk*=0.85;
   if(canalFerryRide){
     legL.rotation.x=legR.rotation.x=-1.5; legL.rotation.z=legR.rotation.z=0;
@@ -12607,7 +12657,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     const keys=['opaque','transparent','additive','outline','pointsSprites','shadowCasters'],counts=Object.fromEntries(keys.map(k=>[k,0])),coverage=Object.fromEntries(keys.map(k=>[k,0]));
     const groups=new Map(),rootGroups=new Map(),viewportArea=Math.max(1,innerWidth*innerHeight),focal=innerHeight/(2*Math.tan(THREE.MathUtils.degToRad(camera.fov)*0.5));
     const rootOf=o=>{ let root=o; while(root.parent&&root.parent!==scene) root=root.parent; return root; },semanticRoots=new Map(),mark=(o,label)=>{ if(o) semanticRoots.set(rootOf(o),label); };
-    mark(starsGroup,'night-sky'); mark(cloudMesh,'clouds'); mark(player,'player'); mark(taxi,'taxi'); mark(driver,'npc'); mark(engineer,'npc'); mark(rigel,'npc');
+    mark(starsGroup,'night-sky'); mark(cloudMesh,'clouds'); mark(player,'player'); mark(SESSION_FOOTPRINT_MESH,'session-footprints'); mark(taxi,'taxi'); mark(driver,'npc'); mark(engineer,'npc'); mark(rigel,'npc');
     if(MEMORIAL_TREE) mark(MEMORIAL_TREE.group,'world-tree'); if(FERRIS) mark(FERRIS.wheel,'ferris'); if(CAROUSEL) mark(CAROUSEL.spin,'carousel');
     if(CHRONO&&CHRONO._group) mark(CHRONO._group,'chronopolis'); if(OBS&&OBS._group) mark(OBS._group,'observatory'); if(STATION&&STATION._group) mark(STATION._group,'station'); if(HEARTH&&HEARTH.g) mark(HEARTH.g,'hearth');
     ZONE_HUBS.forEach(h=>mark(h.group,'zone-hubs')); if(RES_QUARTER) mark(RES_QUARTER.group,'resident-quarter'); RESIDENTS_LIVE.forEach(L=>mark(L.group,'residents')); peers.forEach(p=>mark(p.group,'peers')); SWAY.forEach(g=>mark(g,'sway-trees')); CHOWS.filter(g=>g.parent===scene).forEach(g=>mark(g,'pets'));

--- a/repolis.yaml
+++ b/repolis.yaml
@@ -54,6 +54,7 @@ entrypoints:
   contribution_quests: assets/contribution-quests.js
   elder_lore: assets/lore-fragments.js
   taxi_voice: assets/taxi-voice.js
+  session_footprints: assets/session-footprints.js
   data_builder: scripts/build_repos.py
   launch_config: repolis.config.js
   library_builder: scripts/build-contribution-library.mjs
@@ -109,6 +110,13 @@ features:
     summary: One idle pair autonomously visits real flowers, visible night stars, or a rendered repo house without AI or network calls.
   - id: exploration
     summary: Explorer Passport, district progress, daily Village Chronicle, and Repository Constellation Trail.
+  - id: session-footprints
+    summary: The local avatar leaves a short current-tab trail in one fixed instanced pool, with no storage, identity, synchronization, analytics, or network request.
+    desktop_cap: 36
+    low_end_cap: 18
+    reduced_motion_cap: 8
+    added_draw_calls_while_visible: 1
+    added_network_requests: 0
   - id: town-growth-replay
     summary: Public repo creation dates raise existing houses through a reversible, shareable year timeline without inventing historical metrics or adding render assets.
   - id: repo-portal
@@ -162,6 +170,7 @@ verify:
     - node council/test.mjs
     - node council/test-live.mjs
     - node scripts/smoke.mjs
+    - node scripts/test-session-footprints.mjs
     - node scripts/validate-lore-fragments.mjs
     - node --check scholars.js
     - node --check cloudflare-taxi/src/grounded.js

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -119,6 +119,7 @@ const REPO_ROUTE_SRC = readFileSync(join(ROOT, 'assets/repo-route.js'), 'utf8');
 const CONTRIBUTION_QUEST_SRC = readFileSync(join(ROOT, 'assets/contribution-quests.js'), 'utf8');
 const CITY_TIME_SRC = readFileSync(join(ROOT, 'assets/city-time.js'), 'utf8');
 const WORLD_TREE_STATE_SRC = readFileSync(join(ROOT, 'assets/world-tree/world-tree-state.js'), 'utf8');
+const SESSION_FOOTPRINT_SRC = readFileSync(join(ROOT, 'assets/session-footprints.js'), 'utf8');
 const CITY_STATE = JSON.parse(readFileSync(join(ROOT, 'data/city-state.json'), 'utf8'));
 const CITY_STATE_SCHEMA = JSON.parse(readFileSync(join(ROOT, 'data/city-state.schema.json'), 'utf8'));
 const CITY_REPOS = JSON.parse(readFileSync(join(ROOT, 'repos.json'), 'utf8'));
@@ -2346,6 +2347,38 @@ ok(/const authorized = authorizeTaxiRequest\(body\)/.test(WORKER)
 ok(/validate-lore-fragments\.mjs/.test(REFRESH_WORKFLOW)
   && /scripts\/smoke\.mjs/.test(REFRESH_WORKFLOW),
   'daily publication is gated by lore writing/schema and taxi boundary regressions');
+
+group('Phase 5 session footprints — ephemeral local walking trace');
+const footprintBlock=(HTML.match(/\/\*SESSION_FOOTPRINTS:START\*\/[\s\S]*?\/\*SESSION_FOOTPRINTS:END\*\//)||[''])[0];
+ok(footprintBlock.length>0
+  && /new THREE\.InstancedMesh\(SESSION_FOOTPRINT_GEO,SESSION_FOOTPRINT_MAT,SESSION_FOOTPRINT_STATE\.config\.capacity\)/.test(footprintBlock)
+  && /DynamicDrawUsage/.test(footprintBlock)
+  && /steadyState:0/.test(footprintBlock),
+  'one fixed instanced pool owns every footprint with zero steady-state geometry or material allocation');
+ok(/desktop: Object\.freeze\(\{ capacity: 36, spacing: 1\.35, lifetime: 5\.2/.test(SESSION_FOOTPRINT_SRC)
+  && /lowEnd: Object\.freeze\(\{ capacity: 18, spacing: 1\.8, lifetime: 4\.0/.test(SESSION_FOOTPRINT_SRC)
+  && /reduced: Object\.freeze\(\{ capacity: 8, spacing: 3\.0, lifetime: 1\.2/.test(SESSION_FOOTPRINT_SRC)
+  && /distance < state\.config\.spacing/.test(SESSION_FOOTPRINT_SRC)
+  && /distance > state\.config\.teleportDistance/.test(SESSION_FOOTPRINT_SRC),
+  'movement threshold, teleport reset, LOW_END cap, and reduced-motion lifetime are explicit bounded policy');
+ok(/const footprintTransit=!!\(ride\|\|ferris\|\|carousel\|\|canalFerryRide\|\|GROWTH_REPLAY\.active\)/.test(HTML)
+  && /sample\.walking=walking&&!suspended&&!document\.hidden/.test(footprintBlock)
+  && /_updateSessionFootprints\(dt,false,true\)/.test(HTML)
+  && /sample\.y=player\.position\.y/.test(footprintBlock)
+  && /surfaceOffset: 0\.035/.test(SESSION_FOOTPRINT_SRC)
+  && /polygonOffset:true/.test(footprintBlock),
+  'only post-collision local exterior walking reaches the terrain-offset trail; transit, growth, Atelier, and hidden tabs reset it');
+ok(!/(?:localStorage|sessionStorage|indexedDB|document\.cookie|fetch\(|sendBeacon|WebSocket|track\()/.test(SESSION_FOOTPRINT_SRC+footprintBlock)
+  && !/(?:COLLIDERS|EXTRA_COLLIDERS|RES_QUARTER_COLLIDERS)\.push/.test(footprintBlock)
+  && /colliders:0,stored:false,synced:false/.test(footprintBlock),
+  'the footprint boundary has no storage, identity, network, analytics, synchronization, or collider path');
+ok(/addEventListener\('pagehide'/.test(footprintBlock)
+  && /addEventListener\('pageshow'/.test(footprintBlock)
+  && /teardownSessionFootprints\(SESSION_FOOTPRINT_STATE\)/.test(footprintBlock)
+  && /SESSION_FOOTPRINT_GEO\.dispose\(\); SESSION_FOOTPRINT_MAT\.dispose\(\)/.test(footprintBlock)
+  && /if\(_DBG\)\{[\s\S]*?window\.__footprints/.test(footprintBlock)
+  && /test-session-footprints\.mjs/.test(REFRESH_WORKFLOW),
+  'navigation clears or tears down the pool, while fixtures remain debug-only and daily publication runs the hermetic suite');
 
 group('AURI market oracle — grounded market KB + read-only crypto MCP');
 const marketActionSrc=(HTML.match(/function marketActionQuestion\(q\)\{[\s\S]*?(?=\nfunction marketQuestion)/)||[''])[0];

--- a/scripts/test-session-footprints.mjs
+++ b/scripts/test-session-footprints.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import {
+  SESSION_FOOTPRINT_LIMITS,
+  clearSessionFootprints,
+  createSessionFootprintState,
+  resolveSessionFootprintConfig,
+  sessionFootprintScale,
+  sessionFootprintSnapshot,
+  stepSessionFootprints,
+  teardownSessionFootprints,
+} from '../assets/session-footprints.js';
+
+function step(state, x, z, options = {}) {
+  return stepSessionFootprints(state, {
+    x,
+    y: 0,
+    z,
+    heading: options.heading,
+    dt: options.dt ?? 0.1,
+    walking: options.walking ?? true,
+    resetAnchor: options.resetAnchor ?? false,
+  });
+}
+
+const desktop = createSessionFootprintState();
+assert.equal(step(desktop, 0, 0, { walking: false }), -1);
+assert.equal(step(desktop, 0, 0, { walking: false }), -1);
+assert.equal(sessionFootprintSnapshot(desktop).active, 0);
+assert.equal(step(desktop, SESSION_FOOTPRINT_LIMITS.desktop.spacing - 0.01, 0), -1);
+assert.equal(step(desktop, SESSION_FOOTPRINT_LIMITS.desktop.spacing + 0.01, 0), 0);
+assert.equal(sessionFootprintSnapshot(desktop).active, 1);
+
+clearSessionFootprints(desktop, { resetTotals: true });
+step(desktop, 0, 0, { walking: false });
+for (let index = 1; index <= SESSION_FOOTPRINT_LIMITS.desktop.capacity + 7; index += 1) {
+  step(desktop, index * (SESSION_FOOTPRINT_LIMITS.desktop.spacing + 0.05), 0);
+}
+const reused = sessionFootprintSnapshot(desktop);
+assert.equal(reused.active, SESSION_FOOTPRINT_LIMITS.desktop.capacity);
+assert.equal(reused.spawned, SESSION_FOOTPRINT_LIMITS.desktop.capacity + 7);
+assert.equal(reused.cursor, 7);
+
+clearSessionFootprints(desktop, { resetTotals: true });
+step(desktop, 0, 0, { walking: false });
+assert.equal(step(desktop, SESSION_FOOTPRINT_LIMITS.teleportDistance + 1, 0), -1);
+assert.equal(step(desktop, SESSION_FOOTPRINT_LIMITS.teleportDistance + 1.2, 0), -1);
+assert.equal(sessionFootprintSnapshot(desktop).active, 0);
+assert.equal(step(desktop, 20, 20, { resetAnchor: true }), -1);
+assert.equal(step(desktop, 21, 20, { walking: false }), -1);
+assert.equal(sessionFootprintSnapshot(desktop).active, 0);
+
+const freshReload = createSessionFootprintState();
+assert.equal(sessionFootprintSnapshot(freshReload).active, 0);
+assert.equal(sessionFootprintSnapshot(freshReload).spawned, 0);
+
+const lowEnd = resolveSessionFootprintConfig({ lowEnd: true });
+const reduced = resolveSessionFootprintConfig({ reducedMotion: true });
+assert.equal(lowEnd.capacity, SESSION_FOOTPRINT_LIMITS.lowEnd.capacity);
+assert.ok(lowEnd.capacity < SESSION_FOOTPRINT_LIMITS.desktop.capacity);
+assert.equal(reduced.capacity, SESSION_FOOTPRINT_LIMITS.reduced.capacity);
+assert.ok(reduced.spacing > lowEnd.spacing);
+assert.ok(reduced.lifetime < lowEnd.lifetime);
+
+const fading = createSessionFootprintState();
+step(fading, 0, 0, { walking: false });
+step(fading, 2, 0);
+const bornScale = sessionFootprintScale(fading, 0);
+for (let index = 0; index < 15; index += 1) step(fading, 2, 0, { walking: false, dt: 0.25 });
+const laterScale = sessionFootprintScale(fading, 0);
+assert.equal(bornScale, 1);
+assert.ok(laterScale < bornScale && laterScale > 0);
+for (let index = 0; index < 6; index += 1) step(fading, 2, 0, { walking: false, dt: 0.25 });
+assert.equal(sessionFootprintSnapshot(fading).active, 0);
+
+teardownSessionFootprints(desktop);
+assert.deepEqual(sessionFootprintSnapshot(desktop), {
+  capacity: SESSION_FOOTPRINT_LIMITS.desktop.capacity,
+  spacing: SESSION_FOOTPRINT_LIMITS.desktop.spacing,
+  lifetime: SESSION_FOOTPRINT_LIMITS.desktop.lifetime,
+  lowEnd: false,
+  reducedMotion: false,
+  active: 0,
+  cursor: 0,
+  spawned: 0,
+  disposed: true,
+});
+assert.equal(step(desktop, 0, 0), -1);
+
+console.log('ALL GREEN - session footprint movement, privacy, pool, accessibility, and teardown fixtures');


### PR DESCRIPTION
## Summary
- publish the Phase 5 decision matrix for all four optional experiments
- add a current-tab-only local-player footprint trail with a fixed typed-array ring and one `InstancedMesh`
- exclude stationary frames, teleports, taxi/rides, Growth Replay, Atelier movement, hidden tabs, reloads, and navigation
- gate publication with dedicated movement/privacy/pool/accessibility tests and static runtime guards

Part of #81. Fork lineage remains a separate follow-up PR; returnee events and contributor windows are explicitly deferred with re-entry conditions.

## Privacy and runtime boundary
- no `localStorage`, `sessionStorage`, IndexedDB, cookie, visitor ID, analytics event, socket sync, Worker, or backend request
- local avatar only; no resident or multiplayer peer history
- 36 desktop / 18 LOW_END / 8 reduced-motion slots; one scene child, zero colliders, zero steady-state geometry/material allocation

## Measured budget
- cold decoded load: `3,001,294 → 3,010,884 bytes` (`+9,590`), requests `42 → 43`
- desktop active cap: `+1 draw`, `+216 triangles`, render median `-0.81%`
- LOW_END active cap: `+1 draw`, `+108 triangles`, render median `0.00%`

## Validation
- `node council/test.mjs`
- `node council/test-live.mjs`
- `node scripts/smoke.mjs` (1,269 checks)
- `node scripts/test-session-footprints.mjs`
- city-state, resident-profile, lore, public-artifact, syntax, desktop 1440x900, mobile 390x844 DPR3 touch, reduced-motion, KO/EN, day/night, WebGL nonblank, overflow, and console checks

## Revert boundary
Remove `assets/session-footprints.js`, its `/*SESSION_FOOTPRINTS*/` runtime block, dedicated test, and narrow docs/workflow entries. No generated data or backend is coupled to this experiment.

## Visual QA

Desktop 1440x900 — restrained alternating prints on road/grass, one active draw.

![Desktop session footprints](https://github.com/user-attachments/assets/6d053fdf-f4dd-455d-a7e6-7a51787228e8)

Mobile 390x844 DPR3 touch / LOW_END — bounded trail with no overflow.

![Mobile LOW_END session footprints](https://github.com/user-attachments/assets/19a9ab70-8ee6-4a9e-8b0b-70b97f6ca261)
