### PR TITLE
feat: add public fork lineage

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -61,10 +61,12 @@ jobs:
           python3 scripts/validate_city_state.py
           python3 scripts/test_resident_profiles.py
           python3 scripts/validate_resident_profiles.py
+          python3 scripts/test_fork_lineage.py
           python3 scripts/scan_public_artifacts.py
           node scripts/validate-lore-fragments.mjs
           node scripts/test-city-time.mjs
           node scripts/test-session-footprints.mjs
+          node scripts/test-fork-lineage.mjs
           node scripts/smoke.mjs
 
       - name: Commit if changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`data/lore/fragments.json` + `assets/lore-fragments.js`** | Hand-authored KO/EN elder fragments plus strict validation, deterministic active-roster allocation, and session-bounded delivery. | Changing The Silence fragments or their rarity/allocation contract. Never generate or overwrite the JSON. |
 | **`assets/taxi-voice.js`** | Pure local taxi Shared-state answers, household redirect, and once-per-ride seasonal/district observations. | Changing travel voice without adding a backend call. |
 | **`assets/session-footprints.js`** | Pure bounded current-tab footprint ring: movement threshold, lifetime, LOW_END/reduced-motion policy, and teardown. | Changing the local player's ephemeral walking trace. |
+| **`scripts/fork_lineage.py` + `assets/fork-lineage.js`** | Public-only fork source sanitizer plus deterministic six-color crest projection. | Changing generated fork source truth, lineage cards, or the shared crest batch. |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
 | **`assets/world-tree/world-tree-state.js`** | Pure Phase 2 projection for Chronicle, Roots, sap-flow freshness/mode, and bounded star/repo growth. | Changing how generated city state reaches the silent World Tree. |
@@ -86,7 +87,8 @@ node scripts/build-contribution-library.mjs     # regenerates assets/contributio
 `repos.json` is an **array**; each entry's shape (keys you can rely on):
 `repo, desc, lang, topics[], url, home, stars, forks, fork, views, visitors, clones, size, open_issues,
 license, archived, default_branch, release_tag, release_date, created, pushed, tracked, first_seen,
-social, social_custom, score, rank`. Full meaning: [`docs/domain-model.md`](docs/domain-model.md).
+social, social_custom, score, rank`, plus `lineage{source,url}` only for a proven included public fork.
+Full meaning: [`docs/domain-model.md`](docs/domain-model.md).
 
 `data/city-state.json` is a deterministic projection of that public catalog. It carries `schema`,
 `version`, `era`, `season`, honest aggregate `stats`, `last_sap_flow`, and archived-only `roots`.
@@ -125,8 +127,10 @@ node council/test-live.mjs   # live guards + state machine
 node scripts/smoke.mjs       # city/runtime static + behavioral regression guards
 python3 scripts/test_city_state.py
 python3 scripts/validate_city_state.py
+python3 scripts/test_fork_lineage.py
 node scripts/test-city-time.mjs
 node scripts/test-session-footprints.mjs
+node scripts/test-fork-lineage.mjs
 node scripts/validate-lore-fragments.mjs
 node --check scholars.js
 node --check cloudflare-taxi/src/grounded.js
@@ -178,6 +182,7 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 | Change resident homes, styles, gardens, routines, moods, friendships, haunts, or Shared Joy | The resident social layer + Starlight Row blocks in `index.html`; preserve the resident style map, 3 roof batches, 10/6 desktop/LOW_END detail-batch cap, 42-unit reserve, entrance gap, quarter colliders, home/work truth, owned porch seats, and social ownership guards. |
 | Change elder lore, newcomer voice/scaffolding, or taxi travel observations | `data/lore/fragments.json`, `assets/lore-fragments.js`, `assets/taxi-voice.js`, `assets/city-time.js`, and the Phase 4 blocks in `index.html`; preserve the nine-resident active roster, World Tree silence, local-only delivery, and one observation per ride. |
 | Change session footprints | `assets/session-footprints.js` + `/*SESSION_FOOTPRINTS*/` in `index.html` + the Phase 5 group in `scripts/smoke.mjs`; preserve current-tab memory only, local post-collision walking truth, one fixed instanced pool, zero storage/network/analytics/sync, and no colliders. |
+| Change public fork lineage | `scripts/fork_lineage.py`, `assets/fork-lineage.js`, `/*FORK_LINEAGE*/` in `index.html`, and the Phase 5 lineage tests; preserve included-fork-only build lookups, minimal public fields, one shared crest draw, factual KO/EN copy, and zero runtime GitHub calls. |
 | Fix / improve a scholar's answer or references | `cloudflare-taxi/src/grounded.js` (server) + the trace panel in `index.html`. |
 | Add a new scholar NPC | `scholars.js` + `scholarConfig`/`MCP_NPCS` in `cloudflare-taxi/src/grounded.js`; choose KB-backed or direct MCP deliberately; document in `SCHOLARS.md`. |
 | Tune the taxi's repo search/intent routing | `index.html` (Local search: inverted index + intent agent). |
@@ -189,7 +194,8 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 
 ## 🧩 One-paragraph mental model
 
-A daily Action turns the owner's **public repos + committed traffic logs** into `repos.json`. `index.html`
+A daily Action turns the owner's **public repos + committed traffic logs** into `repos.json`; included public
+forks may also carry a minimal canonical source record. `index.html`
 turns that array into metric-shaped buildings, topic districts, routes, maps, and exploration progress.
 Residents add named homes, home/work commutes, moods, friendships, haunts, Shared Joy excursions, gatherings, and festivals. The oldest eligible 20% of the bounded active roster can rarely let slip a hand-authored local lore fragment; repositories younger than 90 generated-clock days receive a lightweight construction layer and newcomer voice. Landmarks include the Contribution Library, Chronopolis, Observatory, and imported procedural World Tree. Repo Portal lets one public `owner/repo` arrive before its owner catalog, then reuses the same building and Repository Atelier with truthful public-metadata boundaries. Repo Route lets a visitor hand off an ordered 2–3 house path they actually explored. Open Source Quests connects an explicitly loaded current public issue to its real repo house before GitHub handoff. Every repo also rebinds one reusable Atelier where its data, impact signals, current avatar, and in-room Gitber stay inside the exhibition. Town Growth Replay turns public repo creation dates into a reversible, shareable city history without inventing historical metrics. Gitber/POLARIS and the
 scholars (VEGA · MS Learn, RIGEL · DeepWiki, MIRA · Context7, LYRA · Hugging Face) add natural-language

--- a/assets/fork-lineage.js
+++ b/assets/fork-lineage.js
@@ -1,0 +1,53 @@
+export const FORK_LINEAGE_PALETTE = Object.freeze([
+  0x6f9f86,
+  0x7897b8,
+  0xa184b5,
+  0xb18a62,
+  0x8b9c68,
+  0xb17b7b,
+]);
+
+const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
+
+function normalizeRepoName(value) {
+  if (typeof value !== 'string' || value.split('/').length !== 2) return null;
+  const [owner, repo] = value.trim().split('/');
+  return OWNER_RE.test(owner) && REPO_RE.test(repo) ? `${owner}/${repo}` : null;
+}
+
+function canonicalGithubUrl(value, expectedName) {
+  try {
+    const url = new URL(String(value || ''));
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com'
+      || url.username || url.password || url.port || url.search || url.hash) return null;
+    const pathName = normalizeRepoName(url.pathname.replace(/^\/+|\/+$/g, ''));
+    return pathName && pathName.toLowerCase() === expectedName.toLowerCase()
+      ? `https://github.com/${expectedName}` : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function forkLineagePaletteIndex(source, paletteSize = FORK_LINEAGE_PALETTE.length) {
+  const size = Number.isInteger(paletteSize) && paletteSize > 0 ? paletteSize : FORK_LINEAGE_PALETTE.length;
+  let hash = 2166136261;
+  for (const character of String(source || '').toLowerCase()) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % size;
+}
+
+export function projectForkLineage(repo) {
+  if (!repo || repo.fork !== true || !repo.lineage || typeof repo.lineage !== 'object') return null;
+  const source = normalizeRepoName(repo.lineage.source);
+  const url = source && canonicalGithubUrl(repo.lineage.url, source);
+  const owner = normalizeRepoName(`${repo._owner || ''}/${repo.repo || ''}`);
+  if (!source || !url || (owner && source.toLowerCase() === owner.toLowerCase())) return null;
+  return Object.freeze({
+    source,
+    url,
+    paletteIndex: forkLineagePaletteIndex(source),
+  });
+}

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -42,6 +42,7 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | `stars` | number | ⭐ → gold-star roof ornaments. |
 | `forks` | number | ⑂ → building **width** (lot size). |
 | `fork` | boolean | Is this repo itself a fork? (mirror forks are filtered out upstream). |
+| `lineage` | object | Present only for a proven included public fork: canonical public `source` owner/name and `url`. It is origin metadata, not an authorship or maintainer claim. |
 | `views` | number | 📈 → **garden** / fence size. |
 | `visitors` | number | 👁 unique visitors → building **height**. |
 | `clones` | number | ⬇ → **ornamentation** (banners, gold trim). |
@@ -103,7 +104,7 @@ state the boundary instead of presenting derived values as observed traffic.
 github-traffic-monitor (private, daily)        Repolis (public)
   └ cumulative traffic → data/logs/*.csv ──┐
                                            ├─▶ .github/workflows/refresh.yml (daily)
-  gh api: owner's public repos (+ committed forks) ─┘  └ scripts/build_repos.py
+  gh api: owner's public repos (+ committed forks and bounded public source lookup) ─┘  └ scripts/build_repos.py
                                                          ├─▶ repos.json ─────────────────────┐
                                                          ├─▶ data/city-state.json ───────────┤
                                                          ├─▶ data/residents/index.json ──────┤
@@ -114,6 +115,8 @@ github-traffic-monitor (private, daily)        Repolis (public)
 ```
 
 - Only **public** repos appear (created repos + forks you actually committed to; mirror forks skipped).
+- Only those included forks receive a bounded parent/source lookup. Private, deleted, inaccessible, self,
+  malformed, or non-GitHub sources fail soft to no `lineage` field.
 - Both outputs are generated together; `data/city-state.json` is validated against
   `data/city-state.schema.json` and fixture-tested before the refresh can commit.
 - The daily Action commits `chore: refresh` to `main` — **always rebase before pushing** (see AGENTS.md rule 2).

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -26,6 +26,10 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
   and unavailable dialogue are exercised with deterministic fixtures rather than fabricated production history.
 - **Public repos only, by design.** Private repo names never appear. Untouched mirror forks are filtered
   out; only forks you've actually committed to are shown.
+- **Fork lineage is public origin metadata, not credit assignment.** The generated field exists only when
+  GitHub exposes a canonical public source for an included committed-to fork. Deleted, private, inaccessible,
+  malformed, and foreign runtime-only sources show no crest or card row. The shared crest color groups equal
+  sources but does not claim family, authorship, ownership, or a current maintainer relationship.
 - **Public API modes do not have traffic.** Repo Portal and `?user=` receive stars, forks, issues, language,
   topics, and lifecycle dates from unauthenticated public endpoints. GitHub does not return visitors, views,
   or clones there, so Repolis keeps those fields unknown and uses stars, forks, and recency for architecture.

--- a/docs/world-tree-phase5-decisions.md
+++ b/docs/world-tree-phase5-decisions.md
@@ -23,6 +23,24 @@ The controlled Chrome cold baseline is 3,001,294 decoded bytes and 42 requests a
 - The footprint boundary contains no storage, cookie, analytics, network, WebSocket, peer/resident,
   identity, or collider path. Page navigation clears or tears down the one pool.
 
+## Public-fork-lineage ship evidence
+
+- Current generated data: **9/68 forks with lineage, 0 non-forks with lineage, 0 archived repos**. Every
+  lineage object has exactly a canonical public `source` owner/name and `url`.
+- The normal daily build performs a lookup only after a fork passes the existing committed-to filter:
+  at most nine added REST reads in the current snapshot. Private, inaccessible, deleted, malformed,
+  self, and non-GitHub sources fail soft to no field.
+- Cold boot after footprints: 3,019,980 decoded bytes and 44 requests, a direct lineage delta of
+  **+9,096 bytes / +1 request**. The full Phase 5 delta is **+18,686 bytes / +2 requests**.
+- Frozen-pose desktop crest A/B: **+1 draw, +36 triangles, 0.00% render median**. LOW_END:
+  **+1 draw, +36 triangles, +1.59% render median**.
+- All nine crests share one geometry, material, draw, and six-color deterministic palette with zero
+  steady-state allocations; there are no source textures, lights, colliders, or runtime GitHub requests.
+  Growth Replay hides the whole batch.
+- KO/EN cards say only “갈라져 나온 공개 fork / Public fork branched from”, expose the exact
+  `github.com` source with `target=_blank rel=noopener`, and make no family, authorship, ownership, or
+  maintainer claim. Non-forks and unknown/foreign runtime sources render no lineage UI.
+
 ## Guardrails for the two approved experiments
 
 - Each experiment ships in its own branch, commit, PR, test boundary, merge, Pages deployment, and live QA.

--- a/index.html
+++ b/index.html
@@ -288,6 +288,12 @@
   .card .body { padding: 18px 24px 8px; }
   .card .body p { font-size: 14px; line-height: 1.55; color: #5a4636; }
   .card .body p.empty { color: #b39f8c; font-style: italic; }
+  .cardLineage { margin: 0 24px 4px; padding: 10px 12px; border-radius: 11px; background: #f0eee2;
+    color: #53604c; font-size: 11.5px; line-height: 1.45; display: flex; align-items: center; gap: 8px; }
+  .cardLineage[hidden] { display: none; }
+  .cardLineage .crest { width: 12px; height: 15px; flex: 0 0 auto; clip-path: polygon(50% 0,100% 25%,86% 76%,50% 100%,14% 76%,0 25%); }
+  .cardLineage .copy { flex: 1; min-width: 0; }
+  .cardLineage a { color: #456d62; font-weight: 800; text-decoration-thickness: 1px; text-underline-offset: 2px; }
   .card .actions { padding: 16px 24px 22px; display: flex; gap: 10px; flex-wrap: wrap; }
   .btn { flex: 1; min-width: 130px; text-align: center; text-decoration: none; padding: 12px 14px;
     border-radius: 12px; font-weight: 700; font-size: 14px; cursor: pointer; border: none; }
@@ -1639,7 +1645,7 @@
   <div class="stActions"><button id="repoRouteHudRide" type="button"></button></div>
 </div>
 
-<div id="modal" role="dialog" aria-modal="true" aria-labelledby="cardName" aria-describedby="cardDesc cardTimeTrace" aria-hidden="true">
+<div id="modal" role="dialog" aria-modal="true" aria-labelledby="cardName" aria-describedby="cardDesc cardTimeTrace cardLineage" aria-hidden="true">
   <div class="card" tabindex="-1">
     <img id="cardImg" class="hero" alt="repo social preview" />
     <div class="sociallabel" id="cardSocialTag">🎨 <span data-i18n="socialPreview">소셜 프리뷰</span></div>
@@ -1652,6 +1658,7 @@
     <div class="timeTrace" id="cardTimeTrace" role="status"></div>
     <div class="since" id="cardSince"></div>
     <div class="body"><p id="cardDesc"></p></div>
+    <div class="cardLineage" id="cardLineage" hidden></div>
     <div class="metricnote" id="cardMetricNote" data-i18n="metricNote">🏠 건물은 지표로 자라요 — 👁 방문자 = 높이 · ⑂ fork = 너비 · ⬇ clone = 화려함 · 📈 조회수 = 마당 · ★ = 금별 · 🌙 밤엔 창문 밝기 = 작업량(활동).</div>
     <div class="cardAsk" id="cardAsk"></div>
     <div class="actions" id="cardActions"></div>
@@ -1897,6 +1904,7 @@ import { bindResidentSlots, createResidentProfileStore, loadResidentManifest, re
 import { allocateElderFragments, createLoreDeliveryState, loadLoreFragments } from './assets/lore-fragments.js?v=world-tree-phase4-v1';
 import { taxiHouseholdHandoff, taxiRideObservation, taxiSharedResponse } from './assets/taxi-voice.js?v=world-tree-phase4-v1';
 import { clearSessionFootprints, createSessionFootprintState, sessionFootprintScale, sessionFootprintSnapshot, stepSessionFootprints, teardownSessionFootprints } from './assets/session-footprints.js?v=world-tree-phase5-footprints-v1';
+import { FORK_LINEAGE_PALETTE, projectForkLineage } from './assets/fork-lineage.js?v=world-tree-phase5-lineage-v1';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -2293,6 +2301,7 @@ const I18N = {
     rainName:'비정원 날씨 종', rainReached:' — 종을 울려 36초 동안 햇빛 소나기를 불러요. <span class="key">Enter</span> 또는 클릭으로 울리기', rainReachedWet:' — 소나기가 내려요. <span class="key">Enter</span> 또는 클릭으로 맑게 하기', rainStarted:'🌦️ 날씨 종이 울렸어요! 구름이 모이고 주민들이 우산을 펼쳐요', rainStopped:'☀️ 종소리를 따라 소나기가 걷혔어요', rainEnded:'🌤️ 짧은 소나기가 지나가고 마을이 다시 맑아졌어요', lmDriveRain:'🌦️ 비정원의 날씨 종으로 갑니다…', lmArriveRain:'🚕 <b>비정원</b>에 도착했어요! 종을 울려 햇빛 소나기를 불러보세요 🌦️',
     festAllStamps:'🎆 마을을 모두 둘러봤어요! 모든 명소 스탬프 완성 — 축제를 즐겨요!', festRepos:'🎆 레포 {n}곳 방문 달성! 불꽃이 터져요.',
     metricNote:'🏠 건물은 지표로 자라요 — 👁 방문자 = 높이 · ⑂ fork = 너비 · ⬇ clone = 화려함 · 📈 조회수 = 마당 · ★ = 금별 · 🌙 밤엔 창문 밝기 = 작업량(활동).',
+    lineageFrom:'🌿 {source}에서 갈라져 나온 공개 fork', lineageOpen:'공개 원본 저장소 열기 ↗',
     seasonSpring:'봄', seasonSummer:'여름', seasonAutumn:'가을', seasonWinter:'겨울', seasonCity:'도시 계절',
     wearRecent:'최근 손길', wearFaded:'빛바랜 흔적', wearMossed:'이끼 낀 시간',
     ruinStatus:'들꽃이 핀 온화한 폐허', ruinNote:'이 공개 레포는 아카이브되어 잠들었지만, 건물의 실루엣과 이름 명패는 도시의 기억으로 남아 있어요.',
@@ -2611,6 +2620,7 @@ const I18N = {
     rainName:'Rain Garden Weather Bell', rainReached:' — ring for one 36-second sunshower. Press <span class="key">Enter</span> or click to ring', rainReachedWet:' — the sunshower is falling. Press <span class="key">Enter</span> or click to clear it', rainStarted:'🌦️ The Weather Bell rang! Clouds gather and the residents open their umbrellas', rainStopped:'☀️ The sunshower clears with the bell', rainEnded:'🌤️ The brief shower passes and the town brightens again', lmDriveRain:'🌦️ Off to the Rain Garden Weather Bell…', lmArriveRain:"🚕 We've reached the <b>Rain Garden</b>! Ring the bell to call a sunshower 🌦️",
     festAllStamps:'🎆 You\'ve explored the whole village! Every landmark stamped — enjoy the festival!', festRepos:'🎆 {n} repos visited! Fireworks light up the sky.',
     metricNote:'🏠 Buildings grow from metrics — 👁 visitors = height · ⑂ forks = width · ⬇ clones = decoration · 📈 views = yard · ★ = gold star · 🌙 at night, window glow = repo activity.',
+    lineageFrom:'🌿 Public fork branched from {source}', lineageOpen:'Open public source ↗',
     seasonSpring:'Spring', seasonSummer:'Summer', seasonAutumn:'Autumn', seasonWinter:'Winter', seasonCity:'City season',
     wearRecent:'Recently tended', wearFaded:'Faded traces', wearMossed:'Mossed by time',
     ruinStatus:'Gentle ruin with wildflowers', ruinNote:'This public repository is archived and resting, while its original silhouette and accessible nameplate remain part of the city memory.',
@@ -2871,6 +2881,7 @@ function applyLang(){
   if(typeof window.__updateLiveTitle==='function') window.__updateLiveTitle();
   if(typeof _refreshRepositoryAtelierLanguage==='function') _refreshRepositoryAtelierLanguage();
   if(typeof refreshTimeTraceLabels==='function') refreshTimeTraceLabels();
+  { const cardModal=document.getElementById('modal'); if(typeof refreshRepoCardLineage==='function'&&cardModal?.classList.contains('show')&&cardModal._repoKey) refreshRepoCardLineage(repoByKey(cardModal._repoKey)); }
 }
 
 const _maxClones = Math.max(1, ...REPOS.map(r=>r.clones||0));
@@ -2892,6 +2903,7 @@ REPOS.forEach((repo,index)=>{
     wear:sampleWear,archived:(_CITY_TIME_FIXTURES&&index===3)||phase4Ruin,ageDays:phase4Age});
   repo._wearState=cityTime.state; repo._wearDays=cityTime.daysSincePush; repo._ruin=cityTime.archived;
   repo._ageDays=cityTime.ageDays; repo._newcomer=cityTime.newcomer;
+  repo._lineage=projectForkLineage(repo);
   repo.label = labelOf(repo.repo);
   repo.wall=_cityTint(p.wall,CITY_SEASON_STYLE.building,CITY_SEASON_STYLE.buildingMix);
   repo.roof=_cityTint(p.roof,CITY_SEASON_STYLE.building,CITY_SEASON_STYLE.buildingMix*.65);
@@ -5364,6 +5376,31 @@ function makeBuilding(repo){
   repo._group=g; repo._pos=new THREE.Vector3(repo._x,0,repo._z); repo._visited=false; buildings.push(repo);
 }
 REPOS.forEach(makeBuilding);
+/*FORK_LINEAGE:START*/
+const FORK_LINEAGE_RECORDS=REPOS.filter(repo=>repo._lineage&&repo._group&&repo._sign);
+let FORK_LINEAGE_CREST_MESH=null;
+function _buildForkLineageCrests(){
+  if(!FORK_LINEAGE_RECORDS.length) return null;
+  const shape=new THREE.Shape(); shape.moveTo(0,.31); shape.lineTo(.27,.16); shape.lineTo(.22,-.18); shape.lineTo(0,-.34);
+  shape.lineTo(-.22,-.18); shape.lineTo(-.27,.16); shape.closePath();
+  const geometry=new THREE.ShapeGeometry(shape),material=new THREE.MeshBasicMaterial({color:0xffffff,vertexColors:true,transparent:true,opacity:.82,
+    depthWrite:false,polygonOffset:true,polygonOffsetFactor:-1,polygonOffsetUnits:-1});
+  const mesh=new THREE.InstancedMesh(geometry,material,FORK_LINEAGE_RECORDS.length),dummy=new THREE.Object3D(),local=new THREE.Vector3(),world=new THREE.Vector3(),quaternion=new THREE.Quaternion();
+  mesh.name='PublicForkLineageCrests'; mesh.castShadow=false; mesh.receiveShadow=false; mesh.renderOrder=2;
+  FORK_LINEAGE_RECORDS.forEach((repo,index)=>{ const sign=repo._sign,signW=sign.geometry.parameters.width||3.1;
+    const x=-signW*.5+.25,y=sign.position.y,z=sign.position.z+.025;
+    repo._group.updateMatrixWorld(true); local.set(x,y,z); world.copy(local).applyMatrix4(repo._group.matrixWorld); repo._group.getWorldQuaternion(quaternion);
+    dummy.position.copy(world); dummy.quaternion.copy(quaternion); dummy.scale.setScalar(LOW_END?.52:.62); dummy.updateMatrix(); mesh.setMatrixAt(index,dummy.matrix);
+    mesh.setColorAt(index,new THREE.Color(FORK_LINEAGE_PALETTE[repo._lineage.paletteIndex])); repo._lineageCrest={index,paletteIndex:repo._lineage.paletteIndex,local:[x,y,z]}; });
+  mesh.instanceMatrix.needsUpdate=true; if(mesh.instanceColor) mesh.instanceColor.needsUpdate=true;
+  mesh.userData={count:FORK_LINEAGE_RECORDS.length,paletteSize:FORK_LINEAGE_PALETTE.length,draws:1,textures:0,sourceSpecificMaterials:0,colliders:0,
+    geometries:1,materials:1,steadyStateAllocations:0,
+    trianglesPerInstance:geometry.index?geometry.index.count/3:geometry.attributes.position.count/3};
+  scene.add(mesh); FORK_LINEAGE_CREST_MESH=mesh; return mesh;
+}
+function _setForkLineageCrestsVisible(visible){ if(FORK_LINEAGE_CREST_MESH) FORK_LINEAGE_CREST_MESH.visible=visible!==false; }
+_buildForkLineageCrests();
+/*FORK_LINEAGE:END*/
 function makeWorldTreeSapFlow(){
   if(!MEMORIAL_TREE||WORLD_TREE_SAP_MODE==='none') return null;
   const repos=buildings.filter(repo=>!repo._isLibrary&&repo._pos),count=repos.length;
@@ -9733,6 +9770,7 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
   const desc=document.getElementById('cardDesc');
   if(repo.desc){ desc.textContent=repo.desc; desc.className=''; }
   else { desc.textContent=t('noDesc'); desc.className='empty'; }
+  refreshRepoCardLineage(repo);
   const act=document.getElementById('cardActions');
   // 레포 카드에서는 '관련 토론 보기'(크로노폴리스 이동) 버튼을 노출하지 않는다 —
   // 집(레포)에서 갑자기 토론장으로 튕기는 흐름을 없애기 위함. chronoMatch는 검색/디버그용으로만 유지.
@@ -9753,6 +9791,16 @@ function openCard(repo){ if(repo._isLibrary){ openLibrary(); return; }
   track('repo_card_open',{repo:repo.repo});
   renderCardAsk(repo);
   markVisited(repo); setTimeout(()=>{ const close=document.getElementById('closeBtn'); if(close) close.focus(); },0); }
+function refreshRepoCardLineage(repo){
+  const box=document.getElementById('cardLineage'); if(!box) return;
+  box.replaceChildren(); const lineage=repo&&repo._lineage;
+  if(!lineage){ box.hidden=true; return; }
+  const crest=document.createElement('span'); crest.className='crest'; crest.setAttribute('aria-hidden','true');
+  crest.style.background='#'+FORK_LINEAGE_PALETTE[lineage.paletteIndex].toString(16).padStart(6,'0');
+  const copy=document.createElement('span'); copy.className='copy'; copy.append(document.createTextNode(tf('lineageFrom',{source:lineage.source})+' · '));
+  const link=document.createElement('a'); link.href=lineage.url; link.target='_blank'; link.rel='noopener'; link.textContent=t('lineageOpen'); copy.append(link);
+  box.append(crest,copy); box.hidden=false;
+}
 function closeCard(){ const previous=modal._previousFocus; modalOpen=false; modal.classList.remove('show'); modal.setAttribute('aria-hidden','true'); modal._repoKey=null; modal._previousFocus=null; clearRepoHash(); flushStarNudge();
   if(previous&&previous.isConnected&&typeof previous.focus==='function') previous.focus(); }
 /* ───────── 🚕 Repo-card actions — reuse the existing taxi/chat flow (no new backend) ───────── */
@@ -10771,6 +10819,7 @@ function startTownGrowthReplay(options={}){
   panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); passportEl.classList.add('hidden');
   document.getElementById('station').classList.add('hidden'); if(typeof closeMap==='function') closeMap();
   _growthSuspendBackground(GROWTH_REPLAY.saved);
+  _setForkLineageCrestsVisible(false);
   modalOpen=true; player.visible=false; navHolder.visible=false; document.body.classList.add('growth-replay-active');
   growthReplay.classList.remove('hidden'); growthReplay.setAttribute('aria-hidden','false');
   for(const state of GROWTH_REPLAY.saved.lod){ state.entry.forcedTier='far'; state.entry.active.visible=false; _buildingLodAttach(state.entry,'far',true); }
@@ -10789,6 +10838,7 @@ function closeTownGrowthReplay(){
   if(saved){ player.visible=saved.playerVisible; navHolder.visible=saved.navVisible; camYaw=saved.camYaw; camPitch=saved.camPitch; camDist=saved.camDist; freeLook=saved.freeLook;
     camera.far=saved.cameraFar; camera.updateProjectionMatrix(); camera.position.copy(saved.cameraPosition); camera.quaternion.copy(saved.cameraQuaternion); modalOpen=saved.modalOpen; }
   if(saved) for(const state of saved.lod){ state.entry.forcedTier=state.forced; state.entry.active.visible=state.activeVisible; _buildingLodAttach(state.entry,state.tier,true); }
+  _setForkLineageCrestsVisible(true);
   if(saved){ skyT=saved.skyT; skyTarget=saved.skyTarget; skyAuto=saved.skyAuto; skyPhaseIdx=saved.skyPhaseIdx;
     scene.fog.near=saved.fogNear; scene.fog.far=saved.fogFar; applySky(skyT,true); setNightState(saved.isNight); updateDayIcon(); }
   _growthRestoreScenery(saved);
@@ -12548,6 +12598,18 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__cam=()=>({camYaw:+camYaw.toFixed(6),camPitch:+camPitch.toFixed(6),camDist:+camDist.toFixed(4),charYaw:+model.rotation.y.toFixed(6),freeLook,dragging,dragBtn,
     camera:{position:_debugVec(camera.position),quaternion:[+camera.quaternion.x.toFixed(6),+camera.quaternion.y.toFixed(6),+camera.quaternion.z.toFixed(6),+camera.quaternion.w.toFixed(6)]},
     player:{position:_debugVec(player.position)},renderMode:WORLD_TREE_RENDER_MODE,night:isNight});
+  if(_DBG){
+    window.__forkLineage=()=>({forks:REPOS.filter(repo=>repo.fork).length,lineages:FORK_LINEAGE_RECORDS.length,unknown:REPOS.filter(repo=>repo.fork&&!repo._lineage).length,
+      mesh:FORK_LINEAGE_CREST_MESH?{count:FORK_LINEAGE_CREST_MESH.count,visible:FORK_LINEAGE_CREST_MESH.visible,...FORK_LINEAGE_CREST_MESH.userData}:null,
+      records:FORK_LINEAGE_RECORDS.map(repo=>({repo:repo.repo,source:repo._lineage.source,url:repo._lineage.url,...repo._lineageCrest})),
+      runtimeGithubRequests:0,sourceSpecificMaterials:0,colliders:0});
+    window.__lineageFixture=repo=>projectForkLineage(repo);
+    window.__lineageVisible=(visible=true)=>{ _setForkLineageCrestsVisible(visible!==false); return window.__forkLineage(); };
+    window.__lineageView=(name,back=14)=>{ const repo=FORK_LINEAGE_RECORDS.find(item=>item.repo===name)||FORK_LINEAGE_RECORDS[0]; if(!repo) return null;
+      const front=new THREE.Vector3(0,0,1).applyQuaternion(repo._group.quaternion).normalize(),focus=repo._pos.clone().addScaledVector(front,(repo._lodSpec?.d||4)*.5+2.6);
+      player.position.copy(focus); camYaw=Math.atan2(front.x,front.z); camPitch=.16; camDist=back; model.visible=false; freeLook=true;
+      return {repo:repo.repo,source:repo._lineage.source,focus:_debugVec(focus),front:_debugVec(front)}; };
+  }
   window.__postcard=()=>_postcardDebugState();
   window.__postcardOpen=async()=>{ const opened=openPostcardStudio('debug'); if(!opened) return _postcardDebugState();
     await POSTCARD.renderPromise; return _postcardDebugState(); };
@@ -12657,7 +12719,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     const keys=['opaque','transparent','additive','outline','pointsSprites','shadowCasters'],counts=Object.fromEntries(keys.map(k=>[k,0])),coverage=Object.fromEntries(keys.map(k=>[k,0]));
     const groups=new Map(),rootGroups=new Map(),viewportArea=Math.max(1,innerWidth*innerHeight),focal=innerHeight/(2*Math.tan(THREE.MathUtils.degToRad(camera.fov)*0.5));
     const rootOf=o=>{ let root=o; while(root.parent&&root.parent!==scene) root=root.parent; return root; },semanticRoots=new Map(),mark=(o,label)=>{ if(o) semanticRoots.set(rootOf(o),label); };
-    mark(starsGroup,'night-sky'); mark(cloudMesh,'clouds'); mark(player,'player'); mark(SESSION_FOOTPRINT_MESH,'session-footprints'); mark(taxi,'taxi'); mark(driver,'npc'); mark(engineer,'npc'); mark(rigel,'npc');
+    mark(starsGroup,'night-sky'); mark(cloudMesh,'clouds'); mark(player,'player'); mark(SESSION_FOOTPRINT_MESH,'session-footprints'); mark(FORK_LINEAGE_CREST_MESH,'fork-lineage'); mark(taxi,'taxi'); mark(driver,'npc'); mark(engineer,'npc'); mark(rigel,'npc');
     if(MEMORIAL_TREE) mark(MEMORIAL_TREE.group,'world-tree'); if(FERRIS) mark(FERRIS.wheel,'ferris'); if(CAROUSEL) mark(CAROUSEL.spin,'carousel');
     if(CHRONO&&CHRONO._group) mark(CHRONO._group,'chronopolis'); if(OBS&&OBS._group) mark(OBS._group,'observatory'); if(STATION&&STATION._group) mark(STATION._group,'station'); if(HEARTH&&HEARTH.g) mark(HEARTH.g,'hearth');
     ZONE_HUBS.forEach(h=>mark(h.group,'zone-hubs')); if(RES_QUARTER) mark(RES_QUARTER.group,'resident-quarter'); RESIDENTS_LIVE.forEach(L=>mark(L.group,'residents')); peers.forEach(p=>mark(p.group,'peers')); SWAY.forEach(g=>mark(g,'sway-trees')); CHOWS.filter(g=>g.parent===scene).forEach(g=>mark(g,'pets'));
@@ -12879,7 +12941,9 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     const id=chronoMatch(r); return { repo:r.repo, lang:r.lang, topics:(r.topics||[]).length, match:id, sig:(id&&CF&&CF.get)?(CF.get(id).sline):null, question:(id&&CF&&CF.get)?fxQuestion(CF.get(id)):null }; };
   window.__card=(name)=>{ const r=repoByKey(name)||(name&&REPOS.find(x=>x.label===name))||null; if(!r) return {found:false}; openCard(r);
     const b=document.getElementById('relChronoBtn');
-    return { repo:r.repo, cardShown:modal.classList.contains('show'), hasRelBtn:!!b, relText:b?b.textContent:null }; };
+    const lineage=document.getElementById('cardLineage'),link=lineage&&lineage.querySelector('a');
+    return { repo:r.repo, cardShown:modal.classList.contains('show'), hasRelBtn:!!b, relText:b?b.textContent:null,
+      lineage:lineage&&!lineage.hidden?{text:lineage.textContent.trim(),href:link&&link.href,target:link&&link.target,rel:link&&link.rel}:null }; };
   window.__walkSim=(fromX,fromZ,dirX,dirZ,steps=300)=>{
     // drive the player from a start point along a fixed direction through the REAL collider resolver,
     // one physics step (9 u/s @60fps) at a time — proves they never wedge (stop while still moving forward)

--- a/repolis.yaml
+++ b/repolis.yaml
@@ -35,6 +35,7 @@ data:
     generator: scripts/build_repos.py
     generate_cmd: GTM_DIR=data python3 scripts/build_repos.py
     note: Do not hand-edit; regenerate from data/logs/* plus gh api.
+    optional_fork_lineage: "lineage{source,url}; included public forks only"
   contribution_library:
     file: assets/contribution-library.json
     generated: true
@@ -55,6 +56,7 @@ entrypoints:
   elder_lore: assets/lore-fragments.js
   taxi_voice: assets/taxi-voice.js
   session_footprints: assets/session-footprints.js
+  fork_lineage: assets/fork-lineage.js
   data_builder: scripts/build_repos.py
   launch_config: repolis.config.js
   library_builder: scripts/build-contribution-library.mjs
@@ -117,6 +119,11 @@ features:
     reduced_motion_cap: 8
     added_draw_calls_while_visible: 1
     added_network_requests: 0
+  - id: public-fork-lineage
+    summary: Included public fork houses receive a factual canonical source card row and one shared deterministic crest batch without runtime GitHub requests.
+    generated_fields: [lineage.source, lineage.url]
+    added_draw_calls: 1
+    runtime_github_requests: 0
   - id: town-growth-replay
     summary: Public repo creation dates raise existing houses through a reversible, shareable year timeline without inventing historical metrics or adding render assets.
   - id: repo-portal
@@ -171,6 +178,8 @@ verify:
     - node council/test-live.mjs
     - node scripts/smoke.mjs
     - node scripts/test-session-footprints.mjs
+    - python3 scripts/test_fork_lineage.py
+    - node scripts/test-fork-lineage.mjs
     - node scripts/validate-lore-fragments.mjs
     - node --check scholars.js
     - node --check cloudflare-taxi/src/grounded.js

--- a/repos.json
+++ b/repos.json
@@ -2205,6 +2205,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.549,
+"lineage": {
+"source": "gonsoomoon-ml/Kor-LLM-On-SageMaker",
+"url": "https://github.com/gonsoomoon-ml/Kor-LLM-On-SageMaker"
+},
 "rank": 59
 },
 {
@@ -2234,6 +2238,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "csminpp/AccuPreLab",
+"url": "https://github.com/csminpp/AccuPreLab"
+},
 "rank": 60
 },
 {
@@ -2263,6 +2271,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "amazon-archives/amazon-transcribe-websocket-static",
+"url": "https://github.com/amazon-archives/amazon-transcribe-websocket-static"
+},
 "rank": 61
 },
 {
@@ -2292,6 +2304,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "aws-samples/aws-ai-ml-workshop-kr",
+"url": "https://github.com/aws-samples/aws-ai-ml-workshop-kr"
+},
 "rank": 62
 },
 {
@@ -2321,6 +2337,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "microsoft/azure-ai-search-foundry-iq-live-knowledge-sources",
+"url": "https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources"
+},
 "rank": 63
 },
 {
@@ -2350,6 +2370,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "daekeun-ml/genai-ko-LLM",
+"url": "https://github.com/daekeun-ml/genai-ko-LLM"
+},
 "rank": 64
 },
 {
@@ -2379,6 +2403,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "jesamkim/pptx-translation-with-llm",
+"url": "https://github.com/jesamkim/pptx-translation-with-llm"
+},
 "rank": 65
 },
 {
@@ -2408,6 +2436,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "dongjin-ml/sagemaker-immersion-day",
+"url": "https://github.com/dongjin-ml/sagemaker-immersion-day"
+},
 "rank": 66
 },
 {
@@ -2437,6 +2469,10 @@
 "social": "",
 "social_custom": false,
 "score": 0.0,
+"lineage": {
+"source": "AccuInsight/skcc-accuinsight-examples",
+"url": "https://github.com/AccuInsight/skcc-accuinsight-examples"
+},
 "rank": 67
 }
 ]

--- a/scripts/build_repos.py
+++ b/scripts/build_repos.py
@@ -19,6 +19,9 @@ Env vars:
   CITY_STATE_AS_OF  Optional ISO-8601 city reference time. The daily workflow
                    supplies its UTC run day; local builds fall back to the
                    newest reproducible public source timestamp.
+  FORK_LINEAGE_ONLY  Set to 1 to enrich an existing generated snapshot without
+                    refreshing unrelated repository fields.
+  FORK_LINEAGE_INPUT  Optional input snapshot for FORK_LINEAGE_ONLY (default: OUT).
   GH_TOKEN    Token used by `gh` (PAT that can list the repos)
 """
 import csv
@@ -29,6 +32,7 @@ import subprocess
 from pathlib import Path
 
 from city_state import build_city_state, write_city_state
+from fork_lineage import public_fork_lineage
 from resident_profiles import write_resident_artifacts
 
 def resolve_owner():
@@ -53,6 +57,8 @@ GTM_DIR = Path(_configured_gtm) if _configured_gtm else (
     Path("data") if OWNER.lower() == UPSTREAM_OWNER else Path("data") / "towns" / OWNER
 )
 OUT = Path(os.environ.get("OUT", "repos.json"))
+FORK_LINEAGE_ONLY = os.environ.get("FORK_LINEAGE_ONLY", "").strip() == "1"
+FORK_LINEAGE_INPUT = Path(os.environ.get("FORK_LINEAGE_INPUT", str(OUT)))
 CITY_STATE_OUT = Path(os.environ.get("CITY_STATE_OUT", "data/city-state.json"))
 CITY_STATE_AS_OF = os.environ.get("CITY_STATE_AS_OF", "").strip() or None
 RESIDENTS_OUT = Path(os.environ.get("RESIDENTS_OUT", "data/residents"))
@@ -277,6 +283,38 @@ def first_date(path):
     return earliest or ""
 
 
+def record_with_lineage(record, lineage):
+    output = {}
+    for key, value in record.items():
+        if key == "lineage":
+            continue
+        if key == "rank" and lineage:
+            output["lineage"] = lineage
+        output[key] = value
+    if lineage and "lineage" not in output:
+        output["lineage"] = lineage
+    return output
+
+
+def refresh_fork_lineage():
+    records = json.loads(FORK_LINEAGE_INPUT.read_text(encoding="utf-8"))
+    if not isinstance(records, list):
+        raise ValueError("fork lineage input must be a repository array")
+    output = []
+    lookups = 0
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("fork lineage input contains a non-object")
+        lineage = None
+        if record.get("fork") is True:
+            lookups += 1
+            lineage = public_fork_lineage(f"{OWNER}/{record.get('repo', '')}")
+        output.append(record_with_lineage(record, lineage))
+    OUT.write_text(json.dumps(output, ensure_ascii=False, indent=0) + "\n", encoding="utf-8")
+    included = sum(1 for record in output if record.get("lineage"))
+    print(f"wrote {OUT} with {included} public fork lineages ({lookups} bounded lookups)")
+
+
 def build():
     # Public owner endpoint works with the built-in Actions token, so a fork can
     # build its first city without a PAT. A PAT is only needed for traffic data.
@@ -288,9 +326,10 @@ def build():
     for r in repos:
         if r.get("private"):
             continue
-        if r.get("fork") and not i_committed(r.get("full_name") or f"{OWNER}/{r['name']}"):
-            continue
         name = r["name"]
+        full = r.get("full_name") or f"{OWNER}/{name}"
+        if r.get("fork") and not i_committed(full):
+            continue
         views = sum_col(GTM_DIR / "logs" / f"{name}.csv", "views")
         visitors = sum_col(GTM_DIR / "logs" / f"{name}.csv", "uniques")
         clones = sum_col(GTM_DIR / "logs" / "clones" / f"{name}.csv", "clones")
@@ -299,7 +338,7 @@ def build():
                       or first_date(GTM_DIR / "logs" / "clones" / f"{name}.csv"))
         stars = r.get("stargazers_count", 0) or 0
         forks = r.get("forks_count", 0) or 0
-        full = r.get("full_name") or f"{OWNER}/{name}"
+        lineage = public_fork_lineage(full) if r.get("fork") else None
         lic = r.get("license") or {}
         lic_name = lic.get("spdx_id") or lic.get("name") or ""
         if lic_name in ("NOASSERTION", "NONE"):
@@ -316,36 +355,35 @@ def build():
             + math.log1p(forks) * 0.6
             + math.log1p(stars) * 0.5
         )
-        out.append(
-            {
-                "repo": name,
-                "desc": (r.get("description") or "").strip(),
-                "lang": r.get("language") or "Other",
-                "topics": r.get("topics") or [],
-                "url": r.get("html_url"),
-                "home": (r.get("homepage") or "").strip(),
-                "stars": stars,
-                "forks": forks,
-                "fork": bool(r.get("fork")),
-                "views": views,
-                "visitors": visitors,
-                "clones": clones,
-                "size": r.get("size", 0) or 0,
-                "open_issues": r.get("open_issues_count", 0) or 0,
-                "license": lic_name,
-                "archived": bool(r.get("archived")),
-                "default_branch": r.get("default_branch") or "main",
-                "release_tag": (rel or {}).get("tag", ""),
-                "release_date": (rel or {}).get("date", ""),
-                "created": (r.get("created_at") or "")[:10],
-                "pushed": (r.get("pushed_at") or "")[:10],
-                "tracked": tracked,
-                "first_seen": first_seen,
-                "social": (social.get(name) or {}).get("url", ""),
-                "social_custom": (social.get(name) or {}).get("custom", False),
-                "score": round(score, 3),
-            }
-        )
+        record = {
+            "repo": name,
+            "desc": (r.get("description") or "").strip(),
+            "lang": r.get("language") or "Other",
+            "topics": r.get("topics") or [],
+            "url": r.get("html_url"),
+            "home": (r.get("homepage") or "").strip(),
+            "stars": stars,
+            "forks": forks,
+            "fork": bool(r.get("fork")),
+            "views": views,
+            "visitors": visitors,
+            "clones": clones,
+            "size": r.get("size", 0) or 0,
+            "open_issues": r.get("open_issues_count", 0) or 0,
+            "license": lic_name,
+            "archived": bool(r.get("archived")),
+            "default_branch": r.get("default_branch") or "main",
+            "release_tag": (rel or {}).get("tag", ""),
+            "release_date": (rel or {}).get("date", ""),
+            "created": (r.get("created_at") or "")[:10],
+            "pushed": (r.get("pushed_at") or "")[:10],
+            "tracked": tracked,
+            "first_seen": first_seen,
+            "social": (social.get(name) or {}).get("url", ""),
+            "social_custom": (social.get(name) or {}).get("custom", False),
+            "score": round(score, 3),
+        }
+        out.append(record_with_lineage(record, lineage))
 
     out.sort(key=lambda x: x["score"], reverse=True)
     for i, o in enumerate(out):
@@ -379,4 +417,7 @@ def build():
 
 
 if __name__ == "__main__":
-    build()
+    if FORK_LINEAGE_ONLY:
+        refresh_fork_lineage()
+    else:
+        build()

--- a/scripts/fork_lineage.py
+++ b/scripts/fork_lineage.py
@@ -1,0 +1,81 @@
+"""Public-safe fork source projection for generated Repolis repo data."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from urllib.parse import urlparse
+
+
+_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}$")
+
+
+def normalize_repo_name(value):
+    if not isinstance(value, str) or value.count("/") != 1:
+        return None
+    owner, repo = value.strip().split("/", 1)
+    if not _OWNER_RE.fullmatch(owner) or not _REPO_RE.fullmatch(repo):
+        return None
+    return f"{owner}/{repo}"
+
+
+def canonical_github_repo_url(value, expected_name):
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = urlparse(value)
+        invalid = (
+            parsed.scheme != "https"
+            or parsed.hostname != "github.com"
+            or parsed.port is not None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        )
+    except ValueError:
+        return None
+    if invalid:
+        return None
+    path_name = normalize_repo_name(parsed.path.strip("/"))
+    if not path_name or path_name.lower() != expected_name.lower():
+        return None
+    return f"https://github.com/{expected_name}"
+
+
+def sanitize_fork_lineage(payload, current_full_name):
+    if not isinstance(payload, dict) or payload.get("fork") is not True:
+        return None
+    current = normalize_repo_name(current_full_name)
+    source = payload.get("source") or payload.get("parent")
+    if not current or not isinstance(source, dict):
+        return None
+    if source.get("private") is True or str(source.get("visibility") or "public").lower() != "public":
+        return None
+    name = normalize_repo_name(source.get("full_name") or source.get("nameWithOwner"))
+    if not name or name.lower() == current.lower():
+        return None
+    url = canonical_github_repo_url(source.get("html_url") or source.get("url"), name)
+    if not url:
+        return None
+    return {"source": name, "url": url}
+
+
+def public_fork_lineage(full_name):
+    """Return a minimal public source record, or None when GitHub cannot prove one."""
+    current = normalize_repo_name(full_name)
+    if not current:
+        return None
+    try:
+        raw = subprocess.check_output(
+            ["gh", "api", f"/repos/{current}"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        payload = json.loads(raw)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError):
+        return None
+    return sanitize_fork_lineage(payload, current)

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -84,6 +84,11 @@ import {
   resolveSapFlowFreshness,
   resolveSapFlowMode
 } from '../assets/world-tree/world-tree-state.js';
+import {
+  FORK_LINEAGE_PALETTE,
+  forkLineagePaletteIndex,
+  projectForkLineage
+} from '../assets/fork-lineage.js';
 
 const require = createRequire(import.meta.url);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -120,6 +125,8 @@ const CONTRIBUTION_QUEST_SRC = readFileSync(join(ROOT, 'assets/contribution-ques
 const CITY_TIME_SRC = readFileSync(join(ROOT, 'assets/city-time.js'), 'utf8');
 const WORLD_TREE_STATE_SRC = readFileSync(join(ROOT, 'assets/world-tree/world-tree-state.js'), 'utf8');
 const SESSION_FOOTPRINT_SRC = readFileSync(join(ROOT, 'assets/session-footprints.js'), 'utf8');
+const FORK_LINEAGE_SRC = readFileSync(join(ROOT, 'assets/fork-lineage.js'), 'utf8');
+const FORK_LINEAGE_BUILDER = readFileSync(join(ROOT, 'scripts/fork_lineage.py'), 'utf8');
 const CITY_STATE = JSON.parse(readFileSync(join(ROOT, 'data/city-state.json'), 'utf8'));
 const CITY_STATE_SCHEMA = JSON.parse(readFileSync(join(ROOT, 'data/city-state.schema.json'), 'utf8'));
 const CITY_REPOS = JSON.parse(readFileSync(join(ROOT, 'repos.json'), 'utf8'));
@@ -2379,6 +2386,56 @@ ok(/addEventListener\('pagehide'/.test(footprintBlock)
   && /if\(_DBG\)\{[\s\S]*?window\.__footprints/.test(footprintBlock)
   && /test-session-footprints\.mjs/.test(REFRESH_WORKFLOW),
   'navigation clears or tears down the pool, while fixtures remain debug-only and daily publication runs the hermetic suite');
+
+group('Phase 5 public fork lineage — static source truth and one subtle crest batch');
+const lineageBlock=(HTML.match(/\/\*FORK_LINEAGE:START\*\/[\s\S]*?\/\*FORK_LINEAGE:END\*\//)||[''])[0];
+const lineageCardBlock=(HTML.match(/function refreshRepoCardLineage\(repo\)\{[\s\S]*?function closeCard\(\)/)||[''])[0];
+const currentForks=CITY_REPOS.filter(repo=>repo.fork),currentLineages=currentForks.map(repo=>projectForkLineage({...repo,_owner:'hyeonsangjeon'}));
+ok(currentForks.length>0
+  && currentLineages.every(Boolean)
+  && CITY_REPOS.filter(repo=>!repo.fork).every(repo=>!Object.hasOwn(repo,'lineage')),
+  'every current committed-to fork carries valid lineage while non-forks carry no lineage field');
+ok(projectForkLineage({fork:false,lineage:{source:'a/b',url:'https://github.com/a/b'}})===null
+  && projectForkLineage({fork:true,_owner:'owner',repo:'child',lineage:{source:'bad source',url:'https://github.com/bad/source'}})===null
+  && projectForkLineage({fork:true,_owner:'owner',repo:'child',lineage:{source:'source/repo',url:'https://example.com/source/repo'}})===null
+  && projectForkLineage({fork:true,_owner:'owner',repo:'child',lineage:{source:'owner/child',url:'https://github.com/owner/child'}})===null,
+  'non-forks, unknown/malformed sources, non-GitHub URLs, and self-lineage fail soft');
+ok(FORK_LINEAGE_PALETTE.length===6
+  && forkLineagePaletteIndex('source/repo')===forkLineagePaletteIndex('source/repo')
+  && new Set(currentLineages.map(lineage=>lineage.paletteIndex)).size<=FORK_LINEAGE_PALETTE.length,
+  'crest assignment is deterministic and bounded to one shared six-color palette');
+const publicForkProjection=projectPublicRepo({
+  name:'child',full_name:'visitor/child',owner:{login:'visitor'},private:false,disabled:false,fork:true,
+  source:{full_name:'source/repo',html_url:'https://github.com/source/repo'}
+},'visitor',Date.parse('2026-08-24T00:00:00Z'));
+ok(publicForkProjection?.fork===true && !Object.hasOwn(publicForkProjection,'lineage')
+  && /public_fork_lineage\(full\) if r\.get\("fork"\) else None/.test(REPO_BUILDER)
+  && /if record\.get\("fork"\) is True:[\s\S]*?public_fork_lineage/.test(REPO_BUILDER),
+  'foreign/public runtime projections invent no lineage; only included generated forks receive bounded build-time lookups');
+ok(/source\.get\("private"\) is True/.test(FORK_LINEAGE_BUILDER)
+  && /visibility/.test(FORK_LINEAGE_BUILDER)
+  && /parsed\.hostname != "github\.com"/.test(FORK_LINEAGE_BUILDER)
+  && /except \(subprocess\.CalledProcessError, json\.JSONDecodeError, ValueError\):\s+return None/.test(FORK_LINEAGE_BUILDER),
+  'private, inaccessible, deleted, malformed, and non-GitHub sources are rejected without failing the daily build');
+ok(lineageBlock.length>0
+  && (lineageBlock.match(/new THREE\.InstancedMesh/g)||[]).length===1
+  && /count:FORK_LINEAGE_RECORDS\.length,paletteSize:FORK_LINEAGE_PALETTE\.length,draws:1,textures:0,sourceSpecificMaterials:0,colliders:0/.test(lineageBlock)
+  && !/Texture|fetch\(|PointLight|DoubleSide|COLLIDERS\.push|EXTRA_COLLIDERS\.push/.test(lineageBlock),
+  'all source crests share one instanced draw, geometry, material, and bounded palette with zero textures, lights, or colliders');
+ok(/lineageFrom:'🌿 \{source\}에서 갈라져 나온 공개 fork'/.test(HTML)
+  && /lineageFrom:'🌿 Public fork branched from \{source\}'/.test(HTML)
+  && /link\.target='_blank'; link\.rel='noopener'/.test(lineageCardBlock)
+  && !/(family|kinship|bloodline|authored by|created by|가족|혈통|만든 사람)/i.test((HTML.match(/lineageFrom:[^\n]+/g)||[]).join('\n')),
+  'KO/EN card copy states only a public branch fact and the exact GitHub source link is noopener-safe');
+ok(/_setForkLineageCrestsVisible\(false\)/.test(HTML)
+  && /_setForkLineageCrestsVisible\(true\)/.test(HTML)
+  && /repo\._lineage=projectForkLineage\(repo\)/.test(HTML)
+  && !/fetch\(|api\.github\.com|WebSocket|track\(/.test(FORK_LINEAGE_SRC+lineageBlock+lineageCardBlock),
+  'crest visibility cannot ghost through Growth Replay and lineage adds no runtime API, socket, or telemetry path');
+ok(/test_fork_lineage\.py/.test(REFRESH_WORKFLOW)
+  && /test-fork-lineage\.mjs/.test(REFRESH_WORKFLOW)
+  && /FORK_LINEAGE_ONLY/.test(REPO_BUILDER),
+  'daily publication runs sanitizer/catalog fixtures and supports an independent lineage-only generated-data refresh');
 
 group('AURI market oracle — grounded market KB + read-only crypto MCP');
 const marketActionSrc=(HTML.match(/function marketActionQuestion\(q\)\{[\s\S]*?(?=\nfunction marketQuestion)/)||[''])[0];

--- a/scripts/test-fork-lineage.mjs
+++ b/scripts/test-fork-lineage.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  FORK_LINEAGE_PALETTE,
+  forkLineagePaletteIndex,
+  projectForkLineage,
+} from '../assets/fork-lineage.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const repositories = JSON.parse(readFileSync(join(ROOT, 'repos.json'), 'utf8'));
+
+const valid = {
+  repo: 'child',
+  fork: true,
+  _owner: 'fork-owner',
+  lineage: {
+    source: 'source-owner/source-repo',
+    url: 'https://github.com/source-owner/source-repo',
+  },
+};
+assert.deepEqual(projectForkLineage(valid), {
+  source: 'source-owner/source-repo',
+  url: 'https://github.com/source-owner/source-repo',
+  paletteIndex: forkLineagePaletteIndex('source-owner/source-repo'),
+});
+assert.equal(projectForkLineage({ ...valid, fork: false }), null);
+assert.equal(projectForkLineage({ ...valid, lineage: null }), null);
+assert.equal(projectForkLineage({ ...valid, lineage: { ...valid.lineage, source: 'bad source' } }), null);
+assert.equal(projectForkLineage({ ...valid, lineage: { ...valid.lineage, url: 'https://example.com/source-owner/source-repo' } }), null);
+assert.equal(projectForkLineage({ ...valid, lineage: { ...valid.lineage, url: 'javascript:alert(1)' } }), null);
+assert.equal(projectForkLineage({
+  ...valid,
+  lineage: { source: 'fork-owner/child', url: 'https://github.com/fork-owner/child' },
+}), null);
+
+for (let size = 1; size <= FORK_LINEAGE_PALETTE.length; size += 1) {
+  const first = forkLineagePaletteIndex('source-owner/source-repo', size);
+  const second = forkLineagePaletteIndex('source-owner/source-repo', size);
+  assert.equal(first, second);
+  assert.ok(first >= 0 && first < size);
+}
+
+const forks = repositories.filter(repo => repo.fork);
+assert.ok(forks.length > 0);
+assert.ok(forks.every(repo => projectForkLineage({ ...repo, _owner: 'hyeonsangjeon' })));
+assert.ok(repositories.filter(repo => !repo.fork).every(repo => !Object.hasOwn(repo, 'lineage')));
+
+console.log('ALL GREEN - fork lineage projection, sanitization, deterministic crest, and current data');

--- a/scripts/test_fork_lineage.py
+++ b/scripts/test_fork_lineage.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Hermetic fork-lineage sanitizer and daily-build fixture tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+os.environ.setdefault("REPO_OWNER", "fixture-owner")
+
+import build_repos  # noqa: E402
+from fork_lineage import public_fork_lineage, sanitize_fork_lineage  # noqa: E402
+
+
+def source_payload(**source_overrides):
+    source = {
+        "full_name": "source-owner/source-repo",
+        "html_url": "https://github.com/source-owner/source-repo",
+        "private": False,
+        "visibility": "public",
+    }
+    source.update(source_overrides)
+    return {"fork": True, "source": source}
+
+
+def raw_repo(name, *, fork=False):
+    return {
+        "name": name,
+        "full_name": f"fixture-owner/{name}",
+        "private": False,
+        "fork": fork,
+        "description": "",
+        "language": "Python",
+        "topics": [],
+        "html_url": f"https://github.com/fixture-owner/{name}",
+        "homepage": "",
+        "stargazers_count": 1,
+        "forks_count": 0,
+        "size": 1,
+        "open_issues_count": 0,
+        "license": {"spdx_id": "MIT"},
+        "archived": False,
+        "default_branch": "main",
+        "created_at": "2020-01-01T00:00:00Z",
+        "pushed_at": "2026-08-24T00:00:00Z",
+        "updated_at": "2026-08-24T00:00:00Z",
+    }
+
+
+class ForkLineageTests(unittest.TestCase):
+    def test_public_source_is_minimal_and_canonical(self):
+        self.assertEqual(
+            sanitize_fork_lineage(source_payload(), "fixture-owner/child"),
+            {
+                "source": "source-owner/source-repo",
+                "url": "https://github.com/source-owner/source-repo",
+            },
+        )
+        parent = source_payload()
+        parent["parent"] = parent.pop("source")
+        self.assertEqual(
+            sanitize_fork_lineage(parent, "fixture-owner/child")["source"],
+            "source-owner/source-repo",
+        )
+
+    def test_private_deleted_and_malformed_sources_fail_soft(self):
+        self.assertIsNone(sanitize_fork_lineage(source_payload(private=True), "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage(source_payload(visibility="private"), "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage({"fork": True}, "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage(source_payload(full_name="bad source"), "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage(source_payload(html_url="https://example.com/source-owner/source-repo"), "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage(source_payload(html_url="https://github.com:bad/source-owner/source-repo"), "fixture-owner/child"))
+        self.assertIsNone(sanitize_fork_lineage(source_payload(full_name="fixture-owner/child", html_url="https://github.com/fixture-owner/child"), "fixture-owner/child"))
+        with mock.patch("fork_lineage.subprocess.check_output", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertIsNone(public_fork_lineage("fixture-owner/deleted"))
+
+    def test_daily_build_fixture_is_bounded_and_byte_stable(self):
+        fixtures = [raw_repo("original"), raw_repo("worked-fork", fork=True), raw_repo("mirror", fork=True)]
+        lineage_calls = []
+
+        def committed(full_name):
+            return not full_name.endswith("/mirror")
+
+        def lineage(full_name):
+            lineage_calls.append(full_name)
+            return {
+                "source": "source-owner/source-repo",
+                "url": "https://github.com/source-owner/source-repo",
+            }
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            settings = {
+                "OUT": root / "repos.json",
+                "CITY_STATE_OUT": root / "city-state.json",
+                "RESIDENTS_OUT": root / "residents",
+                "RESIDENT_REGISTRY_OUT": root / "resident-registry.js",
+                "GTM_DIR": root / "data",
+                "CITY_STATE_AS_OF": "2026-08-24T00:00:00Z",
+            }
+            patches = [
+                mock.patch.object(build_repos, key, value)
+                for key, value in settings.items()
+            ]
+            with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
+                    mock.patch.object(build_repos, "gh_api", return_value=fixtures), \
+                    mock.patch.object(build_repos, "social_map", return_value={}), \
+                    mock.patch.object(build_repos, "latest_release", return_value=None), \
+                    mock.patch.object(build_repos, "resident_history", return_value={"available": False}), \
+                    mock.patch.object(build_repos, "i_committed", side_effect=committed), \
+                    mock.patch.object(build_repos, "public_fork_lineage", side_effect=lineage):
+                build_repos.build()
+                first = settings["OUT"].read_bytes()
+                build_repos.build()
+                second = settings["OUT"].read_bytes()
+
+            output = json.loads(first)
+            self.assertEqual(first, second)
+            self.assertEqual([repo["repo"] for repo in output], ["original", "worked-fork"])
+            self.assertNotIn("lineage", output[0])
+            self.assertEqual(output[1]["lineage"]["source"], "source-owner/source-repo")
+            self.assertEqual(lineage_calls, ["fixture-owner/worked-fork", "fixture-owner/worked-fork"])
+
+    def test_lineage_only_refresh_preserves_unrelated_generated_fields(self):
+        records = [
+            {"repo": "original", "fork": False, "size": 7, "rank": 0},
+            {"repo": "worked-fork", "fork": True, "size": 11, "lineage": {"source": "stale/source"}, "rank": 1},
+        ]
+        lineage = {
+            "source": "source-owner/source-repo",
+            "url": "https://github.com/source-owner/source-repo",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "input.json"
+            output = root / "output.json"
+            source.write_text(json.dumps(records), encoding="utf-8")
+            with mock.patch.object(build_repos, "FORK_LINEAGE_INPUT", source), \
+                    mock.patch.object(build_repos, "OUT", output), \
+                    mock.patch.object(build_repos, "public_fork_lineage", return_value=lineage) as lookup:
+                build_repos.refresh_fork_lineage()
+                first = output.read_bytes()
+                build_repos.FORK_LINEAGE_INPUT = output
+                build_repos.refresh_fork_lineage()
+                second = output.read_bytes()
+            refreshed = json.loads(first)
+            self.assertEqual(first, second)
+            self.assertEqual(refreshed[0], records[0])
+            self.assertEqual(refreshed[1]["size"], 11)
+            self.assertEqual(refreshed[1]["lineage"], lineage)
+            self.assertEqual(list(refreshed[1]), ["repo", "fork", "size", "lineage", "rank"])
+            self.assertEqual(lookup.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enrich only included committed-to public forks with minimal generated `lineage.source` and canonical `lineage.url`
- sanitize private, inaccessible, deleted, malformed, self, and non-GitHub sources to no lineage without failing the build
- render all current crests through one shared instanced geometry/material/palette and expose the exact source only in the repo card
- finish the Phase 5 decision note with measured evidence for both shipped and both deferred candidates

Part of #81. This is independent of the already-deployed session-footprint PR #89.

## Current generated data
- 68 public repos
- 9 included public forks, all 9 with validated public lineage
- 0 non-forks with lineage
- 0 archived repos
- exactly two added fields per proven fork: `source` and `url`

## Public safety and cost
- lookup occurs only after the existing `i_committed` fork filter; current delta is 9 bounded REST reads during the daily build
- default token budget remains ample (`15,000` core request limit observed)
- runtime GitHub requests for lineage: 0
- no contributor calls, private collaborators, descriptions, commit identity, telemetry event, Worker, model, or backend
- KO/EN copy states only “갈라져 나온 공개 fork / Public fork branched from”; no family, authorship, ownership, or maintainer claim

## Measured budget
- cold decoded load: `3,010,884 → 3,019,980 bytes` (`+9,096`), requests `43 → 44`
- full Phase 5 cold delta from the Phase 4 baseline: `+18,686 bytes / +2 requests`
- desktop crest batch: `+1 draw`, `+36 triangles`, render median `0.00%`
- LOW_END crest batch: `+1 draw`, `+36 triangles`, render median `+1.59%`
- one scene child, one geometry, one material, six shared colors, zero textures/colliders/steady-state allocations

## Validation
- `node council/test.mjs`
- `node council/test-live.mjs`
- `node scripts/smoke.mjs` (1,278 checks)
- `python3 scripts/test_fork_lineage.py`
- `node scripts/test-fork-lineage.mjs`
- byte-stable actual 9-fork lineage-only regeneration (`82c02a6f…`)
- city-state, resident-profile, footprint, lore, public-artifact, syntax, desktop 1440x900, mobile 390x844 DPR3, KO/EN, day/night, reduced-motion, Growth Replay, WebGL nonblank, overflow, resident movement, and console checks

## Revert boundary
Remove `scripts/fork_lineage.py`, `assets/fork-lineage.js`, generated `lineage` fields, the `/*FORK_LINEAGE*/` block/card row, and dedicated tests/docs. Session footprints, repo activity windows, generated city state, residents, and every backend remain independent.

## Visual QA

Desktop 1440x900 — the small shared crest sits at the nameplate edge without hiding the repo identity or entrance.

![Desktop public fork crest](https://github.com/user-attachments/assets/0058c45e-1040-493f-aa40-dca8c0f9bd5b)

Mobile 390x844 DPR3 / LOW_END — the bilingual lineage row wraps safely and exposes the exact public source link.

![Mobile public fork lineage card](https://github.com/user-attachments/assets/9bb1bf9a-f9b9-4779-a9a0-cdbd299c29d7)
