### PR TITLE
feat: add Adaptive Visual Governor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`scripts/build_repos.py`** | Rebuilds `repos.json` and `data/city-state.json` from `data/logs/*` traffic + `gh api`. | Refreshing the city data locally. |
 | **`scripts/resident_profiles.py` + `data/residents/`** | Generates sanitized public resident profiles, the boot manifest, and the Worker authority registry. Profile JSON is generated — do not hand-edit. | Changing repository-bound resident identity or Shared/Bound inputs. |
 | **`scripts/smoke.mjs`** | Hermetic static and behavioral regression guards for the city runtime. | Any client feature, navigation, or generated-module integration change. |
+| **`scripts/test-visual-governor.mjs`** | Extracts and deterministically replays the inline adaptive visual-governor core. | Changing warm-up, thresholds, hysteresis, dwell, LOW_END/reduced-motion bounds, or recovery. |
 | **`scripts/test-portable-town.mjs`** | Deterministic fixtures for canonical, foreign, empty/archive-only, partial, missing-date, leakage, resident-cap, and zero-request portable towns. | Changing public-town projection or local resident derivation. |
 | **`.github/workflows/refresh.yml`** | "Refresh Repolis data" — daily Action that regenerates `repos.json` and pushes `chore: refresh`. | CI / data-refresh changes. |
 | **`scripts/build-contribution-library.mjs` + `assets/contribution-library.json`** | Generates the in-app **Contribution Library** JSON from the sibling `Hyeonsang-AI-Contributions` README (KO/EN); `index.html` fetches it at runtime. JSON is **generated — do not hand-edit.** Daily via `.github/workflows/update-contribution-library.yml`. | Changing the library landmark's data/source. |
@@ -127,6 +128,7 @@ zero LLM, zero cost — so run them freely:
 node council/test.mjs        # deterministic Council crosscheck
 node council/test-live.mjs   # live guards + state machine
 node scripts/smoke.mjs       # city/runtime static + behavioral regression guards
+node scripts/test-visual-governor.mjs
 node scripts/test-portable-town.mjs
 python3 scripts/test_city_state.py
 python3 scripts/validate_city_state.py
@@ -181,6 +183,7 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 | Change Creator Hall profile facts, caching, or upstream Star handoff | `assets/town-creator.js` + the Creator Hall landmark/panel blocks in `index.html` + `scripts/smoke.mjs`; keep profile loading explicit-read and allowlisted. |
 | Change Town Growth Replay years, camera, reveal, share links, or era postcards | `assets/town-growth.js` + `/*TOWN_GROWTH_REPLAY*/` in `index.html` + the Growth Replay group in `scripts/smoke.mjs`; creation dates are historical, building metrics are current, and replay must restore camera/fog/sky/LOD exactly. |
 | Change Repository Atelier room, avatar, data walls, or action terminals | `/*REPOSITORY_ATELIER*/` in `index.html` + the Atelier group in `scripts/smoke.mjs`; preserve one lazy reusable room, three bounded canvas atlases, exact exterior restore, zero exterior renders inside, in-room Ask/Why ownership, and explicit-only exit/GitHub navigation. |
+| Change adaptive frame thresholds or visual tiers | `/*VISUAL_GOVERNOR_CORE*/` + `/*VISUAL_GOVERNOR_RUNTIME*/` in `index.html`, `scripts/test-visual-governor.mjs`, and the matching smoke group; preserve 6 s eligible warm-up, separated hysteresis/dwell, balanced-before-lean ambient ordering, LOW_END/reduced-motion authority, state continuity, and zero storage/network/telemetry. |
 | Change Twin Towns matching or two-person share links | `assets/twin-towns.js` + the Twin Towns block in `index.html` + `scripts/smoke.mjs`. |
 | Change Town Gazette / return-visit freshness | `/*FRESHNESS*/` + Passport render/start flow in `index.html`; keep snapshots local, bounded, per-town, and explicit-read only. |
 | Change resident homes, styles, gardens, routines, moods, friendships, haunts, or Shared Joy | The resident social layer + Starlight Row blocks in `index.html`; preserve the resident style map, 3 roof batches, 10/6 desktop/LOW_END detail-batch cap, 42-unit reserve, entrance gap, quarter colliders, home/work truth, owned porch seats, and social ownership guards. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [1.93.0] — 2026-08-26
+
+### 🎛️ Adaptive Visual Governor — preserve detail within the frame budget
+
+- A three-tier `full` / `balanced` / `lean` governor now observes eligible active render intervals only after
+  6,000 ms of warm-up. Full steps down after a 22.5 ms EMA holds for 3,000 ms; balanced steps down after
+  28.5 ms holds for 5,000 ms. Recovery uses separate 18.5/17.5 ms thresholds, 18,000/14,000 ms evidence,
+  and 14,000/10,000 ms tier dwell so quality returns one step at a time without flicker.
+- Balanced cuts distant building-shadow proxies, particle draw ranges, decorative update cadence, and World Tree
+  bloom cadence first. Lean tightens those bounds and only then biases existing far-building LOD. Repository
+  signs, silhouettes, colliders, functional roots, nearby full detail, and camera/control ownership remain intact.
+- Hidden, idle-capped, intro, modal, Atelier, and Growth Replay frames do not enter evidence. Existing LOW_END
+  clamps the quality ceiling to balanced, and reduced motion keeps decorative cadence at zero through debug force
+  and recovery. Residents, social routines, tours, taxi rides, Atelier, Growth Replay, and Chronicle state are
+  observed but never reset.
+- `?dbg` exposes `window.__visualGovernor()` with force/auto, deterministic low/recover/hidden/transient fixtures,
+  replay, work counts, and continuity state. The helper is in-memory only: no telemetry, persistence, request,
+  backend, model call, dependency, build step, or asset was added.
+- Controlled owner-night diagnostics measured full/balanced/lean shadow proxies at 69/46/23, particles at
+  3,473/2,363/1,459, bloom ceilings at 30/20/12 Hz, and draw calls at 2,481.67/2,465.83/2,417.33. Cold-load requests
+  remain owner 31→31 and foreign 27→27 (the existing foreign GitHub read stays one); decoded same-origin bytes
+  rise by 13,825 (owner 1,726,282→1,740,107; foreign 1,629,433→1,643,258).
+
 ## [1.92.0] — 2026-08-26
 
 ### 🌳 Portable Living Towns — public records grow their own local life

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -101,6 +101,12 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
 - **No full browser automation suite.** `scripts/smoke.mjs` guards many static and extracted behavioral
   contracts, but visual and interaction changes still require serving locally and driving the page in
   Chrome DevTools with 0 console errors on mobile + desktop.
+- **Adaptive quality is an in-memory safety rail, not a benchmark or device profile.** The governor observes
+  visible, active exterior render intervals only after 6 seconds of eligible warm-up, uses three coarse reversible
+  tiers, and forgets everything on reload. Hidden tabs, the intentional idle cap, intro/modals, Atelier, and Growth
+  Replay do not influence it. LOW_END remains the maximum quality bound and reduced motion keeps decorative
+  updates stopped; there is no user dashboard, telemetry, persistence, fingerprint, backend report, or attempt to
+  predict hardware. `?dbg` fixtures are local deterministic replays rather than real-device speed claims.
 - **Owner-town size is a snapshot, not a contract.** Its repository count changes whenever the daily
   public data refresh adds, removes, or filters a repository.
 - **Town Gazette is browser-local.** It compares public repo fields against the last snapshot marked read

--- a/index.html
+++ b/index.html
@@ -3098,6 +3098,91 @@ const IS_MOBILE = _coarse && Math.min(innerWidth, innerHeight) <= 820;      // p
 const LOW_END = (navigator.hardwareConcurrency||8) <= 4 || (navigator.deviceMemory||8) <= 4 || (IS_MOBILE && innerWidth <= 430);
 const DETAIL = IS_MOBILE ? (LOW_END ? 0.5 : 0.72) : (LOW_END ? 0.82 : 1);   // scene-density multiplier (1=full desktop)
 const detail = n => Math.max(0, Math.round(n*DETAIL));                       // scale a per-instance count by the device tier
+/*VISUAL_GOVERNOR_CORE:START*/
+const VISUAL_GOVERNOR_TIER_NAMES=Object.freeze(['full','balanced','lean']);
+const VISUAL_GOVERNOR_CONFIG=Object.freeze({
+  warmupMs:6000,emaAlpha:0.08,minFrameMs:4,maxFrameMs:120,neutralDecay:2,
+  tiers:Object.freeze([
+    Object.freeze({downFrameMs:22.5,downHoldMs:3000,upFrameMs:0,upHoldMs:0,minDwellMs:7000}),
+    Object.freeze({downFrameMs:28.5,downHoldMs:5000,upFrameMs:17.5,upHoldMs:14000,minDwellMs:10000}),
+    Object.freeze({downFrameMs:Infinity,downHoldMs:0,upFrameMs:18.5,upHoldMs:18000,minDwellMs:14000})
+  ]),
+  policies:Object.freeze([
+    Object.freeze({shadowRadius:null,particleScale:1,decorativeStride:1,lodBias:1,bloomHzScale:1}),
+    Object.freeze({shadowRadius:150,particleScale:0.68,decorativeStride:2,lodBias:1,bloomHzScale:0.66}),
+    Object.freeze({shadowRadius:95,particleScale:0.42,decorativeStride:4,lodBias:1.38,bloomHzScale:0.4})
+  ])
+});
+function visualGovernorTierIndex(value){
+  if(Number.isInteger(value)) return Math.max(0,Math.min(VISUAL_GOVERNOR_TIER_NAMES.length-1,value));
+  const index=VISUAL_GOVERNOR_TIER_NAMES.indexOf(String(value||'').toLowerCase()); return index<0?null:index;
+}
+function createVisualGovernorState(options={}){
+  const config=options.config||VISUAL_GOVERNOR_CONFIG,floor=options.lowEnd?1:0;
+  return {config,tier:floor,floor,lowEnd:!!options.lowEnd,reducedMotion:!!options.reducedMotion,manualTier:null,
+    activeMs:0,dwellUntilMs:0,emaMs:0,slowEvidenceMs:0,stableEvidenceMs:0,samples:0,ignored:0,
+    pauses:0,paused:true,lastPauseReason:'boot',transitionCount:0,lastTransition:null};
+}
+function _transitionVisualGovernor(state,nextTier,reason){
+  const next=Math.max(state.floor,Math.min(VISUAL_GOVERNOR_TIER_NAMES.length-1,nextTier));
+  if(next===state.tier) return null;
+  const transition={from:VISUAL_GOVERNOR_TIER_NAMES[state.tier],to:VISUAL_GOVERNOR_TIER_NAMES[next],atMs:+state.activeMs.toFixed(3),reason};
+  state.tier=next; state.transitionCount++; state.lastTransition=transition; state.slowEvidenceMs=0; state.stableEvidenceMs=0;
+  state.dwellUntilMs=state.activeMs+state.config.tiers[next].minDwellMs; return transition;
+}
+function pauseVisualGovernor(state,reason='excluded'){
+  if(!state.paused) state.pauses++;
+  state.paused=true; state.lastPauseReason=reason; state.emaMs=0; state.slowEvidenceMs=0; state.stableEvidenceMs=0;
+}
+function stepVisualGovernor(state,frameMs,eligible=true,reason='frame'){
+  if(state.manualTier!==null) return null;
+  if(!eligible||!Number.isFinite(frameMs)||frameMs>state.config.maxFrameMs){
+    state.ignored++; pauseVisualGovernor(state,reason); return null;
+  }
+  if(frameMs<state.config.minFrameMs){ state.ignored++; return null; }
+  state.activeMs+=frameMs; state.samples++;
+  state.emaMs=state.paused||!state.emaMs?frameMs:state.emaMs+(frameMs-state.emaMs)*state.config.emaAlpha;
+  state.paused=false;
+  if(state.activeMs<state.config.warmupMs){ state.slowEvidenceMs=0; state.stableEvidenceMs=0; return null; }
+  const thresholds=state.config.tiers[state.tier],decay=frameMs*state.config.neutralDecay;
+  if(state.tier<VISUAL_GOVERNOR_TIER_NAMES.length-1&&state.emaMs>=thresholds.downFrameMs){
+    state.slowEvidenceMs+=frameMs; state.stableEvidenceMs=Math.max(0,state.stableEvidenceMs-decay);
+  } else if(state.tier>state.floor&&state.emaMs<=thresholds.upFrameMs){
+    state.stableEvidenceMs+=frameMs; state.slowEvidenceMs=Math.max(0,state.slowEvidenceMs-decay);
+  } else {
+    state.slowEvidenceMs=Math.max(0,state.slowEvidenceMs-decay); state.stableEvidenceMs=Math.max(0,state.stableEvidenceMs-decay);
+  }
+  if(state.activeMs<state.dwellUntilMs) return null;
+  if(state.tier<VISUAL_GOVERNOR_TIER_NAMES.length-1&&state.slowEvidenceMs>=thresholds.downHoldMs) return _transitionVisualGovernor(state,state.tier+1,'sustained-slow');
+  if(state.tier>state.floor&&state.stableEvidenceMs>=thresholds.upHoldMs) return _transitionVisualGovernor(state,state.tier-1,'sustained-stable');
+  return null;
+}
+function forceVisualGovernorTier(state,value){
+  if(value==='auto'){ state.manualTier=null; pauseVisualGovernor(state,'debug-auto'); state.dwellUntilMs=state.activeMs+state.config.tiers[state.tier].minDwellMs; return null; }
+  const requested=visualGovernorTierIndex(value); if(requested===null) return null;
+  state.manualTier=Math.max(state.floor,requested); return _transitionVisualGovernor(state,state.manualTier,'debug-force');
+}
+function visualGovernorDecorativeStride(state){ return state.reducedMotion?0:state.config.policies[state.tier].decorativeStride; }
+function visualGovernorStateSnapshot(state){
+  const thresholds=state.config.tiers[state.tier],policy=state.config.policies[state.tier];
+  return {tier:VISUAL_GOVERNOR_TIER_NAMES[state.tier],qualityCeiling:VISUAL_GOVERNOR_TIER_NAMES[state.floor],mode:state.manualTier===null?'auto':'forced',
+    lowEnd:state.lowEnd,reducedMotion:state.reducedMotion,warmup:{complete:state.activeMs>=state.config.warmupMs,remainingMs:Math.max(0,state.config.warmupMs-state.activeMs)},
+    sample:{activeMs:+state.activeMs.toFixed(3),emaMs:+state.emaMs.toFixed(3),samples:state.samples,ignored:state.ignored,pauses:state.pauses,paused:state.paused,lastPauseReason:state.lastPauseReason},
+    evidence:{slowMs:+state.slowEvidenceMs.toFixed(3),stableMs:+state.stableEvidenceMs.toFixed(3),dwellRemainingMs:+Math.max(0,state.dwellUntilMs-state.activeMs).toFixed(3)},
+    thresholds:{downFrameMs:thresholds.downFrameMs,downHoldMs:thresholds.downHoldMs,upFrameMs:thresholds.upFrameMs,upHoldMs:thresholds.upHoldMs,minDwellMs:thresholds.minDwellMs},
+    policy:{...policy,decorativeStride:visualGovernorDecorativeStride(state)},transitionCount:state.transitionCount,lastTransition:state.lastTransition?{...state.lastTransition}:null};
+}
+function replayVisualGovernor(sequence,options={}){
+  const state=createVisualGovernorState(options),transitions=[];
+  for(const item of sequence||[]){ const frameMs=typeof item==='number'?item:Number(item&&item.frameMs),eligible=typeof item==='number'||item.eligible!==false,reason=typeof item==='number'?'fixture':item.reason||'fixture';
+    const transition=stepVisualGovernor(state,frameMs,eligible,reason); if(transition) transitions.push({...transition}); }
+  return {state:visualGovernorStateSnapshot(state),transitions};
+}
+/*VISUAL_GOVERNOR_CORE:END*/
+const VISUAL_GOVERNOR_STATE=createVisualGovernorState({lowEnd:LOW_END,reducedMotion:REDUCED});
+const VISUAL_GOVERNOR_RUNTIME={lastFrameAt:0,appliedTier:-1,policy:VISUAL_GOVERNOR_CONFIG.policies[VISUAL_GOVERNOR_STATE.tier],
+  decorativeStride:visualGovernorDecorativeStride(VISUAL_GOVERNOR_STATE),ambientDt:0,ambientUpdates:0,ambientSkips:0,
+  shadowActive:0,shadowTotal:0,particleActive:0,particleTotal:0,lastApplyReason:'boot'};
 const WORLD_TREE_NOW=TOWN_PROJECTION.kind==='portable'?cityReferenceTimestamp(CITY_STATE,REPOS,Date.now()):Date.now();
 const WORLD_TREE_RECORD=projectWorldTreeChronicle(CITY_STATE,{now:WORLD_TREE_NOW});
 const WORLD_TREE_GROWTH=projectWorldTreeGrowth(CITY_STATE);
@@ -3133,6 +3218,7 @@ finalComposer.addPass(finalMix); finalComposer.addPass(new OutputPass());
 const BLOOM_DARK_MATERIAL=new THREE.MeshBasicMaterial({color:0x000000,side:THREE.DoubleSide,fog:false,toneMapped:false});
 const MEM_TREE_BLOOM_HZ=LOW_END?20:30, MEM_TREE_DESKTOP_BLOOM_MIN_FRAME_GAP=3;
 const _treeBloomMinFrameGap=()=>_desktopFrameDropGuard()?MEM_TREE_DESKTOP_BLOOM_MIN_FRAME_GAP:0;
+const _treeBloomHz=()=>Math.max(1,Math.min(MEM_TREE_BLOOM_HZ,Math.round(MEM_TREE_BLOOM_HZ*VISUAL_GOVERNOR_RUNTIME.policy.bloomHzScale)));
 let WORLD_TREE_RENDER_MODE='final-composite';
 const WORLD_TREE_SAVED_CLEAR=new THREE.Color();
 const WORLD_TREE_BLOOM_POSITION=new THREE.Vector3(),WORLD_TREE_BLOOM_SCALE=new THREE.Vector3(),WORLD_TREE_BLOOM_ROTATION=new THREE.Quaternion(),
@@ -3245,7 +3331,7 @@ function _renderWorldTreeFrame(){
     bloomFrameGap=_treeBloomMinFrameGap();
   if(needSource&&MEMORIAL_TREE) _updateWorldTreeBloomProjection();
   const sourceDue=needSource&&MEMORIAL_TREE&&(WORLD_TREE_RENDER_MODE!=='final-composite'||MEMORIAL_TREE.bloomDirty
-    || ((!bloomFrameGap||renderedFrame-MEMORIAL_TREE.lastBloomFrame>=bloomFrameGap)&&now-MEMORIAL_TREE.lastBloomAt>=1000/MEM_TREE_BLOOM_HZ));
+    || ((!bloomFrameGap||renderedFrame-MEMORIAL_TREE.lastBloomFrame>=bloomFrameGap)&&now-MEMORIAL_TREE.lastBloomAt>=1000/_treeBloomHz()));
   if(sourceDue){ _prepareWorldTreeBloom(); camera.layers.set(MEM_TREE_LIGHT_LAYER);
     if(forceProofLayer) _setWorldTreeGlowLayers(true);
     _beginWorldTreeBloomExtraction();
@@ -3533,7 +3619,7 @@ const RESIDENT_HOMES=[], RES_HOME_WINDOWS=[], RES_HOME_SURFACES=[], RES_QUARTER_
 const GLOW_FLORA=[]; let _floraLit=false;   // 🌼 luminous roadside blossoms — colourful by day, softly shimmering after dark
 function updateFountains(dt){
   for(const F of FOUNTAINS){ const a=F.pos, st=F.st;
-    for(let i=0;i<st.length;i++){ const d=st[i];
+    for(let i=0;i<(F.activeCount??st.length);i++){ const d=st[i];
       d.vy-=6.6*dt; d.x+=d.vx*dt; d.y+=d.vy*dt; d.z+=d.vz*dt;
       if(d.y<F.basinY){ d.x=0; d.z=0; d.y=F.originY;
         const an=Math.random()*6.2832, sp=0.32+Math.random()*0.5;
@@ -3604,13 +3690,14 @@ const GLINT_TEX=(function(){ const c=document.createElement('canvas'); c.width=c
 const starsGroup=new THREE.Group(); starsGroup.visible=false; scene.add(starsGroup);
 const SKY_DETAIL=LOW_END?0.42:(IS_MOBILE?0.58:0.72), skyDetail=n=>Math.max(1,Math.round(n*SKY_DETAIL));
 const STAR_R=365, _starTints=[0xffffff,0xffffff,0xffffff,0xcfe0ff,0xbcd0ff,0xfff0d6,0xffd9b0,0xd9fbff];
+const SKY_POINT_LAYERS=[];
 function _starLayer(pos,col,size,opacity,tex){
   const g=new THREE.BufferGeometry();
   g.setAttribute('position', new THREE.Float32BufferAttribute(pos,3));
   if(col) g.setAttribute('color', new THREE.Float32BufferAttribute(col,3));
   const m=new THREE.PointsMaterial({size,map:tex||STAR_TEX,transparent:true,opacity,depthWrite:false,fog:false,blending:THREE.AdditiveBlending,sizeAttenuation:true});
   if(col) m.vertexColors=true;
-  const p=new THREE.Points(g,m); starsGroup.add(p); return p;
+  const p=new THREE.Points(g,m); p.userData.visualGovernorBaseCount=pos.length/3; SKY_POINT_LAYERS.push(p); starsGroup.add(p); return p;
 }
 function _pushDir(a,d,r,y){ a.push(d.x*r,d.y*r+y,d.z*r); }
 // scattered all-sky stars (varied tint + brightness)
@@ -3744,7 +3831,8 @@ for(let i=0;i<70;i++){
   fireflyGroup.add(s); fireflies.push(s);
 }
 function updateFireflies(t){ if(!fireflyGroup.visible) return;
-  for(const f of fireflies){ const u=f.userData;
+  const count=VISUAL_GOVERNOR_RUNTIME.fireflyCount??fireflies.length;
+  for(let i=0;i<count;i++){ const f=fireflies[i],u=f.userData;
     f.position.x=u.bx+Math.cos(t*u.sp+u.ph)*u.rad;
     f.position.z=u.bz+Math.sin(t*u.sp*0.8+u.ph)*u.rad;
     f.position.y=u.by+Math.sin(t*u.sp*1.3+u.ph)*0.7;
@@ -4027,7 +4115,7 @@ const starDust=(function(){ const N=detail(54), pos=[], base=[], ph=[];
     pos.push(Math.cos(a)*r,y,Math.sin(a)*r); base.push(Math.cos(a)*r,y,Math.sin(a)*r); ph.push(Math.random()*6.28); }
   const g=new THREE.BufferGeometry(); g.setAttribute('position',new THREE.Float32BufferAttribute(pos,3));
   const m=new THREE.PointsMaterial({size:0.17,map:STAR_TEX,color:0xffe9c0,transparent:true,opacity:0.20,depthWrite:false,fog:false,blending:THREE.AdditiveBlending,sizeAttenuation:true});
-  const p=new THREE.Points(g,m); p._base=base; p._ph=ph; scene.add(p); return p; })();
+  const p=new THREE.Points(g,m); p._base=base; p._ph=ph; p.userData.visualGovernorBaseCount=N; scene.add(p); return p; })();
 // plaza rim
 const rim = new THREE.Mesh(new THREE.RingGeometry(9.5,10.2,40), basic(0xc3ad7c));
 rim.rotation.x=-Math.PI/2; rim.position.y=0.025; scene.add(rim);
@@ -4055,7 +4143,7 @@ rim.rotation.x=-Math.PI/2; rim.position.y=0.025; scene.add(rim);
   const sgeo=new THREE.BufferGeometry(); sgeo.setAttribute('position',new THREE.BufferAttribute(pos,3));
   const smat=new THREE.PointsMaterial({size:0.17,map:GLOW_TEX,color:0xe2f3ff,transparent:true,opacity:0.92,depthWrite:false,blending:THREE.AdditiveBlending,sizeAttenuation:true,fog:false});
   const spray=new THREE.Points(sgeo,smat); scene.add(spray);
-  FOUNTAINS.push({pos,st,geom:sgeo,originY:oY,basinY:bY});
+  FOUNTAINS.push({pos,st,geom:sgeo,points:spray,activeCount:st.length,originY:oY,basinY:bY});
   // soft glow lighting the fountain at night
   const glow=new THREE.Sprite(new THREE.SpriteMaterial({map:GLOW_TEX,color:0xbfe0ff,transparent:true,opacity:0,depthWrite:false,fog:false,blending:THREE.AdditiveBlending}));
   glow.scale.set(5,5,1); glow.position.y=fy+0.7; glow._n=0.42; scene.add(glow); NIGHT_GLOWS.push(glow);
@@ -5685,10 +5773,11 @@ function _buildingLodAttach(entry,tier,forced=false){
 }
 function _buildingLodDesired(entry,projectedPx,outside){
   if(entry.forcedTier) return entry.forcedTier; if(outside) return 'culled'; const th=BUILDING_LOD_PROTO.thresholds;
-  const fullEnter=th.fullEnter*entry.detailScale,fullLeave=th.fullLeave*entry.detailScale;
-  if(entry.tier==='full') return projectedPx<fullLeave?(projectedPx<th.midLeave?'far':'mid'):'full';
-  if(entry.tier==='mid') return projectedPx>fullEnter?'full':projectedPx<th.midLeave?'far':'mid';
-  return projectedPx>fullEnter?'full':projectedPx>th.midEnter?'mid':'far';
+  const bias=VISUAL_GOVERNOR_RUNTIME.policy.lodBias,fullEnter=th.fullEnter*entry.detailScale*bias,fullLeave=th.fullLeave*entry.detailScale*bias,
+    midEnter=th.midEnter*bias,midLeave=th.midLeave*bias;
+  if(entry.tier==='full') return projectedPx<fullLeave?(projectedPx<midLeave?'far':'mid'):'full';
+  if(entry.tier==='mid') return projectedPx>fullEnter?'full':projectedPx<midLeave?'far':'mid';
+  return projectedPx>fullEnter?'full':projectedPx>midEnter?'mid':'far';
 }
 function _updateBuildingLodPrototype(frame,force=false){
   if(!BUILDING_LOD_PROTO.enabled) return; const moved=camera.position.distanceToSquared(BUILDING_LOD_PROTO.lastCameraPos)>2.25,rotated=1-Math.abs(camera.quaternion.dot(BUILDING_LOD_PROTO.lastCameraQuat))>0.0002;
@@ -7034,6 +7123,8 @@ function setNightState(night){
   invalidateTownShadows('night-state'); lastAct=performance.now();   // 밤낮 전환만 그림자를 무효화; 입력/이동은 고정 태양·도시 shadow와 무관
   moon.visible=night; starsGroup.visible=night; fireflyGroup.visible=night;
   birdFlock.visible=!night; butterflyGroup.visible=!night;
+  starDust.material.opacity=night?0.72:0.26;
+  for(const r of RUNE_MATS) r.m.opacity=r.base*(night?1.5:0.5);
   LAMP_BULBS.forEach(b=>b.material.color.setHex(night?0xfff0c2:0xffe6a8));
   LAMP_GLOWS.forEach(o=>{ o.material.opacity = night? o._nightOp : 0; });
   WATER_NIGHT.value = night?1:0;
@@ -12330,14 +12421,94 @@ const EMOTES={
 let emoteT=0, emoteKind='wave';
 function lerpA(a,b,t){ let d=((b-a+Math.PI)%(Math.PI*2))-Math.PI; if(d<-Math.PI)d+=Math.PI*2; return a+d*t; }
 
+/*VISUAL_GOVERNOR_RUNTIME:START*/
+const VISUAL_GOVERNOR_INTRO=document.getElementById('intro');
+function _setVisualGovernorPointCount(points,scale){
+  if(!points||!points.geometry) return {active:0,total:0};
+  const total=points.userData.visualGovernorBaseCount??points.geometry.attributes.position?.count??0,active=total?Math.max(1,Math.min(total,Math.round(total*scale))):0;
+  points.geometry.setDrawRange(0,active); points.userData.visualGovernorActiveCount=active; return {active,total};
+}
+function _applyVisualGovernorTier(reason='transition'){
+  const state=VISUAL_GOVERNOR_STATE,runtime=VISUAL_GOVERNOR_RUNTIME,policy=state.config.policies[state.tier];
+  runtime.policy=policy; runtime.decorativeStride=visualGovernorDecorativeStride(state); runtime.lastApplyReason=reason;
+  let particleActive=0,particleTotal=0;
+  for(const points of SKY_POINT_LAYERS){ const count=_setVisualGovernorPointCount(points,policy.particleScale); particleActive+=count.active; particleTotal+=count.total; }
+  { const count=_setVisualGovernorPointCount(starDust,policy.particleScale); particleActive+=count.active; particleTotal+=count.total; }
+  for(const fountain of FOUNTAINS){ fountain.activeCount=Math.max(1,Math.round(fountain.st.length*policy.particleScale)); fountain.geom.setDrawRange(0,fountain.activeCount);
+    particleActive+=fountain.activeCount; particleTotal+=fountain.st.length; }
+  updateFountains(0);
+  runtime.fireflyCount=Math.max(1,Math.round(fireflies.length*policy.particleScale));
+  for(let i=0;i<fireflies.length;i++) fireflies[i].visible=i<runtime.fireflyCount;
+  particleActive+=runtime.fireflyCount; particleTotal+=fireflies.length; runtime.particleActive=particleActive; runtime.particleTotal=particleTotal;
+  scene.updateMatrixWorld(true); let shadowActive=0,shadowChanged=false;
+  for(const entry of BUILDING_LOD_PROTO.entries){ entry.worldCenter.copy(entry.localCenter).applyMatrix4(entry.root.matrixWorld);
+    const active=policy.shadowRadius===null||camera.position.distanceTo(entry.worldCenter)<=policy.shadowRadius;
+    if(entry.shadowProxy.castShadow!==active){ entry.shadowProxy.castShadow=active; shadowChanged=true; }
+    if(active) shadowActive++; }
+  runtime.shadowActive=shadowActive; runtime.shadowTotal=BUILDING_LOD_PROTO.entries.length;
+  if(shadowChanged) invalidateTownShadows('visual-governor');
+  if(runtime.appliedTier!==state.tier){ runtime.appliedTier=state.tier; BUILDING_LOD_PROTO.lastFrame=-999; _updateBuildingLodPrototype(renderedFrame,true); }
+}
+function _visualGovernorExclusionReason(idle){
+  if(document.hidden) return 'hidden';
+  if(idle) return 'idle-cap';
+  if(VISUAL_GOVERNOR_INTRO&&!VISUAL_GOVERNOR_INTRO.classList.contains('hidden')) return 'initial-ui';
+  if(repositoryAtelierActive()) return 'atelier';
+  if(GROWTH_REPLAY.active) return 'growth-replay';
+  if(modalOpen) return 'modal';
+  return '';
+}
+function _visualGovernorTick(now,idle){
+  const runtime=VISUAL_GOVERNOR_RUNTIME,frameMs=runtime.lastFrameAt?now-runtime.lastFrameAt:0; runtime.lastFrameAt=now;
+  const excluded=_visualGovernorExclusionReason(idle),transition=stepVisualGovernor(VISUAL_GOVERNOR_STATE,frameMs,!excluded&&frameMs>0,excluded||'render-frame');
+  if(transition) _applyVisualGovernorTier(transition.reason);
+}
+function _visualGovernorAmbientDue(dt){
+  const runtime=VISUAL_GOVERNOR_RUNTIME,stride=runtime.decorativeStride;
+  if(!stride){ runtime.ambientDt=0; runtime.ambientSkips++; return false; }
+  runtime.ambientDt=Math.min(0.2,runtime.ambientDt+dt);
+  if(renderedFrame%stride){ runtime.ambientSkips++; return false; }
+  runtime.ambientStepDt=runtime.ambientDt; runtime.ambientDt=0; runtime.ambientUpdates++; return true;
+}
+function _visualGovernorFixture(kind='low'){
+  const sequence=[],push=(duration,frameMs,eligible=true,reason='fixture')=>{ for(let elapsed=0;elapsed<duration;elapsed+=frameMs) sequence.push({frameMs,eligible,reason}); };
+  push(6200,16.67);
+  if(kind==='transient'){ push(1200,16.67); sequence.push({frameMs:80,eligible:true,reason:'spike'}); push(8000,16.67); }
+  else if(kind==='hidden'){ push(2400,30); sequence.push({frameMs:5000,eligible:false,reason:'hidden'}); push(2400,30); }
+  else { push(18000,34); if(kind==='recover') push(42000,16.2); }
+  return {kind,...replayVisualGovernor(sequence,{lowEnd:LOW_END,reducedMotion:REDUCED})};
+}
+function _visualGovernorDebug(){
+  const state=visualGovernorStateSnapshot(VISUAL_GOVERNOR_STATE),runtime=VISUAL_GOVERNOR_RUNTIME,lod={full:0,mid:0,far:0,culled:0};
+  for(const entry of BUILDING_LOD_PROTO.entries) lod[entry.tier]=(lod[entry.tier]||0)+1;
+  return {...state,work:{shadows:{active:runtime.shadowActive,total:runtime.shadowTotal,radius:runtime.policy.shadowRadius},
+      particles:{active:runtime.particleActive,total:runtime.particleTotal,scale:runtime.policy.particleScale,fireflies:runtime.fireflyCount},
+      decorative:{stride:runtime.decorativeStride,updates:runtime.ambientUpdates,skips:runtime.ambientSkips},
+      farDetail:{lodBias:runtime.policy.lodBias,tiers:lod},worldTreeBloomHz:_treeBloomHz()},
+    continuity:{residents:RESIDENTS_LIVE.length,tour:!!(tour&&tour.active),taxi:ride&&ride.phase||null,atelier:REPOSITORY_ATELIER?.state||'outside',
+      growth:GROWTH_REPLAY.active,worldTreeChronicle:WORLD_TREE_UI.open,modal:modalOpen,cameraOwner:_cameraOwnerAtFrameStart()},
+    runtime:{lastApplyReason:runtime.lastApplyReason,appliedTier:VISUAL_GOVERNOR_TIER_NAMES[runtime.appliedTier]||null}};
+}
+function _debugVisualGovernor(command){
+  if(command&&typeof command==='object'&&command.fixture) return _visualGovernorFixture(command.fixture);
+  if(command&&typeof command==='object'&&Array.isArray(command.sequence)) return replayVisualGovernor(command.sequence,{lowEnd:command.lowEnd??LOW_END,reducedMotion:command.reducedMotion??REDUCED});
+  const requested=typeof command==='string'?command:command&&command.force;
+  if(requested){ forceVisualGovernorTier(VISUAL_GOVERNOR_STATE,requested); _applyVisualGovernorTier(requested==='auto'?'debug-auto':'debug-force'); }
+  return _visualGovernorDebug();
+}
+_applyVisualGovernorTier('initial');
+/*VISUAL_GOVERNOR_RUNTIME:END*/
+
 function animate(){
   requestAnimationFrame(animate);
   frame++;
   const _now=performance.now();
   const _idle=_effectiveIdle(_now);   // perf matrix can toggle cadence without synthetic input
-  if(_idle && !repositoryAtelierActive() && !GROWTH_REPLAY.active && !(tour&&tour.active) && !ferris && !carousel && !canalFerryRide && FW.length===0 && _fwQueue===0 && VISIT_FX.length===0 && BOBS.length===0 && _now-lastFrame<33) return;   // perf: idle → cap ~30fps (festival/visit-pops/guided-tour/ferry/growth replay keep full fps)
+  const _idleCapped=_idle && !repositoryAtelierActive() && !GROWTH_REPLAY.active && !(tour&&tour.active) && !ferris && !carousel && !canalFerryRide && FW.length===0 && _fwQueue===0 && VISIT_FX.length===0 && BOBS.length===0;
+  if(_idleCapped && _now-lastFrame<33) return;   // perf: idle → cap ~30fps (festival/visit-pops/guided-tour/ferry/growth replay keep full fps)
   lastFrame=_now; renderedFrame++;
   const dt=Math.min(clock.getDelta(),0.05);
+  _visualGovernorTick(_now,_idleCapped);
   if(_repositoryAtelierFrame(dt)) return;   // one explicit gate: room or frozen transition, never the exterior simulation too
   updateFerris(dt);
   updateCarousel(dt);
@@ -12495,34 +12666,38 @@ function animate(){
     const dist=player.position.distanceTo(navTarget._pos); document.getElementById('navDist').textContent=Math.round(dist);
     if(dist<6){ navHolder.visible=false; navTarget=null; document.getElementById('navBadge').style.display='none'; } }
 
-  updateClouds(dt);
   stepSky(dt);
-  WATER_TIME.value=clock.elapsedTime;
-  updateKoi(clock.elapsedTime);
-  updateFountains(dt);
-  updateSmoke(clock.elapsedTime);
-  updateGarlands(clock.elapsedTime);
-  updateSway(clock.elapsedTime);
+  const ambientDue=_visualGovernorAmbientDue(dt),ambientDt=VISUAL_GOVERNOR_RUNTIME.ambientStepDt||dt;
+  if(ambientDue){
+    updateClouds(ambientDt);
+    WATER_TIME.value=clock.elapsedTime;
+    updateKoi(clock.elapsedTime);
+    updateFountains(ambientDt);
+    updateSmoke(clock.elapsedTime);
+    updateGarlands(clock.elapsedTime);
+    updateSway(clock.elapsedTime);
+  }
   _memHeroUpdate(clock.elapsedTime);   // exact plugin pulse/motion plus uniform-scale light compensation
   _updateWorldTreeTrigger();
   updateWorldTreeSapFlow(clock.elapsedTime);
   updateChows(clock.elapsedTime,dt);
   updateChrono(dt);
-  if(obsScope) obsScope.rotation.y+=dt*0.05;   // the great telescope slowly sweeps the sky
-  if(!isNight){ updateBirds(clock.elapsedTime); updateButterflies(clock.elapsedTime); }
-  if(isNight){ bigStars.material.opacity=0.62+Math.sin(clock.elapsedTime*2.6)*0.38; starsGroup.rotation.y+=dt*0.0016; updateFireflies(clock.elapsedTime);
-    for(let i=0;i<scholarStars.length;i++) scholarStars[i].mat.opacity=0.55+Math.sin(clock.elapsedTime*2.1+i*1.9)*0.45;
-    AURORA_TIME.value=clock.elapsedTime; AURORA_OP.value=Math.min(0.55+(_auroraBoost>0?0.45:0), AURORA_OP.value+dt*0.5); }
+  if(ambientDue){
+    if(obsScope) obsScope.rotation.y+=ambientDt*0.05;   // the great telescope slowly sweeps the sky
+    if(!isNight){ updateBirds(clock.elapsedTime); updateButterflies(clock.elapsedTime); }
+    if(isNight){ bigStars.material.opacity=0.62+Math.sin(clock.elapsedTime*2.6)*0.38; starsGroup.rotation.y+=ambientDt*0.0016; updateFireflies(clock.elapsedTime);
+      for(let i=0;i<scholarStars.length;i++) scholarStars[i].mat.opacity=0.55+Math.sin(clock.elapsedTime*2.1+i*1.9)*0.45;
+      AURORA_TIME.value=clock.elapsedTime; AURORA_OP.value=Math.min(0.55+(_auroraBoost>0?0.45:0), AURORA_OP.value+ambientDt*0.5); }
+    { const _ap=0.5+0.5*Math.sin(clock.elapsedTime*1.6), _nf=isNight?1.6:0.8;
+      for(const a of auraPulse){ a.s1.material.opacity=a.b1*(0.55+0.6*_ap)*_nf; a.s2.material.opacity=a.b2*(0.6+0.6*_ap)*_nf; } }
+    { const _t=clock.elapsedTime,_arr=starDust.geometry.attributes.position.array,_b=starDust._base,_ph=starDust._ph,count=starDust.userData.visualGovernorActiveCount??_ph.length;
+      for(let i=0;i<count;i++){ _arr[i*3]=_b[i*3]+Math.cos(_t*0.28+_ph[i])*0.45; _arr[i*3+1]=_b[i*3+1]+Math.sin(_t*0.5+_ph[i])*0.55; }
+      starDust.geometry.attributes.position.needsUpdate=true;
+      for(const r of RUNE_MATS) r.m.opacity=r.base*(isNight?1.5:0.5)*(0.85+0.15*Math.sin(_t*0.8)); }
+    updateMeteor(ambientDt);
+    updateGlowFlora(clock.elapsedTime);
+  }
   if(_auroraBoost>0) _auroraBoost=Math.max(0,_auroraBoost-dt);
-  { const _ap=0.5+0.5*Math.sin(clock.elapsedTime*1.6), _nf=isNight?1.6:0.8;
-    for(const a of auraPulse){ a.s1.material.opacity=a.b1*(0.55+0.6*_ap)*_nf; a.s2.material.opacity=a.b2*(0.6+0.6*_ap)*_nf; } }
-  { const _t=clock.elapsedTime;
-    if((frame&1)===0){ const _arr=starDust.geometry.attributes.position.array, _b=starDust._base, _ph=starDust._ph;   // perf: drift every other frame (halves CPU calc + GPU upload)
-      for(let i=0;i<_ph.length;i++){ _arr[i*3]=_b[i*3]+Math.cos(_t*0.28+_ph[i])*0.45; _arr[i*3+1]=_b[i*3+1]+Math.sin(_t*0.5+_ph[i])*0.55; }
-      starDust.geometry.attributes.position.needsUpdate=true; }
-    starDust.material.opacity=isNight?0.72:0.26;
-    for(const r of RUNE_MATS) r.m.opacity=r.base*(isNight?1.5:0.5)*(0.85+0.15*Math.sin(_t*0.8)); }
-  updateMeteor(dt);
   updateFireworks(dt);
   updateVisitFx(dt);
   updateStarTrail(clock.elapsedTime);
@@ -12530,7 +12705,6 @@ function animate(){
   updateNpcs(dt);
   updateResidents(dt);
   updateRainGarden(dt);
-  updateGlowFlora(clock.elapsedTime);
   updateHearth(clock.elapsedTime);
   rtTick(dt);
   if(userInput||moving||ride||canalFerryRide||dragging||navTarget||GROWTH_REPLAY.playing||GROWTH_REPLAY.reveals.length) lastAct=_now;   // dynamic state keeps interaction responsive; shadow invalidation is independent
@@ -13190,7 +13364,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
     calls:latest?latest.total.calls:info.render.calls, triangles:latest?latest.total.triangles:info.render.triangles,
     geometries:info.memory.geometries, textures:info.memory.textures, programs:(info.programs||[]).length,
     dpr:+renderer.getPixelRatio().toFixed(2), size:[innerWidth,innerHeight],
-    tier:{ mobile:IS_MOBILE, lowEnd:LOW_END, reduced:REDUCED, detail:DETAIL },
+    tier:{ mobile:IS_MOBILE, lowEnd:LOW_END, reduced:REDUCED, detail:DETAIL, adaptive:VISUAL_GOVERNOR_TIER_NAMES[VISUAL_GOVERNOR_STATE.tier] },
     frame:latest?{renderMs:+latest.renderMs.toFixed(2),cadenceMs:+latest.cadenceMs.toFixed(2),idle:latest.idle,night:latest.night,pitch:+latest.pitch.toFixed(3),gpuMs:latest.gpuMs}:null,
     passes:latest?latest.passes:null,baseScene:latest?latest.baseScene:null,
     targets:{base:baseTargetDpr,emissive:treeEmissiveDpr,bloom:treeBloomDpr,final:finalCompositeDpr},
@@ -13200,6 +13374,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__perfReset=()=>{ RENDER_METRICS.history.length=0; RENDER_METRICS.latest=null; RENDER_METRICS.lastStartedAt=0; return true; };
   window.__perfDiagnostics=()=>({enabled:_DIAGNOSTICS,debug:_DBG,autoReset:renderer.info.autoReset,shadowWrapped:!!renderer.shadowMap.render.__repolisMetrics,
     frameAllocations:RENDER_METRICS.frameAllocations,passTokenAllocations:RENDER_METRICS.passTokenAllocations,historyWrites:RENDER_METRICS.historyWrites,history:RENDER_METRICS.history.length,gpuSupported:GPU_TIMER.supported});
+  window.__visualGovernor=(command)=>_debugVisualGovernor(command);
   window.__worldTreeChronicle=()=>{ const flow=MEMORIAL_TREE&&MEMORIAL_TREE.sapFlow; return {
     open:WORLD_TREE_UI.open,available:WORLD_TREE_RECORD.available,portable:WORLD_TREE_RECORD.portable?JSON.parse(JSON.stringify(WORLD_TREE_RECORD.portable)):null,
     roots:WORLD_TREE_RECORD.roots.length,rootSearch:!worldTreeRootSearchWrap.hidden,
@@ -13224,7 +13399,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
         energyFrontDominantVeinCount:s.energyFrontDominantVeinCount,energyFrontDominantVeinIds:s.energyFrontDominantVeinIds,energyRearDominantVeinCount:s.energyRearDominantVeinCount,energyRearDominantVeinIds:s.energyRearDominantVeinIds,
         energySupportVeinCount:s.energySupportVeinCount,energySupportVeinIds:s.energySupportVeinIds,energySideSupportVeinCount:s.energySideSupportVeinCount,energySideSupportVeinIds:s.energySideSupportVeinIds,energyDominantRadius:s.energyDominantRadius,energySupportRadius:s.energySupportRadius,energySourceWeights:s.energySourceWeights,energyBarkHaloPolicy:s.energyBarkHaloPolicy,
         energyKnotCount:s.energyKnotCount,energyKnotDistribution:s.energyKnotDistribution,energyKnotSizes:s.energyKnotSizes,energyKnotRoles:s.energyKnotRoles,energyDrawMeshes:s.energyDrawMeshes,hangingLightCount:s.hangingLightCount,hangingLightMeshCount:s.hangingLightMeshCount,hangingLightPartCount:s.hangingLightPartCount,hangingLightPolicy:s.hangingLightPolicy,
-        bloomHz:MEM_TREE_BLOOM_HZ,bloomMinFrameGap:_treeBloomMinFrameGap(),dynamicOccluders:MEMORIAL_TREE.dynamicOccluderGroups.size,staticProxies:MEMORIAL_TREE.staticProxyCount||0,objectPerf:_memHeroObjectPerf(MEMORIAL_TREE.group)},
+        bloomHz:_treeBloomHz(),bloomBaseHz:MEM_TREE_BLOOM_HZ,bloomMinFrameGap:_treeBloomMinFrameGap(),dynamicOccluders:MEMORIAL_TREE.dynamicOccluderGroups.size,staticProxies:MEMORIAL_TREE.staticProxyCount||0,objectPerf:_memHeroObjectPerf(MEMORIAL_TREE.group)},
       crownOnlySway:wt.crownOnlySway,sockets:Object.keys(MEMORIAL_TREE.sockets),collider:{x:c.x,z:c.z,r:c.r},target:wt.target,growth:{...MEMORIAL_TREE.growth},
       nightGuide:{night:isNight,light:+MEMORIAL_TREE.light.intensity.toFixed(1),rendered:MEMORIAL_TREE.light.visible,range:+MEMORIAL_TREE.light.distance.toFixed(1),energy:+MEMORIAL_TREE.hero.materials.energy.emissiveIntensity.toFixed(2),amber:+MEMORIAL_TREE.hero.materials.amberLeaf.emissiveIntensity.toFixed(2),cyan:+MEMORIAL_TREE.hero.materials.cyanLeaf.emissiveIntensity.toFixed(2),
         distance:+MEMORIAL_TREE.glowDistance.toFixed(1),distanceLod:+MEMORIAL_TREE.distanceLod.toFixed(2),halos:MEMORIAL_TREE.glowHalos.length,haloMode:adapter.haloMode,pointLightRole:adapter.pointLightRole,environmentLights:0,
@@ -13236,7 +13411,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__memorialTreeVisible=(visible=true)=>{ if(!MEMORIAL_TREE) return false; MEMORIAL_TREE.requestedVisible=visible!==false; MEMORIAL_TREE.group.visible=MEMORIAL_TREE.requestedVisible; _setWorldTreeSapVisible(MEMORIAL_TREE.requestedVisible); MEMORIAL_TREE.bloomDirty=true; return MEMORIAL_TREE.requestedVisible; };
   window.__worldTreeRenderMode=(mode)=>{ const modes=['base-only','emissive-only','bloom-only','final-composite','tree-off']; if(modes.includes(mode)){ WORLD_TREE_RENDER_MODE=mode; if(MEMORIAL_TREE) MEMORIAL_TREE.bloomDirty=true; } return {mode:WORLD_TREE_RENDER_MODE,modes}; };
   window.__worldTreeRenderTargets=()=>({base:{type:'HalfFloatType',colorSpace:baseTarget.texture.colorSpace,depth:true,size:[baseTarget.width,baseTarget.height]},emissive:{type:'HalfFloatType',colorSpace:emissiveTarget.texture.colorSpace,mode:'unlit-depth-aware',depth:true,size:[emissiveTarget.width,emissiveTarget.height]},
-    bloom:{type:'HalfFloatType',colorSpace:worldBloom.renderTargetsHorizontal[0].texture.colorSpace,source:'UnrealBloomPass.renderTargetsHorizontal[0]',hz:MEM_TREE_BLOOM_HZ,depth:false,size:[worldBloom.renderTargetsHorizontal[0].width,worldBloom.renderTargetsHorizontal[0].height]},
+    bloom:{type:'HalfFloatType',colorSpace:worldBloom.renderTargetsHorizontal[0].texture.colorSpace,source:'UnrealBloomPass.renderTargetsHorizontal[0]',hz:_treeBloomHz(),baseHz:MEM_TREE_BLOOM_HZ,depth:false,size:[worldBloom.renderTargetsHorizontal[0].width,worldBloom.renderTargetsHorizontal[0].height]},
     final:{toneMapping:'ACESFilmicToneMapping',outputColorSpace:renderer.outputColorSpace,textures:2,boundedBloom:true,size:[finalComposer.readBuffer.width,finalComposer.readBuffer.height]},
     scales:{base:baseTargetDpr,emissive:treeEmissiveDpr,bloom:treeBloomDpr,final:finalCompositeDpr},outputPasses:1});
   window.__freezeWorldForExposure=(freeze=true)=>{ if(freeze){ clock.stop(); clock.autoStart=false; } else { clock.autoStart=true; clock.start(); } return {frozen:!clock.running,elapsed:+clock.elapsedTime.toFixed(3)}; };

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -16,6 +16,7 @@ import { createRequire } from 'module';
 import { createHash } from 'crypto';
 import { runInNewContext } from 'vm';
 import { runNpcBudgetGovernorTests } from './test-npc-budget-governor.mjs';
+import { runVisualGovernorTests } from './test-visual-governor.mjs';
 import { runLoreTests } from './test-lore.mjs';
 import { runResidentDialogueTests } from './test-resident-dialogue.mjs';
 import { runResidentRuntimeTests } from './test-resident-runtime.mjs';
@@ -3209,6 +3210,57 @@ ok(/window\.__lanternWatchPlan=/.test(HTML) && /window\.__lanternWatchStart=/.te
   && /window\.__lanternWatchNext=/.test(HTML) && /window\.__lanternWatchEnd=/.test(HTML), '?dbg watch plan/start/advance/end hooks are present');
 ok(/updateLanternWatch\(clock\.elapsedTime\)/.test(HTML), 'the main world loop updates active night-watch lanterns');
 
+group('Adaptive Visual Governor - sustained frame budget without gameplay resets');
+const visualGovernorCoreBlock = (HTML.match(/\/\*VISUAL_GOVERNOR_CORE:START\*\/([\s\S]*?)\/\*VISUAL_GOVERNOR_CORE:END\*\//) || [, ''])[1];
+const visualGovernorRuntimeBlock = (HTML.match(/\/\*VISUAL_GOVERNOR_RUNTIME:START\*\/([\s\S]*?)\/\*VISUAL_GOVERNOR_RUNTIME:END\*\//) || [, ''])[1];
+ok(visualGovernorCoreBlock.length > 0 && visualGovernorRuntimeBlock.length > 0,
+  'governor pure transition and runtime adapter blocks remain independently extractable');
+await runVisualGovernorTests(ok);
+ok(/warmupMs:6000,emaAlpha:0\.08,minFrameMs:4,maxFrameMs:120/.test(visualGovernorCoreBlock)
+  && /downFrameMs:22\.5,downHoldMs:3000/.test(visualGovernorCoreBlock)
+  && /downFrameMs:28\.5,downHoldMs:5000,upFrameMs:17\.5,upHoldMs:14000/.test(visualGovernorCoreBlock)
+  && /upFrameMs:18\.5,upHoldMs:18000/.test(visualGovernorCoreBlock),
+  'warm-up, separate down/up thresholds, hysteresis, and slow recovery are explicit bounded policy');
+ok(/floor=options\.lowEnd\?1:0/.test(visualGovernorCoreBlock)
+  && /return state\.reducedMotion\?0:state\.config\.policies\[state\.tier\]\.decorativeStride/.test(visualGovernorCoreBlock)
+  && /state\.manualTier=Math\.max\(state\.floor,requested\)/.test(visualGovernorCoreBlock),
+  'LOW_END clamps maximum quality while reduced motion and debug force cannot re-enable decorative motion');
+ok(/shadowRadius:150,particleScale:0\.68,decorativeStride:2,lodBias:1,bloomHzScale:0\.66/.test(visualGovernorCoreBlock)
+  && /shadowRadius:95,particleScale:0\.42,decorativeStride:4,lodBias:1\.38,bloomHzScale:0\.4/.test(visualGovernorCoreBlock),
+  'balanced removes distant ambient cost first and lean alone biases far-building detail');
+ok(/if\(document\.hidden\) return 'hidden'/.test(visualGovernorRuntimeBlock)
+  && /if\(idle\) return 'idle-cap'/.test(visualGovernorRuntimeBlock)
+  && /VISUAL_GOVERNOR_INTRO&&!VISUAL_GOVERNOR_INTRO\.classList\.contains\('hidden'\)/.test(visualGovernorRuntimeBlock)
+  && /if\(repositoryAtelierActive\(\)\) return 'atelier'/.test(visualGovernorRuntimeBlock)
+  && /if\(GROWTH_REPLAY\.active\) return 'growth-replay'/.test(visualGovernorRuntimeBlock)
+  && /if\(modalOpen\) return 'modal'/.test(visualGovernorRuntimeBlock),
+  'hidden, idle-capped, initial, Atelier, Growth Replay, and modal frames cannot contaminate sustained evidence');
+ok(/const _idleCapped=_idle && !repositoryAtelierActive\(\)[\s\S]*?if\(_idleCapped && _now-lastFrame<33\) return/.test(HTML)
+  && /_visualGovernorTick\(_now,_idleCapped\);\s*if\(_repositoryAtelierFrame\(dt\)\) return/.test(HTML)
+  && /const ambientDue=_visualGovernorAmbientDue\(dt\)/.test(HTML)
+  && /updateResidents\(dt\)/.test(HTML)
+  && /updateFireworks\(dt\)/.test(HTML)
+  && /updateStarTrail\(clock\.elapsedTime\)/.test(HTML)
+  && /updateLanternWatch\(clock\.elapsedTime\)/.test(HTML),
+  'governor samples every rendered exterior frame while resident, ride, route, and triggered effects keep their own cadence');
+ok(/SKY_POINT_LAYERS/.test(visualGovernorRuntimeBlock)
+  && /fountain\.geom\.setDrawRange/.test(visualGovernorRuntimeBlock)
+  && /fireflies\[i\]\.visible=i<runtime\.fireflyCount/.test(visualGovernorRuntimeBlock)
+  && /entry\.shadowProxy\.castShadow=active/.test(visualGovernorRuntimeBlock)
+  && /VISUAL_GOVERNOR_RUNTIME\.policy\.lodBias/.test(HTML),
+  'each tier reversibly reduces distant shadow proxies, particle draw ranges, decorative updates, and far LOD');
+ok(!/(?:fetch|XMLHttpRequest|WebSocket|sendBeacon|localStorage|sessionStorage|indexedDB|track)\s*\(/.test(visualGovernorCoreBlock + visualGovernorRuntimeBlock)
+  && !/visual-governor\.js/.test(HTML),
+  'governor adds no request, telemetry, analytics, persistence, backend, or runtime module load');
+ok(!/(?:endTour|endDrive|_endSharedJoy|exitRepositoryAtelier|_restoreRepositoryAtelier|closeWorldTreeChronicle)\s*\(/.test(visualGovernorRuntimeBlock)
+  && /continuity:\{residents:RESIDENTS_LIVE\.length,tour:!!\(tour&&tour\.active\),taxi:ride&&ride\.phase/.test(visualGovernorRuntimeBlock)
+  && /worldTreeChronicle:WORLD_TREE_UI\.open,modal:modalOpen,cameraOwner:_cameraOwnerAtFrameStart\(\)/.test(visualGovernorRuntimeBlock),
+  'tier application observes but never restarts residents, tours, taxi, Atelier, Growth Replay, Chronicle, modal, or camera ownership');
+ok(/window\.__visualGovernor=\(command\)=>_debugVisualGovernor\(command\)/.test(HTML)
+  && /Array\.isArray\(command\.sequence\)/.test(visualGovernorRuntimeBlock)
+  && /command\.fixture/.test(visualGovernorRuntimeBlock),
+  '?dbg exposes local force, deterministic fixture, replay, work-count, and continuity evidence');
+
 group('one colossal deterministic World Tree Pillar supports the village');
 const memorialTreeBlock = (HTML.match(/\/\*MEMORIAL_TREE:START\*\/([\s\S]*?)\/\*MEMORIAL_TREE:END\*\//) || [, ''])[1];
 const worldTreeChronicleBlock = (HTML.match(/\/\*WORLD_TREE_CHRONICLE:START\*\/([\s\S]*?)\/\*WORLD_TREE_CHRONICLE:END\*\//) || [, ''])[1];
@@ -3539,7 +3591,8 @@ ok(/function _withBuildingLodPrivateRandom\(fn\)/.test(buildingLodPrototypeBlock
   && /proxy-memory-budget-exceeded/.test(buildingLodPrototypeBlock), '2C-A constructors consume private RNG and enforce a five-megabyte proxy budget for full 100-repository towns');
 ok(/fullEnter:280,fullLeave:240,midEnter:\(LOW_END\|\|IS_MOBILE\)\?60:48,midLeave:\(LOW_END\|\|IS_MOBILE\)\?48:36,settle:3,cadence:8,minDwellFrames:24/.test(buildingLodPrototypeBlock)
   && /detailScale:\(LOW_END\|\|IS_MOBILE\)\?1:\(repo\._lodSpec\.tier>=4\?\.82:repo\._lodSpec\.tier===3\?\.92:1\)/.test(buildingLodPrototypeBlock)
-  && /const fullEnter=th\.fullEnter\*entry\.detailScale,fullLeave=th\.fullLeave\*entry\.detailScale/.test(buildingLodPrototypeBlock)
+  && /const bias=VISUAL_GOVERNOR_RUNTIME\.policy\.lodBias,fullEnter=th\.fullEnter\*entry\.detailScale\*bias,fullLeave=th\.fullLeave\*entry\.detailScale\*bias/.test(buildingLodPrototypeBlock)
+  && /midEnter=th\.midEnter\*bias,midLeave=th\.midLeave\*bias/.test(buildingLodPrototypeBlock)
   && /entry\.pendingCount>=BUILDING_LOD_PROTO\.thresholds\.settle/.test(buildingLodUpdateBlock)
   && !/(?:traverse|Box3|new THREE|sort\()/.test(buildingLodUpdateBlock), 'desktop grand homes retain detail longer while LOW_END and the allocation-free hysteresis path stay bounded');
 ok(/const functional=new THREE\.Group\(\),full=new THREE\.Group\(\),mid=new THREE\.Group\(\),far=new THREE\.Group\(\),active=new THREE\.Group\(\)/.test(buildingLodPrototypeBlock)
@@ -3694,11 +3747,12 @@ ok(/const distance=camera\.position\.distanceTo\(MEMORIAL_TREE\.glowWorld\),far=
   'distance is diagnostic only; branch/leaf/glyph bloom luminance stays constant near and far');
 ok(/MEM_TREE_BLOOM_HZ=LOW_END\?20:30, MEM_TREE_DESKTOP_BLOOM_MIN_FRAME_GAP=3/.test(HTML)
   && /const _treeBloomMinFrameGap=\(\)=>_desktopFrameDropGuard\(\)\?MEM_TREE_DESKTOP_BLOOM_MIN_FRAME_GAP:0/.test(HTML)
+  && /const _treeBloomHz=\(\)=>Math\.max\(1,Math\.min\(MEM_TREE_BLOOM_HZ,Math\.round\(MEM_TREE_BLOOM_HZ\*VISUAL_GOVERNOR_RUNTIME\.policy\.bloomHzScale\)\)\)/.test(HTML)
   && /bloomFrameGap=_treeBloomMinFrameGap\(\)/.test(HTML)
-  && /\(!bloomFrameGap\|\|renderedFrame-MEMORIAL_TREE\.lastBloomFrame>=bloomFrameGap\)&&now-MEMORIAL_TREE\.lastBloomAt>=1000\/MEM_TREE_BLOOM_HZ/.test(HTML)
+  && /\(!bloomFrameGap\|\|renderedFrame-MEMORIAL_TREE\.lastBloomFrame>=bloomFrameGap\)&&now-MEMORIAL_TREE\.lastBloomAt>=1000\/_treeBloomHz\(\)/.test(HTML)
   && /lastBloomAt:-Infinity,lastBloomFrame:-Infinity,bloomDirty:true/.test(memorialTreeBlock)
   && /MEMORIAL_TREE\.lastBloomFrame=renderedFrame/.test(HTML),
-  'the glow cache keeps its 20–30Hz ceiling, adds a slow-frame guard only on fine-pointer desktop, and keeps mobile time-driven');
+  'the glow cache keeps its 20–30Hz ceiling and follows the reversible decorative cadence without changing emission');
 ok(/pulse=REDUCED\?1:\(0\.93\+Math\.sin\(elapsed\*1\.5\)\*0\.07\)/.test(memorialTreeBlock),
   'reduced-motion keeps the additive world-tree halos steady');
 ok(/geometry\.translate\(0, -REPOLIS_LEAF_ATTACHMENT\.rootLocalY, 0\)/.test(WORLD_TREE_FACTORY)
@@ -3777,8 +3831,8 @@ ok(/function disableDynamicShadowCasters\(root\)\{ root\.traverse\(o=>\{ if\(o\.
   && /disableDynamicShadowCasters\(taxi\)/.test(HTML) && /disableDynamicShadowCasters\(model\)/.test(HTML)
   && /disableDynamicShadowCasters\(g\); scene\.add\(g\)/.test(HTML)
   && /return disableDynamicShadowCasters\(g\)/.test(HTML), 'moving avatars, NPCs, pets, and rides use blob/contact shadows while gently swaying town trees retain their frozen static shadows');
-ok(/AURORA_OP\.value=Math\.min\(0\.55\+\(_auroraBoost>0\?0\.45:0\), AURORA_OP\.value\+dt\*0\.5\)/.test(HTML),
-  'Aurora keeps the 1.77.2 night intensity; performance work does not dim the global night art');
+ok(/AURORA_OP\.value=Math\.min\(0\.55\+\(_auroraBoost>0\?0\.45:0\), AURORA_OP\.value\+ambientDt\*0\.5\)/.test(HTML),
+  'Aurora keeps the 1.77.2 night intensity while only its update frequency changes');
 ok(/pointLightRole:'runtime-topology-only'/.test(memorialTreeBlock)
   && /haloMode:'world-space-constant-emission'/.test(memorialTreeBlock)
   && /branchGlow:'base-emissive-only'/.test(memorialTreeBlock)

--- a/scripts/test-visual-governor.mjs
+++ b/scripts/test-visual-governor.mjs
@@ -1,0 +1,179 @@
+import { readFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { runInNewContext } from 'vm';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const HTML = readFileSync(join(ROOT, 'index.html'), 'utf8');
+const CORE = (HTML.match(/\/\*VISUAL_GOVERNOR_CORE:START\*\/([\s\S]*?)\/\*VISUAL_GOVERNOR_CORE:END\*\//) || [, ''])[1];
+
+function loadCore() {
+  if (!CORE) throw new Error('visual governor core markers are missing');
+  const context = {};
+  runInNewContext(`${CORE}
+globalThis.__api = {
+  VISUAL_GOVERNOR_TIER_NAMES,
+  VISUAL_GOVERNOR_CONFIG,
+  createVisualGovernorState,
+  stepVisualGovernor,
+  forceVisualGovernorTier,
+  visualGovernorDecorativeStride,
+  visualGovernorStateSnapshot,
+  replayVisualGovernor
+};`, context);
+  return context.__api;
+}
+
+function drive(api, state, frameMs, durationMs, eligible = true, reason = 'fixture') {
+  const transitions = [];
+  for (let elapsed = 0; elapsed < durationMs; elapsed += frameMs) {
+    const transition = api.stepVisualGovernor(state, frameMs, eligible, reason);
+    if (transition) transitions.push({ ...transition });
+  }
+  return transitions;
+}
+
+function lowSequence() {
+  const sequence = [];
+  for (let elapsed = 0; elapsed < 6200; elapsed += 16.67) sequence.push(16.67);
+  for (let elapsed = 0; elapsed < 18000; elapsed += 34) sequence.push(34);
+  return sequence;
+}
+
+export function runVisualGovernorTests(check) {
+  const api = loadCore();
+
+  {
+    const { tiers, policies } = api.VISUAL_GOVERNOR_CONFIG;
+    check(api.VISUAL_GOVERNOR_TIER_NAMES.join(',') === 'full,balanced,lean'
+      && tiers.length === 3
+      && tiers[1].upFrameMs < tiers[0].downFrameMs
+      && tiers[2].upFrameMs < tiers[1].downFrameMs
+      && policies[0].shadowRadius === null
+      && policies[1].lodBias === 1
+      && policies[2].lodBias > 1
+      && policies[0].particleScale > policies[1].particleScale
+      && policies[1].particleScale > policies[2].particleScale,
+    'visual governor has three reversible tiers, separated hysteresis, and defers far-detail bias until lean');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 34, 5900);
+    check(state.tier === 0 && state.transitionCount === 0
+      && api.visualGovernorStateSnapshot(state).warmup.complete === false,
+    'bounded warm-up observes frames without degrading quality');
+  }
+
+  {
+    const result = api.replayVisualGovernor(lowSequence());
+    check(result.state.tier === 'lean'
+      && result.transitions.map(item => `${item.from}>${item.to}`).join(',') === 'full>balanced,balanced>lean',
+    'a sustained deterministic low-frame fixture steps down one tier at a time');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    api.stepVisualGovernor(state, 80, true, 'transient-spike');
+    drive(api, state, 16.67, 9000);
+    check(state.tier === 0 && state.transitionCount === 0 && state.emaMs < state.config.tiers[0].downFrameMs,
+    'one transient frame spike is smoothed and cannot trigger a downgrade');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    const down = drive(api, state, 26, 7000);
+    drive(api, state, 20, 30000);
+    check(down.length === 1 && state.tier === 1 && state.transitionCount === 1,
+    'neutral frames inside the hysteresis band neither recover nor degrade');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    const first = drive(api, state, 26, 7000);
+    const tierAfterFirst = state.tier;
+    drive(api, state, 34, 5000);
+    check(first.length === 1 && tierAfterFirst === 1 && state.tier === 1
+      && state.activeMs < state.dwellUntilMs,
+    'minimum dwell blocks an immediate second downgrade even with continuing slow frames');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    drive(api, state, 34, 19000);
+    const before = state.transitionCount;
+    const firstRecovery = drive(api, state, 16.2, 19500);
+    const afterFirst = state.tier;
+    const secondRecovery = drive(api, state, 16.2, 25000);
+    check(afterFirst === 1
+      && firstRecovery.map(item => item.to).join(',') === 'balanced'
+      && secondRecovery.map(item => item.to).join(',') === 'full'
+      && state.transitionCount === before + 2,
+    'stable frames recover exactly one tier per sustained evidence and dwell interval');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    drive(api, state, 30, 2500);
+    const activeBefore = state.activeMs;
+    api.stepVisualGovernor(state, 5000, false, 'hidden');
+    drive(api, state, 30, 2500);
+    check(state.activeMs > activeBefore && state.activeMs < activeBefore + 2600
+      && state.tier === 0 && state.lastPauseReason === 'hidden',
+    'a hidden-page pause advances no active time and clears partial slow evidence');
+  }
+
+  {
+    const lowEnd = api.createVisualGovernorState({ lowEnd: true });
+    api.forceVisualGovernorTier(lowEnd, 'full');
+    const reduced = api.createVisualGovernorState({ reducedMotion: true });
+    api.forceVisualGovernorTier(reduced, 'lean');
+    api.forceVisualGovernorTier(reduced, 'full');
+    check(lowEnd.floor === 1 && lowEnd.tier === 1
+      && api.visualGovernorStateSnapshot(lowEnd).qualityCeiling === 'balanced'
+      && api.visualGovernorDecorativeStride(reduced) === 0,
+    'LOW_END clamps the quality ceiling and reduced motion cannot be re-enabled by recovery or debug force');
+  }
+
+  {
+    const sequence = lowSequence();
+    for (let elapsed = 0; elapsed < 42000; elapsed += 16.2) sequence.push(16.2);
+    const first = api.replayVisualGovernor(sequence);
+    const second = api.replayVisualGovernor(sequence);
+    check(JSON.stringify(first) === JSON.stringify(second)
+      && first.transitions.map(item => `${item.from}>${item.to}`).join(',')
+        === 'full>balanced,balanced>lean,lean>balanced,balanced>full',
+    'deterministic replay produces byte-stable transitions through degradation and recovery');
+  }
+
+  {
+    const state = api.createVisualGovernorState();
+    drive(api, state, 16.67, 6200);
+    drive(api, state, 34, 19000);
+    drive(api, state, 16.2, 45000);
+    const transitions = state.transitionCount;
+    drive(api, state, 20, 30000);
+    check(state.tier === 0 && state.transitionCount === transitions,
+    'stable recovery stays full without threshold flicker');
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  let passed = 0;
+  const failures = [];
+  runVisualGovernorTests((condition, message) => {
+    if (condition) passed++;
+    else failures.push(message);
+  });
+  if (failures.length) {
+    failures.forEach(message => console.error(`  x ${message}`));
+    process.exitCode = 1;
+  } else {
+    console.log(`VISUAL GOVERNOR GREEN - ${passed} deterministic checks passed`);
+  }
+}


### PR DESCRIPTION
## Summary

- add a three-tier `full` / `balanced` / `lean` adaptive visual governor after 6 seconds of eligible warm-up
- use separate downgrade/recovery thresholds, sustained evidence, minimum dwell, and hysteresis so quality changes one step at a time
- reduce distant shadow proxies, particle draw ranges, decorative cadence, and World Tree bloom before lean biases existing far-building LOD
- preserve nearby repository detail/signs/silhouettes, collisions, interaction roots, camera/control, and every gameplay state machine

## Transition contract

| Tier | Downgrade | Recovery | Ambient policy |
|---|---|---|---|
| full | EMA ≥ 22.5 ms for 3 s | — | all shadows/particles, stride 1, bloom ceiling 30 Hz |
| balanced | EMA ≥ 28.5 ms for 5 s | EMA ≤ 17.5 ms for 14 s | 150-unit shadows, 68% particles, stride 2, bloom ceiling 20 Hz |
| lean | — | EMA ≤ 18.5 ms for 18 s | 95-unit shadows, 42% particles, stride 4, bloom ceiling 12 Hz, far LOD bias 1.38 |

- minimum dwell after entering full/balanced/lean: 7/10/14 seconds of eligible active time
- hidden, intentional idle-cap, intro, modal, Atelier, and Growth Replay frames reset partial evidence and advance no active time
- LOW_END starts at and recovers only to balanced; reduced motion keeps decorative stride at zero at every tier

## State and privacy contract

- tier application changes only existing shadow flags, point draw ranges, ambient cadence, and LOD thresholds
- resident/home/work/social state, tours, taxi ride ID/phase, Atelier snapshot/layers, Growth Replay index, Chronicle/modal state, and camera ownership remain continuous across forced transitions
- `window.__visualGovernor()` exists only under `?dbg`/`?perf` and provides in-memory force/auto, deterministic fixtures/replay, work counts, and continuity state
- no new runtime API/GitHub request, Worker, storage, analytics, telemetry, persistent identity, model call, dependency, build step, asset, or generated JSON edit

## Verification

- Council: 130 deterministic checks; 56 live crosschecks
- city smoke: 1,336 checks
- governor fixtures: 11 checks covering warm-up, sustained low frames, transient spike, hysteresis, dwell, one-step recovery, hidden pause, LOW_END/reduced bounds, deterministic replay, and no flicker
- Portable Living Towns: 11 checks; city state, schema, fork-lineage, city-time, session-footprints, lore, and all syntax guards green
- Chrome desktop 1440×900 and mobile 390×844 DPR3: KO/EN, day/night, full/balanced/lean, LOW_END, native reduced-motion media, owner/`octocat`, nonblank WebGL, no horizontal overflow, and zero console errors
- continuity exercised while resident commute and ambient gathering, guided tour, taxi ride, repo modal, World Tree Chronicle, Atelier, and Growth Replay were active
- nearby `Repolis` stayed full at lean (`1,062 px` projected) with exact mid/far sign and emblem textures; portable residents kept deterministic repo work bindings and continued moving

## Measured budget

| Owner night | full | balanced | lean |
|---|---:|---:|---:|
| building shadow proxies | 69 | 46 | 23 |
| active particle points/sprites | 3,473 | 2,363 | 1,459 |
| bloom ceiling | 30 Hz | 20 Hz | 12 Hz |
| draw calls | 2,481.67 | 2,465.83 | 2,417.33 |
| triangles | 669,179 | 668,246 | 646,414 |

| Cold load | Before | After | Delta |
|---|---:|---:|---:|
| owner same-origin requests | 31 | 31 | 0 |
| foreign same-origin requests | 27 | 27 | 0 |
| owner decoded bytes | 1,726,282 | 1,740,107 | +13,825 |
| foreign decoded bytes | 1,629,433 | 1,643,258 | +13,825 |
| foreign public GitHub reads | 1 | 1 | 0 |

The retained QA artifact is under 200 KiB. Temporary browser profiles and logs were removed.

Closes #96

## Visual evidence

**390×844 DPR3 · native reduced motion · LOW_END · lean**

![Nearby owner-town frame at the lean tier with mobile controls and readable house identity](https://github.com/user-attachments/assets/0ee940e7-a396-4ab2-8fd1-59b3c76ec91d)
