### PR TITLE
Fix Repository Atelier MCP reference validation

### DIFF
--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -1925,7 +1925,11 @@ async function repositoryAtelierHandler(body, request, env, ctx) {
     }, 200, env);
   }
 
-  const scoped = projectRepositoryAtelierReferences(out.data?.references, authorized.repoName);
+  const scoped = projectRepositoryAtelierReferences(
+    out.data?.references,
+    authorized.repoName,
+    out.data?.activity,
+  );
   if (!scoped.exact || !out.answer || isNotFound(out.answer)) {
     emitGroundingOutcome(env, ctx, route, cfg, "taxi", {
       groundingPath: "grounded_via_kb",

--- a/cloudflare-taxi/src/repository-atelier.js
+++ b/cloudflare-taxi/src/repository-atelier.js
@@ -149,25 +149,67 @@ function fullNameFromUrl(value) {
   }
 }
 
-export function projectRepositoryAtelierReferences(references, repoName) {
+function fullNameFromRepository(value) {
+  const repo = object(value);
+  return String(repo?.full_name || fullNameFromUrl(repo?.html_url)).replace(/\.git$/i, '');
+}
+
+function repositoryActivityScopes(activities, repoName) {
+  const target = String(repoName || '').toLowerCase();
+  const scopes = new Map();
+  for (const activity of Array.isArray(activities) ? activities : []) {
+    if (!activity || activity.type !== 'mcpServer') continue;
+    const call = object(activity.mcpServerArguments);
+    const args = object(call?.toolArguments);
+    const owner = clean(args?.owner, 100);
+    const repo = clean(args?.repo, 100);
+    if (!owner || !repo) continue;
+    scopes.set(String(activity.id), {
+      exact: `${owner}/${repo}`.toLowerCase() === target,
+      tool: clean(call?.toolName, 100),
+    });
+  }
+  return scopes;
+}
+
+export function projectRepositoryAtelierReferences(references, repoName, activities = []) {
   const target = String(repoName || '').toLowerCase();
   const refs = [];
+  const seen = new Set();
+  const scopes = repositoryActivityScopes(activities, repoName);
   let rejected = 0;
   for (const reference of Array.isArray(references) ? references : []) {
-    const repo = referenceObject(reference);
-    const fullName = String(repo?.full_name || fullNameFromUrl(repo?.html_url)).replace(/\.git$/i, '');
-    if (!repo || fullName.toLowerCase() !== target) {
+    const source = referenceObject(reference);
+    const scope = scopes.get(String(reference?.activitySource));
+    if (reference?.toolName === 'get_file_contents'
+      && source?.type === 'file'
+      && scope?.tool === 'get_file_contents') {
+      if (!scope.exact) rejected += 1;
+      continue;
+    }
+
+    const repositories = Array.isArray(source?.items) ? source.items : [source];
+    if (!source || !repositories.length) {
       rejected += 1;
       continue;
     }
-    refs.push({
-      name: fullName,
-      url: repo.html_url || `https://github.com/${fullName}`,
-      snippet: clean(repo.description, 600),
-      stars: Number.isFinite(Number(repo.stargazers_count)) ? Number(repo.stargazers_count) : null,
-      lang: clean(repo.language, 50),
-      tool: reference.toolName || '',
-    });
+    for (const repo of repositories) {
+      const fullName = fullNameFromRepository(repo);
+      if (!fullName || fullName.toLowerCase() !== target) {
+        rejected += 1;
+        continue;
+      }
+      if (seen.has(fullName.toLowerCase())) continue;
+      seen.add(fullName.toLowerCase());
+      refs.push({
+        name: fullName,
+        url: repo.html_url || `https://github.com/${fullName}`,
+        snippet: clean(repo.description, 600),
+        stars: Number.isFinite(Number(repo.stargazers_count)) ? Number(repo.stargazers_count) : null,
+        lang: clean(repo.language, 50),
+        tool: reference.toolName || '',
+      });
+    }
   }
   return { refs, rejected, exact: refs.length > 0 && rejected === 0 };
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2443,7 +2443,7 @@ ok(/authorizeRepositoryAtelierRequest\(body\)/.test(atelierWorkerSrc)
   && /buildRepositoryAtelierMessages\(/.test(atelierWorkerSrc)
   && /repositoryAtelierKnowledgeSource\(base\.ks\)/.test(atelierWorkerSrc)
   && /failOnError: true/.test(atelierWorkerSrc)
-  && /projectRepositoryAtelierReferences\(out\.data\?\.references, authorized\.repoName\)/.test(atelierWorkerSrc),
+  && /projectRepositoryAtelierReferences\([\s\S]*?out\.data\?\.references,[\s\S]*?authorized\.repoName,[\s\S]*?out\.data\?\.activity,[\s\S]*?\)/.test(atelierWorkerSrc),
   'the Atelier Worker path validates owner/repo, queries one required GitHub MCP source, and rejects non-exact references');
 ok(/if \(out\.fallback\)/.test(atelierWorkerSrc)
   && /repositoryAtelierMessage\("unavailable"/.test(atelierWorkerSrc)

--- a/scripts/test-repository-atelier-chat.mjs
+++ b/scripts/test-repository-atelier-chat.mjs
@@ -32,6 +32,46 @@ function reference(fullName) {
   };
 }
 
+function searchReference(fullNames) {
+  return {
+    toolName: 'search_repositories',
+    activitySource: 1,
+    sourceData: {
+      content: JSON.stringify({
+        total_count: fullNames.length,
+        items: fullNames.map((fullName) => ({
+          full_name: fullName,
+          name: fullName.split('/')[1],
+          html_url: `https://github.com/${fullName}`,
+          description: `${fullName} description`,
+          stargazers_count: 11,
+        })),
+      }),
+    },
+  };
+}
+
+function fileReference(activitySource, path = 'README.md') {
+  return {
+    toolName: 'get_file_contents',
+    activitySource,
+    sourceData: {
+      content: JSON.stringify({ name: path, path, type: 'file' }),
+    },
+  };
+}
+
+function fileActivity(id, owner, repo) {
+  return {
+    type: 'mcpServer',
+    id,
+    mcpServerArguments: {
+      toolName: 'get_file_contents',
+      toolArguments: { owner, repo, path: '/', ref: 'main' },
+    },
+  };
+}
+
 export async function runRepositoryAtelierChatTests(check) {
   const previous = createRepositoryAtelierChatVisit('hyeonsangjeon/YoutubeDlNas');
   appendRepositoryAtelierChatTurn(previous, 'user', 'How does YoutubeDlNas work?');
@@ -105,13 +145,40 @@ export async function runRepositoryAtelierChatTests(check) {
     'hyeonsangjeon/Dataplatformfrm',
   );
   const missing = projectRepositoryAtelierReferences([], 'hyeonsangjeon/Dataplatformfrm');
+  const foundryExact = projectRepositoryAtelierReferences(
+    [
+      searchReference(['hyeonsangjeon/Dataplatformfrm']),
+      fileReference(3),
+    ],
+    'hyeonsangjeon/Dataplatformfrm',
+    [fileActivity(3, 'hyeonsangjeon', 'Dataplatformfrm')],
+  );
+  const forgedFileScope = projectRepositoryAtelierReferences(
+    [
+      searchReference(['hyeonsangjeon/Dataplatformfrm']),
+      fileReference(4),
+    ],
+    'hyeonsangjeon/Dataplatformfrm',
+    [fileActivity(4, 'hyeonsangjeon', 'YoutubeDlNas')],
+  );
+  const mixedSearch = projectRepositoryAtelierReferences(
+    [searchReference(['hyeonsangjeon/Dataplatformfrm', 'hyeonsangjeon/YoutubeDlNas'])],
+    'hyeonsangjeon/Dataplatformfrm',
+  );
   check(exact.exact
     && exact.refs[0].name === 'hyeonsangjeon/Dataplatformfrm'
     && !mixed.exact
     && mixed.rejected === 1
     && !missing.exact
+    && foundryExact.exact
+    && foundryExact.refs.length === 1
+    && foundryExact.rejected === 0
+    && !forgedFileScope.exact
+    && forgedFileScope.rejected === 1
+    && !mixedSearch.exact
+    && mixedSearch.rejected === 1
     && repositoryAtelierKnowledgeSource('github-repos-mcp-ks,other-ks') === 'github-repos-mcp-ks',
-  'Atelier grounding accepts only exact-repo references and selects only the existing GitHub MCP knowledge source');
+  'Atelier grounding accepts exact Foundry MCP references, rejects cross-repo activity, and selects only the GitHub source');
 
   check(repositoryAtelierMessage('not_found', 'hyeonsangjeon/Dataplatformfrm', 'ko').includes('현재 공개 정보를 찾지 못')
     && repositoryAtelierMessage('not_found', 'hyeonsangjeon/Dataplatformfrm', 'en').includes("couldn't find current public information")


### PR DESCRIPTION
## Summary
- accept the GitHub MCP search_repositories items[] reference shape
- correlate get_file_contents references with exact owner/repo MCP activity
- keep cross-repository and unverifiable evidence fail-closed
- add real-shape and adversarial regression coverage

## Verification
- full AGENTS.md verification block passed
- smoke: 1408 checks passed
- Repository Atelier chat tests passed