### PR TITLE
feat: add Intent Lens wayfinding

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,17 @@
   #panel.hidden { opacity: 0; transform: scale(.94); pointer-events: none; }
   #panel h3 { font-size: 12px; letter-spacing: .04em; text-transform: uppercase; color: #b08a5e;
     padding: 4px 8px 10px; }
+  #intentLens { margin: 0 0 10px; padding: 8px; border: 1px solid #e7d5b7; border-radius: 13px;
+    background: linear-gradient(145deg,rgba(255,253,247,.96),rgba(246,235,216,.9)); }
+  #intentLensTitle { padding: 0 2px 7px; color: #876845; font-size: 10.5px; font-weight: 800; letter-spacing: .02em; }
+  .intentLensChoices { display: flex; flex-direction: column; gap: 5px; }
+  .intentLensChoice { width: 100%; min-height: 40px; display: flex; align-items: center; gap: 9px; padding: 7px 10px;
+    border: 1px solid #e1cfb2; border-radius: 10px; background: #fffdf8; color: #4a3522;
+    font: 800 11.5px/1.25 inherit; text-align: left; cursor: pointer; }
+  .intentLensChoice:hover { border-color: #c99d66; background: #fff8eb; }
+  .intentLensChoice:focus-visible { outline: 3px solid rgba(217,143,46,.34); outline-offset: 1px; }
+  .intentLensChoice:active { transform: translateY(1px); }
+  .intentLensIcon { flex: 0 0 23px; font-size: 16px; line-height: 1; text-align: center; }
   #tourReplayBtn, #postcardMenuBtn, #twinMenuBtn, #creatorMenuBtn, #growthMenuBtn, #repoRouteMenuBtn, #questMenuBtn { width: 100%; min-height: 48px; margin: 0 0 9px; padding: 8px 10px; border: 1px solid #dfc9a6;
     border-radius: 12px; background: linear-gradient(135deg,#fffaf0,#f3e3ca); color: #5a3b24; cursor: pointer;
     display: flex; align-items: center; gap: 10px; text-align: left; font: inherit; }
@@ -1285,6 +1296,7 @@
   /* ---- mobile tap-target a11y (Phase 36) — placed last so it overrides base rules ---- */
   @media (hover: none) and (pointer: coarse) {
     #langBtn, #dayBtn, #passBtn { min-height: 44px; display: inline-flex; align-items: center; }
+    .intentLensChoice { min-height: 44px; }
     .chatHead .x { width: 44px; height: 44px; font-size: 24px; margin-right: -6px; }
     .chatIn input, #repoSearch { font-size: 16px; }
     #station #stationInput { font-size: 16px; }
@@ -1485,6 +1497,14 @@
 
 <div id="panel" class="hidden">
   <h3>Repolis · <span data-i18n="wayfinding">길찾기</span></h3>
+  <section id="intentLens" aria-labelledby="intentLensTitle">
+    <div id="intentLensTitle" data-i18n="intentLensTitle">무엇을 하러 왔나요?</div>
+    <div class="intentLensChoices">
+      <button class="intentLensChoice" type="button" data-intent="understand"><span class="intentLensIcon" aria-hidden="true">⌕</span><span data-i18n="intentUnderstand">레포 하나 이해하기</span></button>
+      <button class="intentLensChoice" type="button" data-intent="explore"><span class="intentLensIcon" aria-hidden="true">🗺️</span><span data-i18n="intentExplore">이 개발자의 도시 둘러보기</span></button>
+      <button class="intentLensChoice" type="button" data-intent="contribute"><span class="intentLensIcon" aria-hidden="true">🧩</span><span data-i18n="intentContribute">기여할 일 찾기</span></button>
+    </div>
+  </section>
   <button id="tourReplayBtn" type="button">
     <span class="pmIcon" aria-hidden="true">🎬</span>
     <span class="pmCopy"><span class="pmTitle" data-i18n="tourReplay">가이드 투어 다시 보기</span><span class="pmSub" data-i18n="tourReplaySub">세계수 · 주민 · 레포 집 · 기존 명소</span></span>
@@ -2548,6 +2568,8 @@ const I18N = {
     modeOwnerLabel:'풀 트래픽 시티', modePublicLabel:'공개 GitHub 마을', modePortalLabel:'레포 포털',
     townOf:'{user} 님의 마을', repoPortalOf:'{repo} 포털', myCity:'내 도시',
     stationBtn:'🚉 역', stationLm:'GitHub 역',
+    intentLensTitle:'무엇을 하러 왔나요?', intentUnderstand:'레포 하나 이해하기',
+    intentExplore:'이 개발자의 도시 둘러보기', intentContribute:'기여할 일 찾기',
     stationTitle:'Repolis 역 · 어디로 갈까요?', stationSub:'username은 공개 레포 마을로, owner/repo나 GitHub URL은 그 레포 전시실로 곧장 연결해요.',
     stationDistrictsH:'🚉 명소로 바로 이동', stationExternalH:'🌍 GitHub 사용자 또는 레포',
     stationCurrent:'현재 마을', stationUserPh:'username · owner/repo · GitHub URL', stationGo:'🚆 이동',
@@ -2915,6 +2937,8 @@ const I18N = {
     modeOwnerLabel:'Full Traffic City', modePublicLabel:'Public GitHub Town', modePortalLabel:'Repo Portal',
     townOf:"{user}'s town", repoPortalOf:'{repo} portal', myCity:'My city',
     stationBtn:'🚉 Station', stationLm:'GitHub Station',
+    intentLensTitle:'What brings you here?', intentUnderstand:'Understand a repository',
+    intentExplore:"Explore this developer's town", intentContribute:'Find something to contribute',
     stationTitle:'Repolis Station · Where to?', stationSub:"A username opens that developer's public town. owner/repo or a GitHub URL goes straight to the repo exhibition.",
     stationDistrictsH:'🚉 Landmark stops', stationExternalH:'🌍 GitHub user or repository',
     stationCurrent:'Current town', stationUserPh:'username · owner/repo · GitHub URL', stationGo:'🚆 Go',
@@ -12103,6 +12127,28 @@ if(mapCanvas) mapCanvas.onclick=(e)=>{ const r=mapCanvas.getBoundingClientRect()
   if(hit) gotoZone(hit.id); };
 _mapReady=true; syncMapChrome();                                     // initialise the map-button label now that the DOM refs exist
 
+/*INTENT_LENS:START*/
+function intentLensTargetRepo(){
+  if(cityMode!=='portal'||!repoPortalTarget) return null;
+  const repo=repoByKey(repoPortalTarget.repo),target=repo&&_repositoryPortalTarget(repo);
+  return target&&target.slug.toLowerCase()===repoPortalTarget.slug.toLowerCase()?repo:null;
+}
+function closeIntentLensWayfinding(){ panel.classList.add('hidden'); menuBtn.setAttribute('aria-expanded','false'); }
+function dispatchIntentLens(intent){
+  if(intent==='understand'){
+    const repo=intentLensTargetRepo();
+    if(!repo){ openStationModal(); return true; }
+    const entered=enterRepositoryAtelier(repo,{autoChat:false}); if(entered) closeIntentLensWayfinding(); return entered;
+  }
+  if(intent==='explore'){ closeIntentLensWayfinding(); openMap(); return true; }
+  if(intent==='contribute') return openContributionQuestBoard('menu');
+  return false;
+}
+document.querySelectorAll('#intentLens [data-intent]').forEach(button=>{
+  button.addEventListener('click',()=>dispatchIntentLens(button.dataset.intent));
+});
+/*INTENT_LENS:END*/
+
 /* ---- 🎡 Ferris wheel ride: board the gondola at the bottom, rise for one slow free-look turn, then step back onto the ground ---- */
 function updateFerris(dt){ if(!FERRIS) return;
   const spin = ferris ? 0.42 : 0.16;                                      // a touch livelier while you're aboard
@@ -13044,12 +13090,14 @@ function _resetRepositoryAtelierInput(){
   dragging=false; dragMoved=false; dom.style.cursor=''; document.body.style.cursor='';
   if(document.activeElement&&document.activeElement.blur) document.activeElement.blur();
 }
-function enterRepositoryAtelier(repo){
+function enterRepositoryAtelier(repo,options={}){
   if(!repo||repo._isLibrary||repositoryAtelierActive()) return false;
   if(busy){ showWave(t('atelierChatWait'),2600); return false; }
   const target=_repositoryPortalTarget(repo); if(!target) return false;
   const A=REPOSITORY_ATELIER||{state:'outside',created:false,resources:{geometries:new Set(),materials:new Set(),textures:new Set()},dummy:new THREE.Object3D()};
-  REPOSITORY_ATELIER=A; _snapshotRepositoryAtelier(repo); A.repo=repo; A.chat=createRepositoryAtelierChatVisit(target.slug); A.outsideChat=null;
+  REPOSITORY_ATELIER=A; _snapshotRepositoryAtelier(repo); A.repo=repo; A.chat=createRepositoryAtelierChatVisit(target.slug);
+  if(options.autoChat===false) A.chat.autoStarted=true;
+  A.outsideChat=null;
   A.pendingExit=false; A.pendingHash=false; A.afterExit=null; A.state='entering'; A.phase='cover'; A.t=0; A.renderInterior=false;
   _resetRepositoryAtelierInput(); atelierFade.classList.add('blocking'); atelierFade.style.opacity='0';
   return true;

--- a/index.html
+++ b/index.html
@@ -62,6 +62,10 @@
   .intentLensChoice:focus-visible { outline: 3px solid rgba(217,143,46,.34); outline-offset: 1px; }
   .intentLensChoice:active { transform: translateY(1px); }
   .intentLensIcon { flex: 0 0 23px; font-size: 16px; line-height: 1; text-align: center; }
+  @media (max-width: 520px) {
+    #intentLens { margin-top: 48px; }
+    #panel:not(.hidden) ~ #chat { visibility: hidden; opacity: 0; pointer-events: none; }
+  }
   #tourReplayBtn, #postcardMenuBtn, #twinMenuBtn, #creatorMenuBtn, #growthMenuBtn, #repoRouteMenuBtn, #questMenuBtn { width: 100%; min-height: 48px; margin: 0 0 9px; padding: 8px 10px; border: 1px solid #dfc9a6;
     border-radius: 12px; background: linear-gradient(135deg,#fffaf0,#f3e3ca); color: #5a3b24; cursor: pointer;
     display: flex; align-items: center; gap: 10px; text-align: left; font: inherit; }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -850,8 +850,9 @@ ok(!/fetch\(|loadContributionQuests|_sendRepositoryAtelierChat|localStorage|sess
   'Intent Lens itself adds no request, model call, resource, timer, storage, profiling, or analytics work');
 ok(/querySelectorAll\('#intentLens \[data-intent\]'\)[\s\S]*?addEventListener\('click'/.test(intentLensSrc)
   &&/\.intentLensChoice \{[^}]*min-height: 40px/.test(HTML)
+  &&/@media \(max-width: 520px\) \{[\s\S]*?#intentLens \{ margin-top: 48px; \}[\s\S]*?#panel:not\(\.hidden\) ~ #chat \{ visibility: hidden; opacity: 0; pointer-events: none; \}/.test(HTML)
   &&/@media \(hover: none\) and \(pointer: coarse\) \{[\s\S]*?\.intentLensChoice \{ min-height: 44px; \}/.test(HTML),
-  'native click activation covers keyboard, touch, and pointer with desktop and coarse-pointer targets');
+  'native activation covers keyboard, touch, and pointer while mobile HUD and chat stay clear');
 if(intentTargetSrc){
   const portalTarget={owner:'Octo-Cat',repo:'hello-world',slug:'Octo-Cat/hello-world'};
   const repo={repo:'hello-world',_owner:'Octo-Cat'};

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -829,6 +829,40 @@ ok(/## 11\. Repo Portal/.test(DOMAIN_MODEL)&&/Public API modes do not have traff
   &&/Repo Portal: `\?repo=owner\/repo/.test(LLMS_INDEX)&&/\[1\.87\.0\]/.test(CHANGELOG),
   'domain, limitations, agent guide, manifest, LLM index, and changelog stay in sync');
 
+group('Intent Lens — three goals reuse existing navigation');
+const intentLensSrc=(HTML.match(/\/\*INTENT_LENS:START\*\/([\s\S]*?)\/\*INTENT_LENS:END\*\//)||[,''])[1];
+const intentTargetSrc=(intentLensSrc.match(/function intentLensTargetRepo\(\)\{[\s\S]*?\n\}/)||[''])[0];
+ok(intentLensSrc.length>0&&intentTargetSrc.length>0, 'Intent Lens runtime is a small extractable integration block');
+ok((HTML.match(/class="intentLensChoice" type="button" data-intent="/g)||[]).length===3
+  &&HTML.indexOf('id="intentLens"')<HTML.indexOf('id="tourReplayBtn"'),
+  'three native intent buttons lead the existing Wayfinding surface without hiding its controls');
+[
+  ['intentUnderstand','레포 하나 이해하기','Understand a repository'],
+  ['intentExplore','이 개발자의 도시 둘러보기',"Explore this developer's town"],
+  ['intentContribute','기여할 일 찾기','Find something to contribute']
+].forEach(([key,ko,en])=>ok((HTML.match(new RegExp(key+":[\\\"']",'g'))||[]).length===2&&HTML.includes(ko)&&HTML.includes(en),
+  `Intent Lens key ${key} is bilingual and concise`));
+ok(/intent==='understand'[\s\S]*?intentLensTargetRepo\(\)[\s\S]*?openStationModal\(\)[\s\S]*?enterRepositoryAtelier\(repo,\{autoChat:false\}\)/.test(intentLensSrc)
+  &&/intent==='explore'[\s\S]*?openMap\(\)/.test(intentLensSrc)
+  &&/intent==='contribute'[\s\S]*?openContributionQuestBoard\('menu'\)/.test(intentLensSrc),
+  'each intent dispatches only to the existing Portal/Atelier, World Map, or Quests flow');
+ok(!/fetch\(|loadContributionQuests|_sendRepositoryAtelierChat|localStorage|sessionStorage|indexedDB|new THREE|setTimeout|setInterval|requestAnimationFrame|track\(/.test(intentLensSrc),
+  'Intent Lens itself adds no request, model call, resource, timer, storage, profiling, or analytics work');
+ok(/querySelectorAll\('#intentLens \[data-intent\]'\)[\s\S]*?addEventListener\('click'/.test(intentLensSrc)
+  &&/\.intentLensChoice \{[^}]*min-height: 40px/.test(HTML)
+  &&/@media \(hover: none\) and \(pointer: coarse\) \{[\s\S]*?\.intentLensChoice \{ min-height: 44px; \}/.test(HTML),
+  'native click activation covers keyboard, touch, and pointer with desktop and coarse-pointer targets');
+if(intentTargetSrc){
+  const portalTarget={owner:'Octo-Cat',repo:'hello-world',slug:'Octo-Cat/hello-world'};
+  const repo={repo:'hello-world',_owner:'Octo-Cat'};
+  const resolve=(mode,target,found,resolved)=>new Function('cityMode','repoPortalTarget','repoByKey','_repositoryPortalTarget',
+    `${intentTargetSrc}\nreturn intentLensTargetRepo();`)(mode,target,()=>found,()=>resolved);
+  ok(resolve('portal',portalTarget,repo,portalTarget)===repo
+    &&resolve('portal',portalTarget,repo,{...portalTarget,owner:'Other',slug:'Other/hello-world'})===null
+    &&resolve('owner',portalTarget,repo,portalTarget)===null,
+    'target handoff requires the same exact owner/repo while untargeted towns never guess a repository');
+}
+
 group('Twin Towns — recipient-specific, reversible public-town referrals');
 const twinLeft = [
   { repo:'agent-harbor', lang:'JavaScript', topics:['agents','threejs'], stars:12, forks:2 },
@@ -2126,7 +2160,7 @@ ok(/validateRepositoryBlueprintTarget\(\{[\s\S]*?repoName:parsed&&parsed\.slug[\
   'Blueprint pins the current exact owner/repo, known default branch, and exact GitHub path');
 ok(/atelierBlueprintScan\.addEventListener\('click'[\s\S]*?_scanRepositoryBlueprint\(\)/.test(atelierSrc)
   &&!/scanRepositoryBlueprint\(/.test(blueprintOpenSrc)
-  &&!/scanRepositoryBlueprint\(/.test((atelierSrc.match(/function enterRepositoryAtelier\(repo\)\{[\s\S]*?(?=\nfunction _activateRepositoryAtelier)/)||[''])[0])
+  &&!/scanRepositoryBlueprint\(/.test((atelierSrc.match(/function enterRepositoryAtelier\(repo,options=\{\}\)\{[\s\S]*?(?=\nfunction _activateRepositoryAtelier)/)||[''])[0])
   &&/await scanRepositoryBlueprint\(B\.target,\{compact:B\.compact,signal:controller\.signal\}\)/.test(blueprintScanSrc)
   &&!/fetch\(/.test(blueprintSrc),
   'only the explicit Blueprint scan starts its single pure-module request; entry and panel reopen stay silent');
@@ -2182,12 +2216,14 @@ ok(/opts&&opts\.repo&&!repositoryAtelierActive\(\)/.test(HTML)
   &&/function startScholarHandoff\(kind\)\{ if\(repositoryAtelierActive\(\)\) return false/.test(HTML),
   'chat replies cannot start an exterior taxi ride or scholar handoff while the room owns interaction');
 ok(!/fetch\(|new WebSocket|groundedAsk|webllmAsk|proxyAsk|import\(/.test(atelierCreateSrc+atelierBindSrc), 'creating and rebinding the reusable room adds no model, CDN, or dynamic-import work');
-ok(/A\.chat=createRepositoryAtelierChatVisit\(target\.slug\)/.test(atelierSrc)
+ok(/function enterRepositoryAtelier\(repo,options=\{\}\)/.test(atelierSrc)
+  &&/A\.chat=createRepositoryAtelierChatVisit\(target\.slug\)/.test(atelierSrc)
+  &&/if\(options\.autoChat===false\) A\.chat\.autoStarted=true/.test(atelierSrc)
   && /_startRepositoryAtelierChatVisit\(\)/.test(atelierSrc)
   && /_sendRepositoryAtelierChat\(t\('atelierChatAuto'\),true\)/.test(atelierSrc)
   && /beginRepositoryAtelierChatCall\(visit\)/.test(atelierSrc)
   && /repositoryAtelierChatPayload\(visit,question,LANG\)/.test(atelierSrc),
-  'entry pins exact owner/repo memory, auto-explains at 1/5, and every started request uses the scoped payload');
+  'entry pins exact owner/repo memory, keeps default auto-explain, and supports an explicit request-free handoff');
 ok(/function _captureRepositoryAtelierChatThread\(\)/.test(atelierSrc)
   && /nodes:\[\.\.\.chatLog\.childNodes\]/.test(atelierSrc)
   && /function _restoreRepositoryAtelierChatThread\(\)/.test(atelierSrc)


### PR DESCRIPTION
## Summary
- add three compact KO/EN intent choices at the top of existing Wayfinding
- reuse the exact target Repo Portal/Atelier, World Map, and Open Source Quests flows without automatic requests
- keep untargeted repository intent on the existing Station input and preserve exact `owner/repo` for target links
- keep mobile intent controls clear of the HUD, tour, and preserved chat surface

## Verification
- [x] `node council/test.mjs`
- [x] `node council/test-live.mjs`
- [x] `node scripts/smoke.mjs`
- [x] `node --check scholars.js`
- [x] `node --check cloudflare-taxi/src/grounded.js`
- [x] Desktop and 390x844 mobile in KO/EN with keyboard, touch, and pointer
- [x] Zero console errors; tour, Passport, Station, World Map, Repo Portal, Atelier/Blueprint, and Open Source Quests checked locally

Closes #106
