### PR TITLE
feat: add the factual Silence Ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`scripts/fork_lineage.py` + `assets/fork-lineage.js`** | Public-only fork source sanitizer plus deterministic six-color crest projection. | Changing generated fork source truth, lineage cards, or the shared crest batch. |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
-| **`assets/world-tree/world-tree-state.js`** | Pure Phase 2 projection for Chronicle, Roots, sap-flow freshness/mode, and bounded star/repo growth. | Changing how generated city state reaches the silent World Tree. |
+| **`assets/world-tree/world-tree-state.js`** | Pure projection for Chronicle, Silence Ledger, Roots, sap-flow freshness/mode, and bounded star/repo growth. | Changing how generated city state reaches the silent World Tree. |
 | **`assets/repo-portal.js`** | Pure username/repository parser, route precedence, public projection, canonical Portal URL, and owner-town expansion link. | Changing `?repo=`, accepted GitHub inputs, public traffic truth, or target share links. |
 | **`assets/repo-route.js`** | Pure 2–3 stop route validator, current-catalog resolver, conflict policy, and canonical Repo Route URL. | Changing visitor-curated multi-repo paths or `?route=` links. |
 | **`assets/contribution-quests.js`** | Pure current-owner/catalog issue projector and bounded quest ranker. | Changing Open Source Quest validation, tier priority, or result diversity. |
@@ -91,7 +91,8 @@ social, social_custom, score, rank`, plus `lineage{source,url}` only for a prove
 Full meaning: [`docs/domain-model.md`](docs/domain-model.md).
 
 `data/city-state.json` is a deterministic projection of that public catalog. It carries `schema`,
-`version`, `era`, `season`, honest aggregate `stats`, `last_sap_flow`, and archived-only `roots`.
+`version`, `era`, `season`, the nested versioned `silence` ledger, honest aggregate `stats`,
+`last_sap_flow`, and archived-only `roots`.
 The daily workflow injects its UTC run day; local builds without that input use the newest
 reproducible public source timestamp.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [1.91.0] — 2026-08-25
+
+### 📜 Silence Ledger — factual long-idle repository records
+
+- `data/city-state.json` now carries a bounded `repolis.silence-ledger` v1 record derived only from
+  unarchived public repositories' latest push dates and the explicit UTC city reference date. It reports
+  valid/missing dates, inclusive 365/730-day quiet counts, and one deterministically tied longest record.
+- The existing silent World Tree Chronicle gains a compact KO/EN section that says “last public push” and
+  “quiet.” Archived repositories remain separate in The Roots; missing or empty inputs fail soft.
+- The ledger adds no runtime request, scene object, draw call, storage, analytics event, backend, model call,
+  dependency, or composite score. Fork and clone metrics do not enter the contract.
+
 ## [1.90.0] — 2026-08-24
 
 ### 🌳 The Silence — elder fragments, newcomer houses, and a traveler taxi

--- a/assets/world-tree/world-tree-state.js
+++ b/assets/world-tree/world-tree-state.js
@@ -15,6 +15,10 @@ export const SAP_FLOW_LIMITS = Object.freeze({
   travelSeconds: 5.6,
 });
 
+export const SILENCE_LEDGER_SCHEMA = 'repolis.silence-ledger';
+export const SILENCE_LEDGER_VERSION = 1;
+export const SILENCE_LEDGER_THRESHOLDS_DAYS = Object.freeze([365, 730]);
+
 function clamp(value, minimum = 0, maximum = 1) {
   return Math.min(maximum, Math.max(minimum, value));
 }
@@ -31,6 +35,14 @@ function finiteCount(value) {
 function boundedText(value, maximum = 180) {
   const text = String(value ?? '').replace(/\s+/g, ' ').trim();
   return text.slice(0, maximum);
+}
+
+function normalizedDate(value) {
+  const text = boundedText(value, 32);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return null;
+  const timestamp = Date.parse(`${text}T00:00:00Z`);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === text
+    ? text : null;
 }
 
 function logarithmicSignal(value, saturation) {
@@ -127,12 +139,73 @@ export function resolveSapFlowMode(sapFlow, options = {}) {
   return 'travel';
 }
 
+export function projectSilenceLedger(value) {
+  const unavailable = () => Object.freeze({
+    available: false,
+    schema: SILENCE_LEDGER_SCHEMA,
+    version: SILENCE_LEDGER_VERSION,
+    referenceDate: null,
+    thresholdsDays: SILENCE_LEDGER_THRESHOLDS_DAYS,
+    repositories: Object.freeze({ total: 0, withPushDate: 0, withoutPushDate: 0 }),
+    quiet: Object.freeze({ atLeast365Days: 0, atLeast730Days: 0, longest: null }),
+  });
+  if (value?.schema !== SILENCE_LEDGER_SCHEMA
+      || value?.version !== SILENCE_LEDGER_VERSION
+      || value?.scope !== 'unarchived_public_repositories'
+      || value?.activity_signal !== 'latest_public_push'
+      || !Array.isArray(value?.thresholds_days)
+      || value.thresholds_days.length !== SILENCE_LEDGER_THRESHOLDS_DAYS.length
+      || value.thresholds_days.some((threshold, index) => (
+        threshold !== SILENCE_LEDGER_THRESHOLDS_DAYS[index]
+      ))) {
+    return unavailable();
+  }
+
+  const referenceDate = normalizedDate(value.reference_date);
+  const total = finiteCount(value.repositories?.total);
+  const withPushDate = finiteCount(value.repositories?.with_push_date);
+  const withoutPushDate = finiteCount(value.repositories?.without_push_date);
+  const atLeast365Days = finiteCount(value.quiet?.at_least_365_days);
+  const atLeast730Days = finiteCount(value.quiet?.at_least_730_days);
+  if (!referenceDate
+      || withPushDate + withoutPushDate !== total
+      || atLeast365Days > withPushDate
+      || atLeast730Days > atLeast365Days) {
+    return unavailable();
+  }
+
+  const sourceLongest = value.quiet?.longest;
+  const longestRepo = boundedText(sourceLongest?.repo, 160);
+  const longestPush = normalizedDate(sourceLongest?.last_public_push);
+  const longestDays = Number(sourceLongest?.elapsed_days);
+  const longest = sourceLongest && longestRepo && longestPush
+      && Number.isFinite(longestDays) && longestDays >= 0
+    ? Object.freeze({
+      repo: longestRepo,
+      lastPublicPush: longestPush,
+      elapsedDays: Math.floor(longestDays),
+    })
+    : null;
+  if ((withPushDate === 0) !== (longest === null)) return unavailable();
+
+  return Object.freeze({
+    available: true,
+    schema: SILENCE_LEDGER_SCHEMA,
+    version: SILENCE_LEDGER_VERSION,
+    referenceDate,
+    thresholdsDays: SILENCE_LEDGER_THRESHOLDS_DAYS,
+    repositories: Object.freeze({ total, withPushDate, withoutPushDate }),
+    quiet: Object.freeze({ atLeast365Days, atLeast730Days, longest }),
+  });
+}
+
 export function projectWorldTreeChronicle(cityState, options = {}) {
   if (!validCityState(cityState)) {
     return Object.freeze({
       available: false,
       era: null,
       season: null,
+      silence: projectSilenceLedger(null),
       stats: null,
       lastSapFlow: resolveSapFlowFreshness(null, options.now),
       roots: Object.freeze([]),
@@ -171,6 +244,7 @@ export function projectWorldTreeChronicle(cityState, options = {}) {
         ? Math.max(0, cityState.season.inputs.recent_to_historical_ratio) : null,
       fallbackUsed: cityState.season?.fallback?.used === true,
     }),
+    silence: projectSilenceLedger(cityState.silence),
     stats: Object.freeze({
       repositories: finiteCount(cityState.stats?.repository_count),
       activeRepositories: finiteCount(cityState.stats?.active_repository_count),

--- a/data/city-state.json
+++ b/data/city-state.json
@@ -38,6 +38,31 @@
     "reason": "Recent latest-push count is 15.75x the average of the prior 6 30-day buckets.",
     "value": "spring"
   },
+  "silence": {
+    "activity_signal": "latest_public_push",
+    "quiet": {
+      "at_least_365_days": 37,
+      "at_least_730_days": 32,
+      "longest": {
+        "elapsed_days": 2995,
+        "last_public_push": "2018-06-12",
+        "repo": "jenkins-dind"
+      }
+    },
+    "reference_date": "2026-08-24",
+    "repositories": {
+      "total": 69,
+      "with_push_date": 69,
+      "without_push_date": 0
+    },
+    "schema": "repolis.silence-ledger",
+    "scope": "unarchived_public_repositories",
+    "thresholds_days": [
+      365,
+      730
+    ],
+    "version": 1
+  },
   "stats": {
     "active_repository_count": 69,
     "archived_repository_count": 0,

--- a/data/city-state.schema.json
+++ b/data/city-state.schema.json
@@ -104,6 +104,124 @@
       },
       "type": "array"
     },
+    "silence": {
+      "additionalProperties": false,
+      "properties": {
+        "activity_signal": {
+          "const": "latest_public_push",
+          "type": "string"
+        },
+        "quiet": {
+          "additionalProperties": false,
+          "properties": {
+            "at_least_365_days": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "at_least_730_days": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "longest": {
+              "additionalProperties": false,
+              "properties": {
+                "elapsed_days": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "last_public_push": {
+                  "format": "date",
+                  "type": "string"
+                },
+                "repo": {
+                  "maxLength": 160,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "repo",
+                "last_public_push",
+                "elapsed_days"
+              ],
+              "type": [
+                "object",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "at_least_365_days",
+            "at_least_730_days",
+            "longest"
+          ],
+          "type": "object"
+        },
+        "reference_date": {
+          "format": "date",
+          "type": "string"
+        },
+        "repositories": {
+          "additionalProperties": false,
+          "properties": {
+            "total": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "with_push_date": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "without_push_date": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total",
+            "with_push_date",
+            "without_push_date"
+          ],
+          "type": "object"
+        },
+        "schema": {
+          "const": "repolis.silence-ledger",
+          "type": "string"
+        },
+        "scope": {
+          "const": "unarchived_public_repositories",
+          "type": "string"
+        },
+        "thresholds_days": {
+          "const": [
+            365,
+            730
+          ],
+          "items": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "version": {
+          "const": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "schema",
+        "version",
+        "reference_date",
+        "scope",
+        "activity_signal",
+        "thresholds_days",
+        "repositories",
+        "quiet"
+      ],
+      "type": "object"
+    },
     "schema": {
       "const": "repolis.city-state",
       "type": "string"
@@ -324,6 +442,7 @@
     "version",
     "era",
     "season",
+    "silence",
     "stats",
     "last_sap_flow",
     "roots"

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -20,6 +20,7 @@ see [`AGENTS.md`](../AGENTS.md); for narrative see [`README.md`](../README.md).
 | **Elder fragment** | hand-authored `data/lore/fragments.json` | A short bilingual recollection allocated only to the oldest eligible 20% of the nine-resident active roster and delivered rarely in local life contexts. |
 | **Exploration state** | browser `localStorage` | Passport visits, district progress, daily Village Chronicle, Town Gazette baselines, constellation completion, and the Maintainers' Night Watch stamp. |
 | **Session footprint** | current-tab memory + one instanced mesh | A short local-player walking trace; never persisted, synchronized, or derived from residents/peers. |
+| **Silence Ledger** | nested `data/city-state.json` projection | A bounded dated record of long-quiet unarchived public repos, separate from archived Roots. |
 | **Scholar (NPC)** | `scholars.js` (`window.SCHOLARS`) | A named star + myth + exactly one MCP knowledge source. |
 | **Taxi** | the POLARIS scholar (`kind: taxi`) | The only all-district traveler; finds a repo, drives there, knows Shared city state, and redirects household memory to that home. |
 | **Grounding Worker** | `cloudflare-taxi/` (`repolis-taxi`) | Server brain: KB retrieval + in-persona chat. |
@@ -131,12 +132,25 @@ github-traffic-monitor (private, daily)        Repolis (public)
 - `season` compares repositories pushed in the latest 30-day window with six preceding 30-day
   buckets. Sparse histories use the recorded recent-active share fallback. The value is one of
   `spring`, `summer`, `autumn`, or `winter`, with its inputs and reason stored beside it.
+- `silence` is a nested `repolis.silence-ledger` v1 projection scoped only to unarchived public
+  repositories. It records the UTC city reference date, fixed `[365, 730]` day thresholds,
+  repositories with and without a valid latest public push date, inclusive counts at each threshold,
+  and at most one longest-quiet repository. Elapsed days compare UTC calendar dates and clamp future
+  signals to zero. Longest-quiet ties sort by elapsed days descending, then repository name
+  case-insensitively and finally exactly ascending. Invalid or missing dates count only as
+  `without_push_date`; an empty scope produces zero counts and `longest: null`.
 - `stats` contains only aggregates defensible from the current public catalog. Complete commit
   history is unavailable, so `commit_history.total` stays `null` rather than being estimated.
 - `last_sap_flow` is that explicit UTC batch day or, for local fallback builds, the latest reproducible
   source timestamp. It is never an implicit wall-clock read inside the generator.
 - `roots` contains archived public repositories only, with active years and a one-line achievement
   derived from public metadata. It is correctly empty when the catalog has no archived repos.
+
+Fork and clone values never enter the Silence Ledger and cannot affect its counts or longest record.
+The ledger is one current generated snapshot, not a commit timeline, abandonment claim, preservation
+score, or statement about copies. The pure World Tree projection accepts the nested contract without
+reading owner DOM, storage, the network, or the wall clock, so later public-town and daily-ledger work
+can reuse the same bounded shape.
 
 The owner town uses this state for a restrained static sky/fog/light palette. Other public towns use
 the neutral summer palette because no owner-specific city-state artifact is fetched for them.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -24,6 +24,11 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
 - **Newcomer and ruin visuals follow reproducible public dates.** A repository is new only while its generated
   city-reference age is under 90 days. The current snapshot has no archived repository, so warm ruin composition
   and unavailable dialogue are exercised with deterministic fixtures rather than fabricated production history.
+- **The Silence Ledger is a dated current snapshot, not a repository health judgment.** It uses only each
+  unarchived public repository's latest public push date and the generated UTC city reference date. Missing or
+  invalid push dates stay explicitly unavailable; 365- and 730-day counts include the boundary day, and only one
+  deterministically tied longest-quiet repository is retained. Archived repositories remain separate in The Roots.
+  Fork and clone counts have no bearing on quiet time, copies, recoverability, or preservation.
 - **Public repos only, by design.** Private repo names never appear. Untouched mirror forks are filtered
   out; only forks you've actually committed to are shown.
 - **Fork lineage is public origin metadata, not credit assignment.** The generated field exists only when

--- a/index.html
+++ b/index.html
@@ -1312,6 +1312,12 @@
   .worldTreeStat b { display:block; color:#3f2e1d; font:750 18px/1.1 Georgia,serif; overflow:hidden; text-overflow:ellipsis; }
   .worldTreeStat span { display:block; margin-top:4px; color:#8c714d; font-size:9px; line-height:1.25; text-transform:uppercase; }
   .worldTreeCommitNote { margin:7px 0 0; color:#968067; font-size:9.5px; line-height:1.45; }
+  .worldTreeQuiet { margin-top:18px; padding:14px 0; border-top:1px solid rgba(112,79,42,.2);
+    border-bottom:1px solid rgba(112,79,42,.2); }
+  .worldTreeQuiet h3 { margin:0; color:#3e2d1d; font:750 18px/1.15 Georgia,serif; }
+  .worldTreeQuietBasis { margin:4px 0 0; color:#90795e; font-size:10px; line-height:1.45; }
+  .worldTreeQuietSummary { margin:10px 0 0; color:#59432d; font:650 12px/1.55 Georgia,serif; }
+  .worldTreeQuietLongest { margin:5px 0 0; color:#80694f; font-size:10.5px; line-height:1.5; overflow-wrap:anywhere; }
   .worldTreeRootsHead { display:flex; align-items:end; justify-content:space-between; gap:12px; margin-top:21px; }
   .worldTreeRootsHead h3 { margin:0; color:#3e2d1d; font:750 20px/1.15 Georgia,serif; }
   .worldTreeRootsHead p { margin:3px 0 0; color:#90795e; font-size:10.5px; line-height:1.45; }
@@ -1444,9 +1450,15 @@
         </dl>
         <div id="worldTreeStats" class="worldTreeStats" role="list" data-i18n-aria="worldTreeStatsAria" aria-label="도시 공개 집계"></div>
         <p id="worldTreeCommitNote" class="worldTreeCommitNote"></p>
+        <section class="worldTreeQuiet" aria-labelledby="worldTreeQuietTitle">
+          <h3 id="worldTreeQuietTitle" data-i18n="worldTreeQuietTitle">고요 장부</h3>
+          <p id="worldTreeQuietBasis" class="worldTreeQuietBasis"></p>
+          <p id="worldTreeQuietSummary" class="worldTreeQuietSummary"></p>
+          <p id="worldTreeQuietLongest" class="worldTreeQuietLongest"></p>
+        </section>
         <section aria-labelledby="worldTreeRootsTitle">
           <div class="worldTreeRootsHead">
-            <div><h3 id="worldTreeRootsTitle" data-i18n="worldTreeRootsTitle">The Roots</h3><p data-i18n="worldTreeRootsSub">이름 · 활동한 해 · 남은 한 줄</p></div>
+            <div><h3 id="worldTreeRootsTitle" data-i18n="worldTreeRootsTitle">The Roots</h3><p data-i18n="worldTreeRootsSub">이름 · 활동한 해 · 공개 설명</p></div>
             <label id="worldTreeRootSearchWrap" hidden><span class="srOnly" data-i18n="worldTreeRootSearch">뿌리 기록 찾기</span>
               <input id="worldTreeRootSearch" type="search" autocomplete="off" data-i18n-ph="worldTreeRootSearch" data-i18n-aria="worldTreeRootSearch" aria-label="뿌리 기록 찾기" />
             </label>
@@ -1899,7 +1911,7 @@ import { CAMERA_OBSTRUCTION_DEFAULTS, CAMERA_ARRIVAL_OFFSETS, resolveCameraObstr
 import { CANAL_FERRY_DEFAULTS, sampleCanalFerryRoute } from './assets/canal-ferry.js?v=petite-venise-ferry-v1';
 import { RAIN_GARDEN_DEFAULTS, sampleRainGarden, seedRainDrop, wrapRainDropY } from './assets/rain-garden.js?v=weather-bell-v1';
 import { CITY_STATE_SCHEMA, CITY_STATE_VERSION, REPO_NEWCOMER_DAYS, cityReferenceTimestamp, constructionScaffoldPlan, projectCityTime, resolveCitySeason, seasonPalette } from './assets/city-time.js?v=world-tree-phase4-v1';
-import { SAP_FLOW_LIMITS, projectWorldTreeChronicle, projectWorldTreeGrowth, resolveSapFlowMode } from './assets/world-tree/world-tree-state.js?v=world-tree-phase2-v1';
+import { SAP_FLOW_LIMITS, projectWorldTreeChronicle, projectWorldTreeGrowth, resolveSapFlowMode } from './assets/world-tree/world-tree-state.js?v=world-tree-phase2-v2';
 import { analyzeTownFrame, composeTownPostcard, createTownPostcardIdentity, createTownReadmePortal, flipPixelRows, postcardCanvasToBlob, postcardCaptureSize, postcardFormatForViewport, summarizeTownRepos } from './assets/town-postcard.js?v=town-postcard-v2';
 import { summarizePublicTown } from './assets/public-town-proof.js?v=personal-ready-v1';
 import { createTwinTownLink, createTwinTownMatch } from './assets/twin-towns.js?v=twin-towns-v1';
@@ -2241,9 +2253,13 @@ const I18N = {
     worldTreeOpen:'세계수 연대기 열기', worldTreeClose:'세계수 연대기 닫기', worldTreeKicker:'CITY CHRONICLE',
     worldTreeTitle:'세계수 연대기', worldTreeSilence:'말은 없다. 날짜가 붙은 기록 하나.', worldTreeUnavailable:'이 마을에는 생성된 도시 기록이 없습니다.',
     worldTreeEraLabel:'도시력', worldTreeSeasonLabel:'계절', worldTreeSapLabel:'마지막 수액', worldTreeRootsTitle:'The Roots',
-    worldTreeRootsSub:'이름 · 활동한 해 · 남은 한 줄', worldTreeRootSearch:'뿌리 기록 찾기', worldTreeRootsEmpty:'이 기록에는 아카이브된 공개 레포가 없습니다.',
+    worldTreeRootsSub:'이름 · 활동한 해 · 공개 설명', worldTreeRootSearch:'뿌리 기록 찾기', worldTreeRootsEmpty:'이 기록에는 아카이브된 공개 레포가 없습니다.',
     worldTreeRootsNoMatch:'일치하는 뿌리 기록이 없습니다.', worldTreeRootsCount:'기록 {shown}/{total}', worldTreeStatsAria:'도시 공개 집계',
     worldTreeStatRepos:'공개 레포', worldTreeStatStars:'스타', worldTreeStatForks:'포크', worldTreeStatArchived:'아카이브', worldTreeStatLanguages:'언어',
+    worldTreeQuietTitle:'고요 장부', worldTreeQuietBasis:'아카이브되지 않은 공개 레포 집 · 마지막 공개 push · UTC 기준일 {date} · 365/730일 경계 포함',
+    worldTreeQuietSummary:'유효 push 날짜가 있는 레포 {withDate}/{total} · 없는 레포 {withoutDate} · 365일 이상 고요 {quiet365} · 730일 이상 고요 {quiet730}',
+    worldTreeQuietLongest:'가장 오래 고요한 레포 · {repo} · 마지막 공개 push {date} · {days}일', worldTreeQuietNoPush:'사용 가능한 마지막 공개 push 날짜가 없습니다.',
+    worldTreeQuietEmpty:'아카이브되지 않은 공개 레포 집이 없습니다.', worldTreeQuietUnavailable:'고요 장부 기록을 사용할 수 없습니다.',
     worldTreeCityYear:'도시력 {year}년', worldTreeFounded:'{date} 시작 · 첫 기록 {repo}',
     worldTreeSeasonRatio:'최근 30일 latest-push {recent}개 · 앞선 6개 구간 평균의 {ratio}배',
     worldTreeSeasonFallback:'최근 30일 latest-push {recent}/{total}개 · 기록 부족 규칙',
@@ -2562,9 +2578,13 @@ const I18N = {
     worldTreeOpen:'Open the World Tree Chronicle', worldTreeClose:'Close the World Tree Chronicle', worldTreeKicker:'CITY CHRONICLE',
     worldTreeTitle:'World Tree Chronicle', worldTreeSilence:'No voice. One dated record.', worldTreeUnavailable:'No generated city record is available for this town.',
     worldTreeEraLabel:'City era', worldTreeSeasonLabel:'Season', worldTreeSapLabel:'Last sap flow', worldTreeRootsTitle:'The Roots',
-    worldTreeRootsSub:'Name · active years · one surviving line', worldTreeRootSearch:'Search root records', worldTreeRootsEmpty:'No archived public repository appears in this record.',
+    worldTreeRootsSub:'Name · active years · public description', worldTreeRootSearch:'Search root records', worldTreeRootsEmpty:'No archived public repository appears in this record.',
     worldTreeRootsNoMatch:'No root record matches.', worldTreeRootsCount:'Records {shown}/{total}', worldTreeStatsAria:'Public city aggregates',
     worldTreeStatRepos:'Public repos', worldTreeStatStars:'Stars', worldTreeStatForks:'Forks', worldTreeStatArchived:'Archived', worldTreeStatLanguages:'Languages',
+    worldTreeQuietTitle:'Silence Ledger', worldTreeQuietBasis:'Unarchived public repo homes · last public push · UTC reference {date} · 365/730-day thresholds inclusive',
+    worldTreeQuietSummary:'Repositories with a valid push date {withDate}/{total} · without one {withoutDate} · quiet ≥365 days {quiet365} · quiet ≥730 days {quiet730}',
+    worldTreeQuietLongest:'Longest quiet repository · {repo} · last public push {date} · quiet {days} days', worldTreeQuietNoPush:'No usable last public push date is available.',
+    worldTreeQuietEmpty:'No unarchived public repo home appears in this record.', worldTreeQuietUnavailable:'The Silence Ledger record is unavailable.',
     worldTreeCityYear:'City year {year}', worldTreeFounded:'Founded {date} · first record {repo}',
     worldTreeSeasonRatio:'{recent} latest-push signals in 30 days · {ratio}× the prior six-bucket average',
     worldTreeSeasonFallback:'{recent}/{total} latest-push signals in 30 days · limited-history rule',
@@ -9315,6 +9335,20 @@ function renderWorldTreeChronicle(){
   const statsEl=document.getElementById('worldTreeStats'); statsEl.replaceChildren(...rows.map(([value,key])=>{ const item=document.createElement('div'); item.className='worldTreeStat'; item.setAttribute('role','listitem');
     const number=document.createElement('b'),label=document.createElement('span'); number.textContent=_worldTreeNumber(value); label.textContent=t(key); item.append(number,label); return item; }));
   document.getElementById('worldTreeCommitNote').textContent=stats.commitTotal===null?t('worldTreeCommitUnavailable'):'';
+  const silence=record.silence,quietBasis=document.getElementById('worldTreeQuietBasis'),
+    quietSummary=document.getElementById('worldTreeQuietSummary'),quietLongest=document.getElementById('worldTreeQuietLongest');
+  if(!silence.available){ quietBasis.textContent=''; quietSummary.textContent=t('worldTreeQuietUnavailable'); quietLongest.textContent=''; }
+  else {
+    const repositories=silence.repositories,quiet=silence.quiet;
+    quietBasis.textContent=tf('worldTreeQuietBasis',{date:_worldTreeDate(silence.referenceDate)});
+    quietSummary.textContent=repositories.total
+      ?tf('worldTreeQuietSummary',{withDate:_worldTreeNumber(repositories.withPushDate),total:_worldTreeNumber(repositories.total),
+        withoutDate:_worldTreeNumber(repositories.withoutPushDate),quiet365:_worldTreeNumber(quiet.atLeast365Days),quiet730:_worldTreeNumber(quiet.atLeast730Days)})
+      :t('worldTreeQuietEmpty');
+    quietLongest.textContent=quiet.longest
+      ?tf('worldTreeQuietLongest',{repo:quiet.longest.repo,date:_worldTreeDate(quiet.longest.lastPublicPush),days:_worldTreeNumber(quiet.longest.elapsedDays)})
+      :(repositories.total?t('worldTreeQuietNoPush'):'');
+  }
   renderWorldTreeRoots(worldTreeRootSearch.value);
 }
 function _worldTreeFocusables(){ return [...worldTreePanel.querySelectorAll('button:not([disabled]),input:not([disabled])')]
@@ -13123,6 +13157,8 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     frameAllocations:RENDER_METRICS.frameAllocations,passTokenAllocations:RENDER_METRICS.passTokenAllocations,historyWrites:RENDER_METRICS.historyWrites,history:RENDER_METRICS.history.length,gpuSupported:GPU_TIMER.supported});
   window.__worldTreeChronicle=()=>{ const flow=MEMORIAL_TREE&&MEMORIAL_TREE.sapFlow; return {
     open:WORLD_TREE_UI.open,available:WORLD_TREE_RECORD.available,roots:WORLD_TREE_RECORD.roots.length,rootSearch:!worldTreeRootSearchWrap.hidden,
+    silence:{available:WORLD_TREE_RECORD.silence.available,referenceDate:WORLD_TREE_RECORD.silence.referenceDate,
+      repositories:{...WORLD_TREE_RECORD.silence.repositories},quiet:{...WORLD_TREE_RECORD.silence.quiet}},
     modal:{role:worldTreeModal.getAttribute('role'),hidden:worldTreeModal.getAttribute('aria-hidden'),active:document.activeElement&&document.activeElement.id},
     trigger:{hidden:worldTreeTrigger.hidden,label:worldTreeTrigger.getAttribute('aria-label')},growth:{...WORLD_TREE_GROWTH},
     sap:{available:WORLD_TREE_RECORD.lastSapFlow.available,freshness:WORLD_TREE_RECORD.lastSapFlow.freshness,mode:WORLD_TREE_SAP_MODE,

--- a/scripts/city_state.py
+++ b/scripts/city_state.py
@@ -16,6 +16,9 @@ SCHEMA_VERSION = 1
 SEASONS = ("spring", "summer", "autumn", "winter")
 RECENT_WINDOW_DAYS = 30
 HISTORICAL_BUCKETS = 6
+SILENCE_SCHEMA_NAME = "repolis.silence-ledger"
+SILENCE_SCHEMA_VERSION = 1
+SILENCE_THRESHOLDS_DAYS = (365, 730)
 
 
 def _parse_datetime(value):
@@ -151,6 +154,43 @@ def _season(repositories, reference_day):
     }
 
 
+def _silence(repositories, reference_day):
+    unarchived = [repo for repo in repositories if not bool(repo.get("archived"))]
+    dated = []
+    for repo in unarchived:
+        pushed = _parse_datetime(repo.get("pushed") or repo.get("pushed_at"))
+        if not pushed:
+            continue
+        elapsed_days = max(0, (reference_day - pushed.date()).days)
+        dated.append({
+            "repo": _repo_name(repo),
+            "last_public_push": pushed.date().isoformat(),
+            "elapsed_days": elapsed_days,
+        })
+
+    dated.sort(key=lambda item: (-item["elapsed_days"], item["repo"].casefold(), item["repo"]))
+    quiet_365 = sum(item["elapsed_days"] >= SILENCE_THRESHOLDS_DAYS[0] for item in dated)
+    quiet_730 = sum(item["elapsed_days"] >= SILENCE_THRESHOLDS_DAYS[1] for item in dated)
+    return {
+        "schema": SILENCE_SCHEMA_NAME,
+        "version": SILENCE_SCHEMA_VERSION,
+        "reference_date": reference_day.isoformat(),
+        "scope": "unarchived_public_repositories",
+        "activity_signal": "latest_public_push",
+        "thresholds_days": list(SILENCE_THRESHOLDS_DAYS),
+        "repositories": {
+            "total": len(unarchived),
+            "with_push_date": len(dated),
+            "without_push_date": len(unarchived) - len(dated),
+        },
+        "quiet": {
+            "at_least_365_days": quiet_365,
+            "at_least_730_days": quiet_730,
+            "longest": dated[0] if dated else None,
+        },
+    }
+
+
 def _achievement(repo):
     text = re.sub(r"\s+", " ", str(repo.get("desc") or repo.get("description") or "")).strip()
     if not text:
@@ -209,6 +249,7 @@ def build_city_state(repositories, source_timestamps=None, *, as_of=None):
             "basis": "Oldest creation date among the public repositories included in repos.json.",
         },
         "season": _season(public, reference_day),
+        "silence": _silence(public, reference_day),
         "stats": {
             "repository_count": len(public),
             "active_repository_count": len(public) - len(archived),

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -78,7 +78,10 @@ import {
 } from '../assets/city-time.js';
 import {
   SAP_FLOW_LIMITS,
+  SILENCE_LEDGER_SCHEMA,
+  SILENCE_LEDGER_VERSION,
   WORLD_TREE_GROWTH_LIMITS,
+  projectSilenceLedger,
   projectWorldTreeChronicle,
   projectWorldTreeGrowth,
   resolveSapFlowFreshness,
@@ -287,7 +290,7 @@ ok(/Path\("data"\) \/ "towns" \/ OWNER/.test(REPO_BUILDER), 'manual non-upstream
 
 group('deterministic city state — generated time, wear, ruins, and season');
 ok(CITY_STATE.schema==='repolis.city-state' && CITY_STATE.version===1
-  &&['era','season','stats','last_sap_flow','roots'].every(key=>key in CITY_STATE),
+  &&['era','season','silence','stats','last_sap_flow','roots'].every(key=>key in CITY_STATE),
   'generated city state exposes the versioned minimum contract');
 ok(CITY_STATE_SCHEMA.$id==='https://hyeonsangjeon.github.io/Repolis/data/city-state.schema.json'
   &&CITY_STATE_SCHEMA.additionalProperties===false
@@ -308,6 +311,34 @@ ok(CITY_STATE.stats.commit_history.available===false
 ok(CITY_STATE.roots.length===archivedCityRepos.length
   &&CITY_STATE.roots.every(root=>archivedCityRepos.some(repo=>repo.repo===root.repo)),
   'roots contain every and only archived public repository');
+const silenceCityRepos=CITY_REPOS.filter(repo=>!repo.archived);
+const silenceReference=Date.parse(`${CITY_STATE.silence.reference_date}T00:00:00Z`);
+const silenceCityRows=silenceCityRepos.map(repo=>{
+  const day=String(repo.pushed||'').slice(0,10),pushed=Date.parse(`${day}T00:00:00Z`);
+  return {repo:repo.repo,lastPublicPush:day,elapsedDays:Number.isFinite(pushed)?Math.max(0,Math.floor((silenceReference-pushed)/86400000)):null};
+});
+const silenceDated=silenceCityRows.filter(row=>row.elapsedDays!==null)
+  .sort((left,right)=>right.elapsedDays-left.elapsedDays
+    ||left.repo.toLocaleLowerCase('en-US').localeCompare(right.repo.toLocaleLowerCase('en-US'),'en-US')
+    ||left.repo.localeCompare(right.repo,'en-US'));
+ok(CITY_STATE.silence.schema===SILENCE_LEDGER_SCHEMA&&CITY_STATE.silence.version===SILENCE_LEDGER_VERSION
+  &&CITY_STATE.silence.scope==='unarchived_public_repositories'
+  &&CITY_STATE.silence.activity_signal==='latest_public_push'
+  &&JSON.stringify(CITY_STATE.silence.thresholds_days)==='[365,730]',
+  'Silence Ledger is a nested versioned latest-public-push contract with fixed inclusive thresholds');
+ok(CITY_STATE.silence.repositories.total===silenceCityRepos.length
+  &&CITY_STATE.silence.repositories.with_push_date===silenceDated.length
+  &&CITY_STATE.silence.repositories.without_push_date===silenceCityRepos.length-silenceDated.length
+  &&CITY_STATE.silence.quiet.at_least_365_days===silenceDated.filter(row=>row.elapsedDays>=365).length
+  &&CITY_STATE.silence.quiet.at_least_730_days===silenceDated.filter(row=>row.elapsedDays>=730).length,
+  'Silence Ledger reconciles only unarchived public repositories and includes the 365/730-day boundaries');
+ok(!silenceDated.length||(
+  CITY_STATE.silence.quiet.longest.repo===silenceDated[0].repo
+  &&CITY_STATE.silence.quiet.longest.last_public_push===silenceDated[0].lastPublicPush
+  &&CITY_STATE.silence.quiet.longest.elapsed_days===silenceDated[0].elapsedDays
+), 'Silence Ledger keeps one deterministic longest-quiet repository with stable name tie-breaking');
+ok(!/\b(?:fork|clone)/i.test(JSON.stringify(CITY_STATE.silence)),
+  'fork and clone metrics cannot enter or influence the Silence Ledger contract');
 ok(/sort_keys=True/.test(CITY_STATE_BUILDER)
   &&/schema_path/.test(CITY_STATE_VALIDATOR)
   &&/CITY_STATE_AS_OF=\$\(date -u \+%FT00:00:00Z\)/.test(REFRESH_WORKFLOW)
@@ -360,15 +391,22 @@ ok(/citySeason/.test(HTML)&&/cityTimeFixtures/.test(HTML)&&/prefers-reduced-moti
   'debug fixtures and the existing reduced-motion contract cover static time treatments');
 
 group('World Tree Phase 2 — city-state projection, roots, growth, and sap freshness');
-const worldTreeFixture=(stars,repositories,roots=[],lastSapFlow='2026-08-23T00:00:00Z')=>({
+const worldTreeFixture=(stars,repositories,roots=[],lastSapFlow='2026-08-23T00:00:00Z')=>{
+  const unarchived=Math.max(0,repositories-roots.length);
+  return {
   schema:'repolis.city-state',version:1,last_sap_flow:lastSapFlow,
   era:{as_of:'2026-08-23',founded_on:'2017-01-23',oldest_repository:'first-repo',city_age_years:9.58,city_year:10,basis:'fixture'},
   season:{value:'spring',fallback:{used:false},inputs:{recent_active_repositories:4,repositories_with_push_date:repositories,recent_to_historical_ratio:1.5}},
+  silence:{schema:'repolis.silence-ledger',version:1,reference_date:'2026-08-23',scope:'unarchived_public_repositories',
+    activity_signal:'latest_public_push',thresholds_days:[365,730],
+    repositories:{total:unarchived,with_push_date:unarchived,without_push_date:0},
+    quiet:{at_least_365_days:0,at_least_730_days:0,longest:unarchived
+      ?{repo:'quiet-fixture',last_public_push:'2026-01-01',elapsed_days:234}:null}},
   stats:{repository_count:repositories,active_repository_count:Math.max(0,repositories-roots.length),archived_repository_count:roots.length,
     total_stars:stars,total_forks:7,language_distribution:[{language:'JavaScript',repositories:Math.max(1,repositories)}],
     commit_history:{available:false,total:null,limitation:'Complete commit history is unavailable.'}},
   roots
-});
+};};
 const growthMinimum=projectWorldTreeGrowth(worldTreeFixture(0,0));
 const growthMiddle=projectWorldTreeGrowth(worldTreeFixture(420,54));
 const growthMaximum=projectWorldTreeGrowth(worldTreeFixture(
@@ -395,6 +433,16 @@ ok(emptyChronicle.roots.length===0
   &&manyChronicle.roots[0].repo==='archived-01'
   &&manyChronicle.roots.at(-1).activeYears.count===3,
   'Chronicle keeps an honest empty Roots state and preserves every bounded root in a many-roots fixture');
+const generatedSilence=projectSilenceLedger(CITY_STATE.silence);
+ok(emptyChronicle.silence.available&&emptyChronicle.silence.repositories.total===0
+  &&manyChronicle.silence.repositories.total===6
+  &&generatedSilence.available
+  &&generatedSilence.quiet.atLeast365Days===CITY_STATE.silence.quiet.at_least_365_days
+  &&generatedSilence.quiet.longest.repo===CITY_STATE.silence.quiet.longest.repo,
+  'pure Chronicle projection exposes the bounded versioned Silence Ledger without owner-DOM coupling');
+ok(!projectSilenceLedger(null).available
+  &&!projectSilenceLedger({...CITY_STATE.silence,repositories:{total:1,with_push_date:1,without_push_date:1}}).available,
+  'missing or inconsistent Silence Ledger data fails soft to an unavailable projection');
 const recentSap=resolveSapFlowFreshness('2026-08-23T00:00:00Z',Date.parse('2026-08-23T12:00:00Z'));
 const staleSap=resolveSapFlowFreshness('2026-07-20T00:00:00Z',Date.parse('2026-08-23T12:00:00Z'));
 ok(recentSap.animate&&recentSap.freshness==='recent'
@@ -404,8 +452,9 @@ ok(recentSap.animate&&recentSap.freshness==='recent'
   &&resolveSapFlowMode(recentSap,{lowEnd:true})==='static'
   &&resolveSapFlowMode(staleSap)==='static',
   'sap travel is short-lived only for a recent record; stale, reduced-motion, and LOW_END fixtures stay static');
-ok(SAP_FLOW_LIMITS.travelSeconds<7&&!/\bfetch\s*\(|api\.github|workers\.dev|\/taxi\b/i.test(WORLD_TREE_STATE_SRC),
-  'World Tree projection is bounded, local-only, and adds no runtime GitHub, LLM, or service request');
+ok(SAP_FLOW_LIMITS.travelSeconds<7
+  &&!/\bfetch\s*\(|api\.github|workers\.dev|\/taxi\b|localStorage|sessionStorage|document\./i.test(WORLD_TREE_STATE_SRC),
+  'World Tree projections are bounded, DOM-free, local-only, and add no request or persistence');
 
 group('Repo Portal — one repository becomes the first shareable destination');
 const portalUser=parseRepoPortalInput('@Octo-Cat');
@@ -3149,7 +3198,7 @@ ok(/makePark\(MEMORIAL_TREE_POS\.x,MEMORIAL_TREE_POS\.z,true\)/.test(HTML)
   && (HTML.match(/if\(memorial\) makeMemorialTree\(cx,cz\)/g) || []).length === 1, 'exactly one memorial tree is requested, at the north rest park centre');
 ok(/const stage='full'/.test(memorialTreeBlock)
   && /createRepolisHero\(\{seed:MEMORIAL_TREE_SEED,variant:MEM_TREE_HERO_VARIANT,stage\}\)/.test(memorialTreeBlock), 'desktop and touch tiers both use the exact full Solar Archive hero');
-ok(/world-tree-state\.js\?v=world-tree-phase2-v1/.test(HTML)
+ok(/world-tree-state\.js\?v=world-tree-phase2-v2/.test(HTML)
   &&/hero\.runtime\.nodes\['living-system'\]\.scale\.setScalar\(WORLD_TREE_GROWTH\.scale\)/.test(memorialTreeBlock)
   &&/const collider=\{x,z,r:11\.6,_memorialTree:true\}/.test(memorialTreeBlock)
   &&/growthScale:WORLD_TREE_GROWTH\.scale/.test(memorialTreeBlock),
@@ -3180,6 +3229,22 @@ ok(/worldTreeRootSearchWrap\.hidden=total<10/.test(worldTreeChronicleBlock)
   &&(worldTreeChronicleBlock.match(/empty\.setAttribute\('role','listitem'\)/g)||[]).length===2
   &&/role="status" aria-live="polite"/.test(HTML),
   'Roots stays quiet when empty and only exposes an accessible search when the generated list is large');
+const silenceLedgerCopy=[...HTML.matchAll(/worldTreeQuiet(?:Title|Basis|Summary|Longest|NoPush|Empty|Unavailable):'([^']*)'/g)]
+  .map(match=>match[1]).join(' ');
+ok(/class="worldTreeQuiet" aria-labelledby="worldTreeQuietTitle"/.test(HTML)
+  &&/id="worldTreeQuietBasis"/.test(HTML)&&/id="worldTreeQuietSummary"/.test(HTML)&&/id="worldTreeQuietLongest"/.test(HTML)
+  &&/const silence=record\.silence/.test(worldTreeChronicleBlock)
+  &&/repositories\.total\?/.test(worldTreeChronicleBlock)
+  &&/quiet\.longest/.test(worldTreeChronicleBlock),
+  'Silence Ledger stays a compact fail-soft section inside the existing World Tree Chronicle');
+ok((HTML.match(/worldTreeQuietTitle:/g)||[]).length===2
+  &&(HTML.match(/worldTreeQuietBasis:/g)||[]).length===2
+  &&(HTML.match(/worldTreeQuietSummary:/g)||[]).length===2
+  &&(HTML.match(/worldTreeQuietLongest:/g)||[]).length===2,
+  'Silence Ledger scope, counts, and longest-quiet wording have Korean and English parity');
+ok(/\blast public push\b/i.test(silenceLedgerCopy)&&/\bquiet\b/i.test(silenceLedgerCopy)
+  &&!/\b(?:dead|lost|asleep|irrecoverable)\b|unique copy|\bfork\b|\bclone\b/i.test(silenceLedgerCopy),
+  'Silence Ledger copy stays factual and never infers death, loss, copies, forks, or clones');
 ok((HTML.match(/worldTreeTitle:/g)||[]).length===2
   &&(HTML.match(/worldTreeRootsEmpty:/g)||[]).length===2
   &&(HTML.match(/worldTreeSapStale:/g)||[]).length===2,

--- a/scripts/test_city_state.py
+++ b/scripts/test_city_state.py
@@ -52,6 +52,9 @@ class CityStateTests(unittest.TestCase):
         self.assertFalse(state["stats"]["commit_history"]["available"])
         self.assertEqual([root["repo"] for root in state["roots"]], ["memory"])
         self.assertEqual(state["roots"][0]["active_years"], {"from": 2018, "to": 2022, "count": 5})
+        self.assertEqual(state["silence"]["repositories"]["total"], 1)
+        self.assertEqual(state["silence"]["repositories"]["with_push_date"], 1)
+        self.assertEqual(state["silence"]["quiet"]["at_least_365_days"], 0)
         self.assertNotIn("secret", serialize_city_state(state))
 
     def test_identical_inputs_are_byte_stable_and_order_independent(self):
@@ -68,6 +71,72 @@ class CityStateTests(unittest.TestCase):
         ))
         self.assertEqual(first, second)
         self.assertEqual(first, serialize_city_state(json.loads(first)))
+
+    def test_silence_ledger_is_unarchived_inclusive_and_stably_tied(self):
+        repos = [
+            repo("beta-earliest", "2019-01-01", "2020-01-01", stars=40),
+            repo("alpha-earliest", "2019-01-01", "2020-01-01", stars=1),
+            repo("threshold-730", "2020-01-01", "2024-06-30"),
+            repo("threshold-365", "2020-01-01", "2025-06-30"),
+            repo("recent", "2020-01-01", "2026-06-29"),
+            repo("missing", "2020-01-01", ""),
+            repo("invalid", "2020-01-01", "not-a-date"),
+            repo("archived-older", "2010-01-01", "2010-01-01", archived=True),
+            repo("private-older", "2000-01-01", "2000-01-01", private=True),
+        ]
+        for index, item in enumerate(repos):
+            item["forks"] = 1000 - index
+            item["clones"] = 5000 + index
+
+        state = build_city_state(repos, as_of="2026-06-30T00:00:00Z")
+        ledger = state["silence"]
+        self.validate_state(state)
+        self.assertEqual(ledger["schema"], "repolis.silence-ledger")
+        self.assertEqual(ledger["version"], 1)
+        self.assertEqual(ledger["reference_date"], "2026-06-30")
+        self.assertEqual(ledger["scope"], "unarchived_public_repositories")
+        self.assertEqual(ledger["activity_signal"], "latest_public_push")
+        self.assertEqual(ledger["thresholds_days"], [365, 730])
+        self.assertEqual(
+            ledger["repositories"],
+            {"total": 7, "with_push_date": 5, "without_push_date": 2},
+        )
+        self.assertEqual(ledger["quiet"]["at_least_365_days"], 4)
+        self.assertEqual(ledger["quiet"]["at_least_730_days"], 3)
+        self.assertEqual([root["repo"] for root in state["roots"]], ["archived-older"])
+        self.assertEqual(
+            ledger["quiet"]["longest"],
+            {
+                "repo": "alpha-earliest",
+                "last_public_push": "2020-01-01",
+                "elapsed_days": 2372,
+            },
+        )
+
+        changed_metrics = [dict(item, forks=0, clones=0) for item in reversed(repos)]
+        changed = build_city_state(changed_metrics, as_of="2026-06-30T00:00:00Z")
+        self.assertEqual(ledger, changed["silence"])
+
+    def test_silence_ledger_fails_soft_for_empty_and_missing_push_dates(self):
+        empty = build_city_state([], as_of="2026-06-30T00:00:00Z")
+        missing = build_city_state(
+            [repo("missing", "2020-01-01", ""), repo("invalid", "2020-01-01", "invalid")],
+            as_of="2026-06-30T00:00:00Z",
+        )
+        self.validate_state(empty)
+        self.validate_state(missing)
+        self.assertEqual(
+            empty["silence"]["repositories"],
+            {"total": 0, "with_push_date": 0, "without_push_date": 0},
+        )
+        self.assertIsNone(empty["silence"]["quiet"]["longest"])
+        self.assertEqual(
+            missing["silence"]["repositories"],
+            {"total": 2, "with_push_date": 0, "without_push_date": 2},
+        )
+        self.assertEqual(missing["silence"]["quiet"]["at_least_365_days"], 0)
+        self.assertEqual(missing["silence"]["quiet"]["at_least_730_days"], 0)
+        self.assertIsNone(missing["silence"]["quiet"]["longest"])
 
     def test_explicit_as_of_advances_a_quiet_city(self):
         state = build_city_state(


### PR DESCRIPTION
## Summary
- add a nested, bounded `repolis.silence-ledger` v1 projection to generated city state
- derive unarchived quiet-home facts only from latest public push dates and the explicit UTC reference date
- present compact factual KO/EN copy inside the existing silent World Tree Chronicle, separate from archived Roots
- fail soft for missing/empty dates and keep fork/clone metrics outside the contract

## Contract
- scope: unarchived public repositories
- signal: latest public push
- thresholds: inclusive 365 and 730 UTC calendar days
- longest tie-break: elapsed days descending, then repository name case-insensitively and exactly ascending
- bounded output: counts plus at most one longest-quiet repository

## Verification
- complete `AGENTS.md` release block passed
- 1,304 smoke checks, 130 Council checks, 56 live Council crosschecks, 11 city-state tests, schema validation, fork-lineage/time/footprint/lore checks
- desktop and 390×844 DPR3 mobile: KO/EN, day/night, reduced motion, LOW_END, WebGL, console, overflow, focus/close target, and modal bounds
- decoded boot assets: 1,293,278 → 1,300,643 bytes (+7,365 bytes)
- same-origin boot resources: 30 → 30; feature-owned WebGL draws: +0

## Privacy and cost
No runtime GitHub/Worker/API request, analytics event, storage, persistence, backend, model call, dependency, build step, or visual asset was added.

Closes #93

## Visual evidence

**Desktop · EN · day**

![Silence Ledger desktop English day](https://github.com/user-attachments/assets/f331cc2c-344c-40b6-a370-39be1ea07bf9)

**390×844 DPR3 mobile · KO · night · LOW_END**

![Silence Ledger mobile Korean night](https://github.com/user-attachments/assets/4872f2f1-0ebf-4ad6-afb6-4b5e233ae0e0)
