### PR TITLE
feat: add Procedural Surface Pass v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`data/lore/fragments.json` + `assets/lore-fragments.js`** | Hand-authored KO/EN elder fragments plus strict validation, deterministic active-roster allocation, and session-bounded delivery. | Changing The Silence fragments or their rarity/allocation contract. Never generate or overwrite the JSON. |
 | **`assets/taxi-voice.js`** | Pure local taxi Shared-state answers, household redirect, and once-per-ride seasonal/district observations. | Changing travel voice without adding a backend call. |
 | **`assets/session-footprints.js`** | Pure bounded current-tab footprint ring: movement threshold, lifetime, LOW_END/reduced-motion policy, and teardown. | Changing the local player's ephemeral walking trace. |
+| **`assets/procedural-surfaces.js`** | Pure facade/roof seed, UV phase, family, and bounded-cache contract for the shared procedural maps. | Changing repository-house material identity, tiling, or texture budgets. |
 | **`scripts/fork_lineage.py` + `assets/fork-lineage.js`** | Public-only fork source sanitizer plus deterministic six-color crest projection. | Changing generated fork source truth, lineage cards, or the shared crest batch. |
 | **`scholars.js`** | `window.SCHOLARS` roster: POLARIS · VEGA · RIGEL · MIRA · LYRA. | Adding / editing an NPC scholar. |
 | **`assets/world-tree/createRepolisHero.js`** | Procedural World Tree factory imported by `index.html`. | Changing the tree geometry, materials, sockets, or actions. |
@@ -53,6 +54,7 @@ CDN import map (Three.js r0.160 via jsDelivr) plus local data, scripts, and modu
 | **`scripts/resident_profiles.py` + `data/residents/`** | Generates sanitized public resident profiles, the boot manifest, and the Worker authority registry. Profile JSON is generated — do not hand-edit. | Changing repository-bound resident identity or Shared/Bound inputs. |
 | **`scripts/smoke.mjs`** | Hermetic static and behavioral regression guards for the city runtime. | Any client feature, navigation, or generated-module integration change. |
 | **`scripts/test-visual-governor.mjs`** | Extracts and deterministically replays the inline adaptive visual-governor core. | Changing warm-up, thresholds, hysteresis, dwell, LOW_END/reduced-motion bounds, or recovery. |
+| **`scripts/test-procedural-surfaces.mjs`** | Hermetic seed, UV, family, bounded-cache, pixel-hash, and disposal fixtures. | Changing procedural facade/roof helpers or cache limits. |
 | **`scripts/test-portable-town.mjs`** | Deterministic fixtures for canonical, foreign, empty/archive-only, partial, missing-date, leakage, resident-cap, and zero-request portable towns. | Changing public-town projection or local resident derivation. |
 | **`.github/workflows/refresh.yml`** | "Refresh Repolis data" — daily Action that regenerates `repos.json` and pushes `chore: refresh`. | CI / data-refresh changes. |
 | **`scripts/build-contribution-library.mjs` + `assets/contribution-library.json`** | Generates the in-app **Contribution Library** JSON from the sibling `Hyeonsang-AI-Contributions` README (KO/EN); `index.html` fetches it at runtime. JSON is **generated — do not hand-edit.** Daily via `.github/workflows/update-contribution-library.yml`. | Changing the library landmark's data/source. |
@@ -138,6 +140,7 @@ python3 scripts/validate_city_state.py
 python3 scripts/test_fork_lineage.py
 node scripts/test-city-time.mjs
 node scripts/test-session-footprints.mjs
+node scripts/test-procedural-surfaces.mjs
 node scripts/test-fork-lineage.mjs
 node scripts/test-repository-atelier-chat.mjs
 node scripts/test-repository-blueprint.mjs
@@ -193,6 +196,7 @@ Tested on Node v24. There is no linter or formatter configured — match the sur
 | Change Repository Atelier room, avatar, data walls, action terminals, or scoped chat | `assets/repository-atelier-chat.js` + `cloudflare-taxi/src/repository-atelier.js` + `/*REPOSITORY_ATELIER*/` in `index.html` + the Atelier group in `scripts/smoke.mjs`; preserve one lazy reusable room, three bounded canvas atlases, exact exterior restore, zero exterior renders inside, exact public `owner/repo` grounding, isolated in-memory visit history, five started calls, panel-reopen continuity, room-reentry reset, and explicit-only exit/GitHub navigation. |
 | Change Repository Blueprint scanning, Blueprint Deep Link sharing, projection, or DOM/3D focus | `assets/repo-portal.js` + `assets/repository-blueprint.js` + `/*REPOSITORY_ATELIER*/` in `index.html` + `scripts/test-repository-blueprint.mjs` + the Atelier smoke group; preserve explicit one-request Tree API access, exact owner/repo, 512-byte shared paths, confirmation-before-request, 8 s/2 MiB bounds, current-repo-only memory, 220/96 nodes, depth 4, 160/64 edges, two instanced batches, one line batch, zero Blueprint atlases/lights/exterior objects, and factual source-tree-only copy. |
 | Change adaptive frame thresholds or visual tiers | `/*VISUAL_GOVERNOR_CORE*/` + `/*VISUAL_GOVERNOR_RUNTIME*/` in `index.html`, `scripts/test-visual-governor.mjs`, and the matching smoke group; preserve 6 s eligible warm-up, separated hysteresis/dwell, balanced-before-lean ambient ordering, LOW_END/reduced-motion authority, state continuity, and zero storage/network/telemetry. |
+| Change repository-house facade or roof surfaces | `assets/procedural-surfaces.js` + `/*PROCEDURAL_SURFACES*/` in `index.html` + `scripts/test-procedural-surfaces.mjs` + the matching smoke group; preserve the eight facade families, shingle, nine-entry texture cap, seeded scene RNG sequence, color-space/filter/wrap contract, context restore, zero feature draws, and LOW_END `+0` texture ceiling. |
 | Change the 30-day Sap Ledger fields, retention, or Chronicle summary | `scripts/city_state.py` + `data/city-state.schema.json` + `assets/world-tree/world-tree-state.js` + `/*WORLD_TREE_CHRONICLE*/` in `index.html`; preserve actual UTC entries only, same-day replacement, 30-entry/32 KiB caps, public aggregate privacy, and unavailable foreign history. |
 | Change Twin Towns matching or two-person share links | `assets/twin-towns.js` + the Twin Towns block in `index.html` + `scripts/smoke.mjs`. |
 | Change Town Gazette / return-visit freshness | `/*FRESHNESS*/` + Passport render/start flow in `index.html`; keep snapshots local, bounded, per-town, and explicit-read only. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/); date
 This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier releases are preserved in
 [`docs/changelog-archive.md`](docs/changelog-archive.md).
 
+## [Unreleased]
+
+### Procedural Surface Pass v2
+
+- Brick, siding, panel, stone, stucco, timber, board-and-batten, metal, and shingle now use deterministic seeded
+  procedural relief with material-correct seams, mortar, grain, fasteners, restrained variation, and UV phase.
+- Nine shared texture entries replace per-house texture clones. The bounded pools preserve existing palette,
+  wear, ruins, signs, windows, flower boxes, gutters, scaffolding, architectural LOD, and Visual Governor truth.
+- Fixed seeded warm-route p95 held flat or improved up to 15.7%, reduced live textures by 30 desktop and 12
+  LOW_END, and added no draw, request, asset, light, collider, timer, or PBR channel.
+
 ## [1.95.0] — 2026-08-29
 
 ### 🌳 The Undercroft — a walkable archive beneath the World Tree

--- a/assets/procedural-surfaces.js
+++ b/assets/procedural-surfaces.js
@@ -1,0 +1,111 @@
+export const PROCEDURAL_SURFACE_VERSION = 2;
+
+export const PROCEDURAL_SURFACE_FAMILIES = Object.freeze([
+  'brick',
+  'siding',
+  'panel',
+  'stone',
+  'stucco',
+  'timber',
+  'board',
+  'metal',
+]);
+
+export const PROCEDURAL_SURFACE_LIMITS = Object.freeze({
+  desktopVariants: 1,
+  compactVariants: 1,
+  desktopCacheEntries: PROCEDURAL_SURFACE_FAMILIES.length + 1,
+  compactCacheEntries: PROCEDURAL_SURFACE_FAMILIES.length + 1,
+  materialCacheEntries: 384,
+});
+
+const FAMILY_SCALE = Object.freeze({
+  brick: Object.freeze([3.8, 3.1]),
+  siding: Object.freeze([4.6, 3.4]),
+  panel: Object.freeze([4.4, 4.4]),
+  stone: Object.freeze([4.2, 3.5]),
+  stucco: Object.freeze([5.2, 4.6]),
+  timber: Object.freeze([5.2, 4.8]),
+  board: Object.freeze([4.4, 4.4]),
+  metal: Object.freeze([4.8, 4.8]),
+});
+
+export function surfaceSeed(value) {
+  const text = String(value ?? '');
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function createSurfaceRng(seed) {
+  let state = surfaceSeed(seed) || 0x6d2b79f5;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function normalizeSurfaceFamily(family) {
+  return PROCEDURAL_SURFACE_FAMILIES.includes(family) ? family : 'stucco';
+}
+
+export function surfaceVariant(seed, compact = false) {
+  const count = compact
+    ? PROCEDURAL_SURFACE_LIMITS.compactVariants
+    : PROCEDURAL_SURFACE_LIMITS.desktopVariants;
+  const hash = surfaceSeed(seed);
+  return ((hash ^ (hash >>> 16)) >>> 0) % count;
+}
+
+export function surfaceTextureKey(kind, family, variant) {
+  const normalizedKind = kind === 'roof' ? 'roof' : 'wall';
+  const normalizedFamily = normalizedKind === 'roof' ? 'shingle' : normalizeSurfaceFamily(family);
+  return `${normalizedKind}:${normalizedFamily}:v${variant}`;
+}
+
+export function surfaceUvTransform(seed) {
+  const random = createSurfaceRng(`uv:${seed}`);
+  return Object.freeze({
+    offsetX: random(),
+    offsetY: random(),
+    mirrorX: random() >= 0.5,
+  });
+}
+
+export function surfaceWallRepeat(family, width, height) {
+  const scale = FAMILY_SCALE[normalizeSurfaceFamily(family)];
+  return Object.freeze({
+    x: Math.max(1.15, Number(width) / scale[0]),
+    y: Math.max(1.15, Number(height) / scale[1]),
+  });
+}
+
+export function getOrCreateBoundedSurface(cache, key, limit, create) {
+  if (!(cache instanceof Map)) throw new TypeError('surface cache must be a Map');
+  if (cache.has(key)) return cache.get(key);
+  if (cache.size >= limit) throw new RangeError(`surface cache limit exceeded: ${limit}`);
+  const value = create();
+  if (!value) throw new Error(`surface factory returned no value for ${key}`);
+  cache.set(key, value);
+  return value;
+}
+
+export function disposeBoundedSurfaceCache(cache, dispose = value => value.dispose()) {
+  for (const value of cache.values()) dispose(value);
+  cache.clear();
+}
+
+export function surfacePixelHash(bytes) {
+  let hash = 2166136261;
+  for (let index = 0; index < bytes.length; index += 1) {
+    hash ^= bytes[index];
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -117,6 +117,10 @@ change around a constraint that can't move. Pair this with [`AGENTS.md`](../AGEN
 - **No full browser automation suite.** `scripts/smoke.mjs` guards many static and extracted behavioral
   contracts, but visual and interaction changes still require serving locally and driving the page in
   Chrome DevTools with 0 console errors on mobile + desktop.
+- **Facade relief is intentionally lightweight.** Eight facade families and the roof use nine shared seeded
+  color maps plus per-geometry UV phases, not downloaded materials or a photorealistic PBR stack. LOW_END keeps
+  the same material identities with fewer micro-marks and lower anisotropy. No bump, normal, or roughness map
+  is retained.
 - **Adaptive quality is an in-memory safety rail, not a benchmark or device profile.** The governor observes
   visible, active exterior render intervals only after 6 seconds of eligible warm-up, uses three coarse reversible
   tiers, and forgets everything on reload. Hidden tabs, the intentional idle cap, intro/modals, Atelier, and Growth

--- a/docs/procedural-surface-pass-v2.md
+++ b/docs/procedural-surface-pass-v2.md
@@ -1,0 +1,64 @@
+# Procedural Surface Pass v2
+
+Issue [#114](https://github.com/hyeonsangjeon/Repolis/issues/114) improves the existing facade and roof
+families without adding fetched textures, binary assets, models, dependencies, build steps, scene lights,
+colliders, timers, or render passes.
+
+## Runtime contract
+
+- `assets/procedural-surfaces.js` owns the pure seed, UV phase, repeat scale, fixed family list, and cache helpers.
+- The runtime owns one neutral `CanvasTexture` for each of brick, siding, panel, stone, stucco, timber,
+  board-and-batten, metal, and shingle. Existing wall/roof colors, including wear and ruin tints, remain material
+  colors.
+- Each house gets deterministic geometry UV scale, offset, and mirroring. Houses do not get a full-resolution
+  texture clone.
+- Main-body night warmth is quantized to low / medium / high activity in the material key; meshes share a material
+  only when their facade map, palette color, and emissive level match.
+- The texture cache is a fixed nine-entry keyspace on desktop and LOW_END. The shared material pool
+  is bounded at 384 entries, covering three pooled keys for every supported 100-repository town plus headroom.
+  Overflow throws instead of growing silently.
+- Canvas maps are sRGB, repeat-wrapped, mipmapped, trilinear-minified, linear-magnified, and use anisotropy 8
+  desktop / 4 LOW_END at most.
+- Context restoration marks every pooled texture for upload. A non-bfcache page exit disposes both pools.
+- No bump, normal, or roughness channel shipped: the color/relief pass met the visual goal without another
+  texture, shader variant, or mobile cost.
+
+The old per-mesh `Texture.clone()` also allocated a `Texture` UUID and a `Source` UUID from `Math.random`.
+The new pool preserves those two initialization-time UUID draws without creating a texture, so unrelated
+procedural scenery remains byte-for-byte on the same seeded fixture.
+
+## Reproducible evidence
+
+Measured locally in Chrome 152 on the same Mac and browser process. Both `origin/main` and the feature were
+served from immutable local directories. The fixture fixed `Math.random` to seed `123456789`, cleared storage,
+loaded `?dbg=1`, forced `full` on desktop and the LOW_END `balanced` ceiling on mobile, and walked from
+`(15,-7)` at yaw `pi` with `KeyW` for eight seconds. The first route was discarded; the next 300 active frames
+formed the warm sample.
+
+The seeded scene contract matched exactly before timing: LOD-init RNG count and full-group draw sum were
+`190,385 / 4,438` on desktop and `168,755 / 4,293` on 390x844 LOW_END for both versions.
+
+| Fixture | Warm render p95 before | After | Regression |
+|---|---:|---:|---:|
+| Desktop day | 7.0 ms | 7.0 ms | 0.0% |
+| Desktop night | 11.5 ms | 9.7 ms | -15.7% |
+| 390x844 LOW_END day | 6.5 ms | 6.3 ms | -3.1% |
+| 390x844 LOW_END night | 8.9 ms | 8.3 ms | -6.7% |
+
+| Fixture | Calls p95 before | After | Live GPU textures before | After | Programs |
+|---|---:|---:|---:|---:|---:|
+| Desktop day | 1337 | 1336 | 185 | 155 | 100 -> 98 |
+| Desktop night | 1515 | 1401 | 185 | 155 | 100 -> 98 |
+| 390x844 LOW_END day | 546 | 545 | 136 | 124 | 97 -> 95 |
+| 390x844 LOW_END night | 567 | 579 | 136 | 124 | 97 -> 95 |
+
+The pass adds no mesh or render pass, and the seeded full-group draw sum is exact, so its owned draw-call delta
+is zero. The dynamic mobile-night p95 sample varied by 12 calls as existing LOD/night effects settled; it is
+reported rather than treated as a new feature draw. Desktop textures decreased by 30 and LOW_END by 12, both
+below their respective `+8` and `+0` ceilings.
+
+`window.__proceduralSurfaces()` recorded all eight facade families plus shingle with nonzero pixel ranges,
+stable hashes across day/night and reload, and cache sizes at or below 9. `WEBGL_lose_context` recovery retained
+the same hashes and cache size while incrementing the restore counter. `window.__canvasPixels()` reported a
+fully framed canvas with no horizontal overflow and 99.933% / 98.962% nonblank pixels on mobile / desktop.
+Desktop and mobile day/night captures were kept as local session evidence, not committed.

--- a/index.html
+++ b/index.html
@@ -2151,6 +2151,7 @@ import { FORK_LINEAGE_PALETTE, projectForkLineage } from './assets/fork-lineage.
 import { REPOSITORY_ATELIER_CHAT_LIMIT, appendRepositoryAtelierChatTurn, beginRepositoryAtelierChatCall, createRepositoryAtelierChatVisit, repositoryAtelierChatPayload, repositoryAtelierChatSnapshot, setRepositoryAtelierChatPanel } from './assets/repository-atelier-chat.js?v=atelier-scoped-chat-v1';
 import { REPOSITORY_BLUEPRINT_LIMITS, createRepositoryBlueprintMemoryCache, createRepositoryBlueprintPathUrl, projectRepositoryBlueprint, resolveRepositoryBlueprintFocus, scanRepositoryBlueprint, validateRepositoryBlueprintTarget } from './assets/repository-blueprint.js?v=repository-blueprint-v2';
 import { ISSUE_CODE_SCOUT_LIMITS, scoutIssueCodePaths } from './assets/issue-code-scout.js?v=issue-code-scout-v1';
+import { PROCEDURAL_SURFACE_FAMILIES, PROCEDURAL_SURFACE_LIMITS, PROCEDURAL_SURFACE_VERSION, createSurfaceRng, disposeBoundedSurfaceCache, getOrCreateBoundedSurface, normalizeSurfaceFamily, surfacePixelHash, surfaceTextureKey, surfaceUvTransform, surfaceVariant, surfaceWallRepeat } from './assets/procedural-surfaces.js?v=procedural-surface-v2-3';
 
 /* ====================== REPO DATA + CITY MODE ======================
    Owner mode (default) loads the full CI-built repos.json — unchanged.
@@ -3420,7 +3421,7 @@ function _installShadowMetrics(){
 }
 if(_DIAGNOSTICS) _installShadowMetrics();
 renderer.domElement.addEventListener('webglcontextlost',()=>{ _suspendGpuTimer(); RENDER_METRICS.lastStartedAt=0; });
-renderer.domElement.addEventListener('webglcontextrestored',()=>{ if(_DIAGNOSTICS){ _installShadowMetrics(); _installGpuTimer(); } invalidateTownShadows('context-restored'); if(MEMORIAL_TREE) MEMORIAL_TREE.bloomDirty=true; if(typeof _undercroftContextRestored==='function') _undercroftContextRestored(); if(typeof _repositoryAtelierContextRestored==='function') _repositoryAtelierContextRestored(); });
+renderer.domElement.addEventListener('webglcontextrestored',()=>{ if(_DIAGNOSTICS){ _installShadowMetrics(); _installGpuTimer(); } invalidateTownShadows('context-restored'); if(typeof _restoreProceduralSurfaceTextures==='function') _restoreProceduralSurfaceTextures(); if(MEMORIAL_TREE) MEMORIAL_TREE.bloomDirty=true; if(typeof _undercroftContextRestored==='function') _undercroftContextRestored(); if(typeof _repositoryAtelierContextRestored==='function') _repositoryAtelierContextRestored(); });
 document.addEventListener('visibilitychange',()=>{ if(!document.hidden) RENDER_METRICS.lastStartedAt=0; });
 
 /* ---- device quality tier: gate detail density so mobile/low-end lower overdraw without touching desktop ---- */
@@ -4333,7 +4334,8 @@ const DIRT_TEX=_noiseTex('#e1d3b3',[['#cfbd95',52,7,17,0.5],['#d8c9a3',40,5,12,0
 const SAND_TEX=_noiseTex('#d8c596',[['#cdb985',40,7,16,0.45],['#e3d3a8',34,5,12,0.4],['#c3ad7c',30,2,5,0.5]],256,{ speckle:[['#c3ad7c','#e3d3a8','#bfa775'],560,0.4] });
 function texMat(tex, rx, ry, clone=true){ const t=clone?tex.clone():tex; t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(rx,ry); t.anisotropy=MAXANISO; t.needsUpdate=true; return applyRim(new THREE.MeshToonMaterial({ map:t, gradientMap:GRAD })); }
 
-/* ---- procedural wall & roof textures, themed per category (cached by style+colour) ---- */
+/*PROCEDURAL_SURFACES:START*/
+/* ---- deterministic procedural facade/roof surfaces: shared neutral maps, tinted by the existing palette ---- */
 function shade(col, amt){
   const n=(typeof col==='string')?parseInt(col.replace('#',''),16):(col>>>0);
   let r=(n>>16)&255, g=(n>>8)&255, b=n&255; const f=amt/100;
@@ -4342,76 +4344,127 @@ function shade(col, amt){
 }
 const WALL_STYLES={ AI:['panel','metal'], Data:['brick','board'], AIOps:['stone','metal'], Finetune:['stucco','timber'], Software:['siding','board'] };
 function wallStyleFor(repo){ const arr=WALL_STYLES[repo._cat]||['siding']; return arr[hashStr((repo.repo||'')+'w')%arr.length]; }
-const _wallCache=new Map();
-function wallTexture(style, col){
-  const key=style+'_'+col; if(_wallCache.has(key)) return _wallCache.get(key);
-  const W=128,H=128,S=2; const cv=document.createElement('canvas'); cv.width=W*S; cv.height=H*S; const x=cv.getContext('2d'); x.scale(S,S);
-  const base=shade(col,0), dk=shade(col,-15), dk2=shade(col,-30), lt=shade(col,14), lt2=shade(col,24);
-  let seed=(((typeof col==='string')?parseInt(col.replace('#',''),16):col)>>>0)||1; const rnd=()=>{ seed=(seed*9301+49297)%233280; return seed/233280; };
-  x.fillStyle=base; x.fillRect(0,0,W,H);
-  if(style==='brick'){ const bh=15,bw=30,mg=2.2;
-    x.fillStyle=dk2; x.fillRect(0,0,W,H);
-    for(let r=-bh,row=0;r<H+bh;r+=bh,row++){ const off=(row%2)?bw/2:0;
-      for(let c=-bw;c<W+bw;c+=bw){ const bx=c+off+mg/2, by=r+mg/2, w=bw-mg, h=bh-mg;
-        x.fillStyle=shade(col,(rnd()-0.5)*26); x.fillRect(bx,by,w,h);
-        x.globalAlpha=0.5; x.fillStyle=lt2; x.fillRect(bx,by,w,1); x.fillRect(bx,by,1,h);
-        x.globalAlpha=0.55; x.fillStyle=dk2; x.fillRect(bx,by+h-1.2,w,1.2); x.fillRect(bx+w-1.2,by,1.2,h); x.globalAlpha=1; } } }
-  else if(style==='siding'){ const bh=12;
-    for(let r=0;r<H+bh;r+=bh){ x.fillStyle=shade(col,(rnd()-0.5)*10); x.fillRect(0,r,W,bh);
-      x.globalAlpha=0.5; x.fillStyle=lt2; x.fillRect(0,r,W,2);
-      x.globalAlpha=0.5; x.fillStyle=dk2; x.fillRect(0,r+bh-2.2,W,2.2); x.globalAlpha=1; } }
-  else if(style==='panel'){ const g=22;
-    for(let c=0;c<W;c+=g) for(let r=0;r<H;r+=g){ x.fillStyle=shade(col,(rnd()-0.5)*9); x.fillRect(c+1,r+1,g-2,g-2);
-      x.globalAlpha=0.4; x.fillStyle=lt2; x.fillRect(c+1,r+1,g-2,1); x.fillRect(c+1,r+1,1,g-2);
-      x.globalAlpha=0.5; x.fillStyle=dk2; x.fillRect(c+1,r+g-2,g-2,1.3); x.fillRect(c+g-2,r+1,1.3,g-2); x.globalAlpha=1; }
-    x.strokeStyle=dk; x.lineWidth=1.3;
-    for(let c=0;c<=W;c+=g){ x.beginPath(); x.moveTo(c,0); x.lineTo(c,H); x.stroke(); }
-    for(let r=0;r<=H;r+=g){ x.beginPath(); x.moveTo(0,r); x.lineTo(W,r); x.stroke(); }
-    for(let c=g/2;c<W;c+=g) for(let r=g/2;r<H;r+=g){ x.fillStyle=dk2; x.beginPath(); x.arc(c,r,1.4,0,7); x.fill(); x.fillStyle='rgba(255,255,255,0.45)'; x.beginPath(); x.arc(c-0.4,r-0.4,0.6,0,7); x.fill(); } }
-  else if(style==='stone'){ x.fillStyle=dk2; x.fillRect(0,0,W,H);
-    let y=0; while(y<H){ const rh=10+rnd()*8; let xx=-rnd()*20; while(xx<W){ const rw=16+rnd()*16;
-      x.fillStyle=shade(col,(rnd()-0.5)*30); x.fillRect(xx+1,y+1,rw-2,rh-2);
-      x.globalAlpha=0.45; x.fillStyle=lt2; x.fillRect(xx+1,y+1,rw-2,1.2); x.fillRect(xx+1,y+1,1.2,rh-2);
-      x.globalAlpha=0.5; x.fillStyle=dk2; x.fillRect(xx+1,y+rh-2,rw-2,1.4); x.fillRect(xx+rw-2,y+1,1.4,rh-2); x.globalAlpha=1;
-      xx+=rw; } y+=rh; } }
-  else if(style==='timber'){ // Tudor half-timber: pale stucco field crossed by dark structural beams
-    x.fillStyle=lt; x.fillRect(0,0,W,H);
-    for(let i=0;i<420;i++){ x.fillStyle=rnd()<0.5?base:lt2; x.globalAlpha=0.05+rnd()*0.08; x.fillRect(rnd()*W,rnd()*H,2,2); } x.globalAlpha=1;
-    const beam=shade(col,-54), bw=7; x.fillStyle=beam;
-    x.fillRect(0,0,W,bw); x.fillRect(0,H-bw,W,bw); x.fillRect(0,0,bw,H); x.fillRect(W-bw,0,bw,H);
-    x.fillRect(0,H/2-bw/2,W,bw); x.fillRect(W/3-bw/2,0,bw,H); x.fillRect(2*W/3-bw/2,0,bw,H);
-    x.strokeStyle=beam; x.lineWidth=bw; x.beginPath(); x.moveTo(bw,H/2); x.lineTo(W/3,H-bw); x.moveTo(W-bw,H/2); x.lineTo(2*W/3,H-bw); x.stroke();
-    x.globalAlpha=0.32; x.fillStyle=shade(col,-72); x.fillRect(0,H/2+bw/2-1.4,W,1.4); x.globalAlpha=1; }
-  else if(style==='board'){ // board-and-batten: wide vertical boards with raised battens over the seams
-    const bw=16;
-    for(let c=0;c<W+bw;c+=bw){ x.fillStyle=shade(col,(rnd()-0.5)*12); x.fillRect(c,0,bw,H);
-      x.globalAlpha=0.5; x.fillStyle=lt2; x.fillRect(c,0,2,H); x.globalAlpha=0.5; x.fillStyle=dk2; x.fillRect(c+bw-2.2,0,2.2,H); x.globalAlpha=1;
-      x.fillStyle=shade(col,9); x.fillRect(c-2,0,4,H);
-      x.globalAlpha=0.4; x.fillStyle=lt2; x.fillRect(c-2,0,1,H); x.globalAlpha=0.5; x.fillStyle=dk2; x.fillRect(c+1,0,1,H); x.globalAlpha=1; } }
-  else if(style==='metal'){ // standing-seam metal: vertical ribbed panels with a soft sheen
-    const pw=16; const gr=x.createLinearGradient(0,0,0,H); gr.addColorStop(0,dk); gr.addColorStop(0.5,lt2); gr.addColorStop(1,dk); x.fillStyle=gr; x.fillRect(0,0,W,H);
-    for(let c=0;c<=W;c+=pw){ x.globalAlpha=0.55; x.fillStyle=dk2; x.fillRect(c-1,0,2,H); x.globalAlpha=0.5; x.fillStyle=lt2; x.fillRect(c+1,0,1.4,H); x.globalAlpha=1; }
-    x.globalAlpha=0.16; x.fillStyle=dk2; for(let r=10;r<H;r+=34) x.fillRect(0,r,W,1); x.globalAlpha=1; }
-  else { for(let i=0;i<26;i++){ x.globalAlpha=0.05+rnd()*0.06; x.fillStyle=rnd()<0.5?dk:lt; const px=rnd()*W,py=rnd()*H,r=8+rnd()*20; x.beginPath(); x.arc(px,py,r,0,7); x.fill(); }
-    for(let i=0;i<1300;i++){ const px=rnd()*W, py=rnd()*H; x.fillStyle=rnd()<0.5?dk:lt; x.globalAlpha=0.07+rnd()*0.12; x.fillRect(px,py,1.6,1.6); } x.globalAlpha=1; }
-  const t=new THREE.CanvasTexture(cv); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=MAXANISO; t.needsUpdate=true;
-  _wallCache.set(key,t); return t;
+const SURFACE_COMPACT=LOW_END||IS_MOBILE;
+const SURFACE_VARIANTS=SURFACE_COMPACT?PROCEDURAL_SURFACE_LIMITS.compactVariants:PROCEDURAL_SURFACE_LIMITS.desktopVariants;
+const SURFACE_CACHE_LIMIT=SURFACE_COMPACT?PROCEDURAL_SURFACE_LIMITS.compactCacheEntries:PROCEDURAL_SURFACE_LIMITS.desktopCacheEntries;
+const SURFACE_MATERIAL_CACHE_LIMIT=PROCEDURAL_SURFACE_LIMITS.materialCacheEntries;
+const _surfaceCache=new Map(),_surfaceMaterialCache=new Map(),_legacySurfaceSourceKeys=new Set(),SURFACE_CACHE_STATE={requests:0,hits:0,created:0,materialHits:0,contextRestores:0,disposed:false};
+const SURFACE_TONE={base:'#f8f4ec',light:'#fffefa',mid:'#e8e0d4',dark:'#c5baa9',deep:'#9f927f'};
+function _surfaceCanvas(kind){
+  const wall=kind==='wall',W=wall?128:64,H=wall?128:64,S=SURFACE_COMPACT?1:2,cv=document.createElement('canvas');
+  cv.width=W*S; cv.height=H*S; const x=cv.getContext('2d'); x.scale(S,S); return {cv,x,W,H,S};
 }
-const _roofCache=new Map();
-function roofTexture(col){ const key='r_'+col; if(_roofCache.has(key)) return _roofCache.get(key);
-  const W=64,H=64,S=2; const cv=document.createElement('canvas'); cv.width=W*S; cv.height=H*S; const x=cv.getContext('2d'); x.scale(S,S);
-  const base=shade(col,0), dk=shade(col,-22), dk2=shade(col,-38), lt=shade(col,16);
-  let seed=(((typeof col==='string')?parseInt(col.replace('#',''),16):col)>>>0)||1; const rnd=()=>{ seed=(seed*9301+49297)%233280; return seed/233280; };
-  x.fillStyle=dk2; x.fillRect(0,0,W,H);
-  const rh=11, tw=18;
-  for(let r=-rh,row=0;r<H+rh;r+=rh,row++){ const off=(row%2)?tw/2:0;
-    for(let c=-tw;c<W+tw;c+=tw){ const sx=c+off+0.8, sy=r+0.8, w=tw-1.6, h=rh-1.6;
-      x.fillStyle=shade(col,(rnd()-0.5)*22); x.fillRect(sx,sy,w,h);
-      x.globalAlpha=0.45; x.fillStyle=lt; x.fillRect(sx,sy,w,1.3);
-      x.globalAlpha=0.55; x.fillStyle=dk2; x.fillRect(sx,sy+h-2,w,2); x.globalAlpha=1; } }
-  const t=new THREE.CanvasTexture(cv); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=MAXANISO; t.needsUpdate=true;
-  _roofCache.set(key,t); return t;
+function _surfacePrivateUuid(key,create){
+  const globalRandom=Math.random,privateRandom=createSurfaceRng(`uuid:${key}`); Math.random=privateRandom;
+  try { return create(); } finally { Math.random=globalRandom; }
 }
+function _preserveTextureCloneUuidSequence(){ THREE.MathUtils.generateUUID(); THREE.MathUtils.generateUUID(); }
+function _surfaceTextureFinish(cv,x,key,kind,family,variant,privateUuid){
+  const pixels=x.getImageData(0,0,cv.width,cv.height).data; let min=255,max=0,sum=0;
+  for(let i=0;i<pixels.length;i+=4){ const luma=(pixels[i]*54+pixels[i+1]*183+pixels[i+2]*19)>>8; min=Math.min(min,luma); max=Math.max(max,luma); sum+=luma; }
+  const texture=privateUuid?_surfacePrivateUuid(key,()=>new THREE.CanvasTexture(cv)):new THREE.CanvasTexture(cv); texture.wrapS=texture.wrapT=THREE.RepeatWrapping;
+  texture.colorSpace=THREE.SRGBColorSpace; texture.generateMipmaps=true; texture.minFilter=THREE.LinearMipmapLinearFilter; texture.magFilter=THREE.LinearFilter;
+  texture.anisotropy=Math.min(MAXANISO,SURFACE_COMPACT?4:8); texture.needsUpdate=true;
+  texture.userData={proceduralSurface:true,version:PROCEDURAL_SURFACE_VERSION,key,kind,family,variant,pixelHash:surfacePixelHash(pixels),
+    pixelStats:{min,max,mean:+(sum/(pixels.length/4)).toFixed(2),range:max-min}};
+  SURFACE_CACHE_STATE.created++; return texture;
+}
+function _surfaceCached(kind,family,variant,legacyColor,draw){
+  const key=surfaceTextureKey(kind,family,variant),legacyKey=`${kind}:${family}:${legacyColor}`,surfaceMiss=!_surfaceCache.has(key),legacyMiss=!_legacySurfaceSourceKeys.has(legacyKey);
+  _legacySurfaceSourceKeys.add(legacyKey); SURFACE_CACHE_STATE.requests++; if(!surfaceMiss) SURFACE_CACHE_STATE.hits++;
+  if(legacyMiss&&!surfaceMiss) _preserveTextureCloneUuidSequence();
+  return getOrCreateBoundedSurface(_surfaceCache,key,SURFACE_CACHE_LIMIT,()=>{
+    const canvas=_surfaceCanvas(kind),random=createSurfaceRng(`${key}:pixels:v${PROCEDURAL_SURFACE_VERSION}`);
+    draw(canvas,random); return _surfaceTextureFinish(canvas.cv,canvas.x,key,kind,family,variant,!legacyMiss);
+  });
+}
+function _surfaceTile(x,W,H,draw){ for(let ox=-1;ox<=1;ox++) for(let oy=-1;oy<=1;oy++){ x.save(); x.translate(ox*W,oy*H); draw(); x.restore(); } }
+function _surfaceSpeckle(x,W,H,random,count,colors,alpha,radius=1){
+  for(let i=0;i<count;i++){ const px=random()*W,py=random()*H,r=.35+random()*radius; x.fillStyle=colors[(random()*colors.length)|0]; x.globalAlpha=alpha*(.45+random()*.55);
+    _surfaceTile(x,W,H,()=>{ x.beginPath(); x.arc(px,py,r,0,Math.PI*2); x.fill(); }); } x.globalAlpha=1;
+}
+function wallTexture(style,seed,color,variantOverride=null){
+  const family=normalizeSurfaceFamily(style),variant=variantOverride==null?surfaceVariant(seed,SURFACE_COMPACT):Math.max(0,Math.min(SURFACE_VARIANTS-1,variantOverride|0));
+  return _surfaceCached('wall',family,variant,color,({x,W,H},random)=>{
+    const T=SURFACE_TONE; x.fillStyle=T.base; x.fillRect(0,0,W,H);
+    for(let i=0;i<18;i++){ const px=random()*W,py=random()*H,r=12+random()*30; x.fillStyle=random()>.5?T.light:T.dark; x.globalAlpha=.025+random()*.035;
+      _surfaceTile(x,W,H,()=>{ x.beginPath(); x.arc(px,py,r,0,Math.PI*2); x.fill(); }); } x.globalAlpha=1;
+    if(family==='brick'){ const bh=16,bw=32,mg=1.2; x.fillStyle=T.deep; x.fillRect(0,0,W,H);
+      for(let row=-1;row<=H/bh;row++){ const y=row*bh,off=(row&1)?bw/2:0;
+        for(let c=-bw;c<W+bw;c+=bw){ const bx=c+off+mg/2,by=y+mg/2,w=bw-mg,h=bh-mg; x.fillStyle=random()>.5?T.base:T.mid; x.fillRect(bx,by,w,h);
+          x.globalAlpha=.55; x.fillStyle=T.light; x.fillRect(bx,by,w,1); x.fillRect(bx,by,1,h);
+          x.fillStyle=T.dark; x.fillRect(bx,by+h-1.5,w,1.5); x.fillRect(bx+w-1.2,by,1.2,h); x.globalAlpha=1; } } _surfaceSpeckle(x,W,H,random,SURFACE_COMPACT?90:180,[T.light,T.dark],.12,.7); }
+    else if(family==='siding'){ const bh=16;
+      for(let row=0;row<H/bh;row++){ const y=row*bh; x.fillStyle=row%3===variant?T.mid:T.base; x.fillRect(0,y,W,bh);
+        x.globalAlpha=.62; x.fillStyle=T.light; x.fillRect(0,y,W,1.4); x.fillStyle=T.dark; x.fillRect(0,y+bh-2.2,W,2.2); x.globalAlpha=1;
+        const joint=(row*37+variant*19)%64; x.fillStyle=T.deep; x.fillRect(joint,y+2,1,bh-4); x.fillRect(joint+64,y+2,1,bh-4);
+        for(const px of [joint+3,joint+61]){ x.beginPath(); x.arc(px,y+4,.65,0,Math.PI*2); x.fill(); } } }
+    else if(family==='panel'){ const g=32; x.fillStyle=T.dark; x.fillRect(0,0,W,H);
+      for(let c=0;c<W;c+=g) for(let r=0;r<H;r+=g){ x.fillStyle=(c/g+r/g+variant)%3===0?T.mid:T.base; x.fillRect(c+1.5,r+1.5,g-3,g-3);
+        x.globalAlpha=.6; x.fillStyle=T.light; x.fillRect(c+2,r+2,g-4,1); x.fillRect(c+2,r+2,1,g-4); x.fillStyle=T.deep; x.fillRect(c+2,r+g-3,g-4,1.4); x.globalAlpha=1;
+        for(const [px,py] of [[c+4,r+4],[c+g-4,r+4],[c+4,r+g-4],[c+g-4,r+g-4]]){ x.fillStyle=T.deep; x.beginPath(); x.arc(px,py,1,0,Math.PI*2); x.fill(); } } }
+    else if(family==='stone'){ const rows=[16,24,16,24,20,28]; x.fillStyle=T.deep; x.fillRect(0,0,W,H); let y=0;
+      for(let row=0;row<rows.length;row++){ const rh=rows[row],off=(row&1)?16:0;
+        for(let c=-32;c<W+32;c+=32){ const bx=c+off+.8,by=y+.8,w=30.4,h=rh-1.6,j=(random()-.5)*1.4;
+          x.fillStyle=(row+c/32+variant)%3===0?T.mid:T.base; x.beginPath(); x.moveTo(bx+1,by); x.lineTo(bx+w,by+Math.max(0,j)); x.lineTo(bx+w-1,by+h); x.lineTo(bx,by+h-Math.max(0,-j)); x.closePath(); x.fill();
+          x.globalAlpha=.42; x.strokeStyle=T.light; x.lineWidth=.6; x.stroke(); x.globalAlpha=1; } y+=rh; } _surfaceSpeckle(x,W,H,random,SURFACE_COMPACT?70:140,[T.light,T.dark],.1,.8); }
+    else if(family==='timber'){ x.fillStyle=T.light; x.fillRect(0,0,W,H); _surfaceSpeckle(x,W,H,random,SURFACE_COMPACT?160:320,[T.base,T.mid,T.dark],.1,.8);
+      const bw=8,beam='#776a5a'; x.fillStyle=beam; x.fillRect(0,0,W,bw); x.fillRect(0,H-bw,W,bw); x.fillRect(0,0,bw,H); x.fillRect(W-bw,0,bw,H);
+      x.fillRect(0,H/2-bw/2,W,bw); x.fillRect(W/3-bw/2,0,bw,H); x.fillRect(2*W/3-bw/2,0,bw,H);
+      x.strokeStyle=beam; x.lineWidth=bw; x.beginPath(); x.moveTo(bw,H/2); x.lineTo(W/3,H-bw); x.moveTo(W-bw,H/2); x.lineTo(2*W/3,H-bw); x.stroke();
+      x.globalAlpha=.28; x.strokeStyle=T.light; x.lineWidth=1; for(let i=0;i<28;i++){ const y=random()*H; x.beginPath(); x.moveTo(0,y); x.lineTo(W,y+(random()-.5)*3); x.stroke(); } x.globalAlpha=1; }
+    else if(family==='board'){ const bw=16;
+      for(let c=0;c<W;c+=bw){ x.fillStyle=(c/bw+variant)%3===0?T.mid:T.base; x.fillRect(c,0,bw,H);
+        x.globalAlpha=.5; x.fillStyle=T.light; x.fillRect(c,0,2,H); x.fillStyle=T.deep; x.fillRect(c+bw-2,0,2,H); x.globalAlpha=1;
+        x.fillStyle=T.light; x.fillRect(c-2,0,4,H); x.fillStyle=T.dark; x.fillRect(c+1,0,1,H);
+        x.globalAlpha=.18; x.fillStyle=T.deep; for(let i=0;i<4;i++) x.fillRect(c+4+random()*8,random()*H,1,12+random()*24); x.globalAlpha=1; } }
+    else if(family==='metal'){ const pw=16;
+      for(let c=0;c<W;c+=pw){ const gr=x.createLinearGradient(c,0,c+pw,0); gr.addColorStop(0,T.dark); gr.addColorStop(.18,T.base); gr.addColorStop(.58,T.light); gr.addColorStop(1,T.mid); x.fillStyle=gr; x.fillRect(c,0,pw,H);
+        x.fillStyle=T.deep; x.fillRect(c,0,1.6,H); x.fillStyle=T.light; x.fillRect(c+1.6,0,1,H); }
+      x.globalAlpha=.36; x.fillStyle=T.deep; for(let r=12+variant*8;r<H;r+=32) x.fillRect(0,r,W,1); x.globalAlpha=1;
+      for(let c=8;c<W;c+=16) for(let r=8;r<H;r+=32){ x.fillStyle=T.deep; x.beginPath(); x.arc(c,r,.8,0,Math.PI*2); x.fill(); } }
+    else { _surfaceSpeckle(x,W,H,random,SURFACE_COMPACT?440:1100,[T.light,T.mid,T.dark],.1,1.15);
+      for(let i=0;i<(SURFACE_COMPACT?12:28);i++){ const px=random()*W,py=random()*H,r=5+random()*15; x.strokeStyle=random()>.5?T.light:T.dark; x.globalAlpha=.04+random()*.05; x.lineWidth=1;
+        _surfaceTile(x,W,H,()=>{ x.beginPath(); x.arc(px,py,r,0,Math.PI*2); x.stroke(); }); } x.globalAlpha=1; }
+  });
+}
+function roofTexture(seed,color,variantOverride=null){
+  const variant=variantOverride==null?surfaceVariant(seed,SURFACE_COMPACT):Math.max(0,Math.min(SURFACE_VARIANTS-1,variantOverride|0));
+  return _surfaceCached('roof','shingle',variant,color,({x,W,H},random)=>{
+    const T=SURFACE_TONE,rh=16,tw=32; x.fillStyle=T.deep; x.fillRect(0,0,W,H);
+    for(let row=-1;row<=H/rh;row++){ const y=row*rh,off=(row&1)?tw/2:0;
+      for(let c=-tw;c<W+tw;c+=tw){ const sx=c+off+1,sy=y+1,w=tw-2,h=rh-2; x.fillStyle=(row+c/tw+variant)%3===0?T.mid:T.base; x.fillRect(sx,sy,w,h);
+        const sheen=x.createLinearGradient(sx,sy,sx+w,sy); sheen.addColorStop(0,T.dark); sheen.addColorStop(.32,T.light); sheen.addColorStop(.68,T.base); sheen.addColorStop(1,T.dark);
+        x.globalAlpha=.24; x.fillStyle=sheen; x.fillRect(sx,sy,w,h); x.globalAlpha=.62; x.fillStyle=T.light; x.fillRect(sx,sy,w,1.2); x.fillStyle=T.deep; x.fillRect(sx,sy+h-2,w,2); x.globalAlpha=1;
+        x.strokeStyle=T.dark; x.globalAlpha=.3; x.lineWidth=.8; x.beginPath(); x.moveTo(sx+w*.5,sy+2); x.lineTo(sx+w*.5,sy+h-2); x.stroke(); x.globalAlpha=1; } }
+    _surfaceSpeckle(x,W,H,random,SURFACE_COMPACT?45:90,[T.light,T.dark],.09,.55);
+  });
+}
+function _surfaceUv(geometry,repeatX,repeatY,seed){
+  const uv=geometry&&geometry.attributes&&geometry.attributes.uv; if(!uv) return geometry; const tr=surfaceUvTransform(seed);
+  for(let i=0;i<uv.count;i++){ const u=uv.getX(i)*repeatX,v=uv.getY(i)*repeatY; uv.setXY(i,(tr.mirrorX?-u:u)+tr.offsetX,v+tr.offsetY); }
+  uv.needsUpdate=true; geometry.userData.proceduralSurfaceUv={repeatX,repeatY,offsetX:tr.offsetX,offsetY:tr.offsetY,mirrorX:tr.mirrorX}; return geometry;
+}
+function _surfaceMaterial(texture,color,{preserveCloneSequence=false,legacyMaterial=true,glow=0}={}){
+  if(preserveCloneSequence) _preserveTextureCloneUuidSequence();
+  const surfaceGlow=texture.userData.kind==='wall'?Math.round(Math.max(0,Math.min(1,glow))*2)/2*.45:0;
+  const create=()=>{ const material=applyRim(new THREE.MeshToonMaterial({map:texture,color,gradientMap:GRAD,vertexColors:texture.userData.kind==='wall'}));
+    material.userData.proceduralSurfaceGlow=surfaceGlow; return material; };
+  const key=`${texture.userData.kind}:${texture.userData.key}:${color}:g${surfaceGlow}`,cached=_surfaceMaterialCache.get(key);
+  if(cached){ if(legacyMaterial) THREE.MathUtils.generateUUID(); SURFACE_CACHE_STATE.materialHits++; return cached; }
+  if(_surfaceMaterialCache.size>=SURFACE_MATERIAL_CACHE_LIMIT) throw new RangeError(`surface material cache limit exceeded: ${SURFACE_MATERIAL_CACHE_LIMIT}`);
+  const material=legacyMaterial?create():_surfacePrivateUuid(`material:${key}`,create);
+  _surfaceMaterialCache.set(key,material); return material;
+}
+function _applySurfaceMaterial(mesh,texture,color,repeatX,repeatY,seed,material=null,options={}){
+  _surfaceUv(mesh.geometry,repeatX,repeatY,seed); const previous=mesh.material; mesh.material=material||_surfaceMaterial(texture,color,options);
+  mesh.userData.proceduralSurfaceKind=texture.userData.kind;
+  if(previous&&previous!==mesh.material) previous.dispose(); return mesh;
+}
+function _restoreProceduralSurfaceTextures(){ if(SURFACE_CACHE_STATE.disposed) return; for(const texture of _surfaceCache.values()) texture.needsUpdate=true; SURFACE_CACHE_STATE.contextRestores++; }
+function _disposeProceduralSurfaceTextures(){ if(SURFACE_CACHE_STATE.disposed) return; disposeBoundedSurfaceCache(_surfaceCache); disposeBoundedSurfaceCache(_surfaceMaterialCache); SURFACE_CACHE_STATE.disposed=true; }
+window.addEventListener('pagehide',event=>{ if(!event.persisted) _disposeProceduralSurfaceTextures(); });
+/*PROCEDURAL_SURFACES:END*/
 
 /* ---- ground ---- */
 // segmented plane (planar UVs → clean grass tiling) with a baked radial meadow gradient: a sunlit clearing
@@ -5434,41 +5487,43 @@ function typology(repo){
   return {kind, roof, tier};
 }
 /* ---- roof variants ---- */
-function makeRoof(style,w,h,color){
+function makeRoof(style,w,h,color,seed='shared-roof'){
   const grp=new THREE.Group();
-  const rmat=(rx,ry)=>texMat(roofTexture(color), rx, ry);
+  const texture=roofTexture(seed,color); let surfacePart=0;
+  const rmesh=(geometry,rx,ry)=>{ _surfaceUv(geometry,rx,ry,`${seed}:${style}:${surfacePart++}`); const mesh=new THREE.Mesh(geometry,_surfaceMaterial(texture,color,{preserveCloneSequence:true})); mesh.userData.proceduralSurfaceKind='roof'; return mesh; };
+  const rboxSurface=(bw,bh,bd,r,rx,ry)=>_applySurfaceMaterial(rbox(bw,bh,bd,color,r),texture,color,rx,ry,`${seed}:${style}:${surfacePart++}`,null,{preserveCloneSequence:true});
   if(style==='flat'){
-    const slab=rbox(w*1.02,0.5,w*1.02,color,0.06); slab.material=rmat(2.4,2.4); slab.position.y=h+0.25; outline(slab,0.05); grp.add(slab);
+    const slab=rboxSurface(w*1.02,0.5,w*1.02,0.06,2.4,2.4); slab.position.y=h+0.25; outline(slab,0.05); grp.add(slab);
     const ph=0.55, pt=0.16, e=w*0.51;
     [[0,e],[0,-e],[e,0],[-e,0]].forEach(([x,z])=>{ const horiz=Math.abs(z)>0; const pr=rbox(horiz?w*1.04:pt, ph, horiz?pt:w*1.04, color,0.04); pr.position.set(x,h+0.6,z); grp.add(pr); });
   } else if(style==='hip'){
-    const r=new THREE.Mesh(new THREE.ConeGeometry(w*0.9,1.7,4), rmat(4,1.4)); r.position.y=h+0.85; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
+    const r=rmesh(new THREE.ConeGeometry(w*0.9,1.7,4),4,1.4); r.position.y=h+0.85; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
   } else if(style==='gambrel'){
-    const lo=new THREE.Mesh(new THREE.CylinderGeometry(w*0.62,w*0.96,1.1,4,1), rmat(4,1.2)); lo.position.y=h+0.55; lo.rotation.y=Math.PI/4; lo.castShadow=true; outline(lo,0.06); grp.add(lo);
-    const hi=new THREE.Mesh(new THREE.ConeGeometry(w*0.64,1.5,4), rmat(4,1.3)); hi.position.y=h+1.6; hi.rotation.y=Math.PI/4; hi.castShadow=true; outline(hi,0.06); grp.add(hi);
+    const lo=rmesh(new THREE.CylinderGeometry(w*0.62,w*0.96,1.1,4,1),4,1.2); lo.position.y=h+0.55; lo.rotation.y=Math.PI/4; lo.castShadow=true; outline(lo,0.06); grp.add(lo);
+    const hi=rmesh(new THREE.ConeGeometry(w*0.64,1.5,4),4,1.3); hi.position.y=h+1.6; hi.rotation.y=Math.PI/4; hi.castShadow=true; outline(hi,0.06); grp.add(hi);
   } else if(style==='mansard'){
     // French Second-Empire: steep flared lower skirt + shallow hip cap (a graceful, boxy top)
-    const skirt=new THREE.Mesh(new THREE.CylinderGeometry(w*0.7,w*1.0,1.6,4,1), rmat(4,1.5)); skirt.position.y=h+0.8; skirt.rotation.y=Math.PI/4; skirt.castShadow=true; outline(skirt,0.06); grp.add(skirt);
-    const cap=new THREE.Mesh(new THREE.ConeGeometry(w*0.74,0.7,4), rmat(4,0.8)); cap.position.y=h+1.95; cap.rotation.y=Math.PI/4; cap.castShadow=true; outline(cap,0.05); grp.add(cap);
+    const skirt=rmesh(new THREE.CylinderGeometry(w*0.7,w*1.0,1.6,4,1),4,1.5); skirt.position.y=h+0.8; skirt.rotation.y=Math.PI/4; skirt.castShadow=true; outline(skirt,0.06); grp.add(skirt);
+    const cap=rmesh(new THREE.ConeGeometry(w*0.74,0.7,4),4,0.8); cap.position.y=h+1.95; cap.rotation.y=Math.PI/4; cap.castShadow=true; outline(cap,0.05); grp.add(cap);
     const cor=new THREE.Mesh(new THREE.TorusGeometry(w*0.7,0.07,6,4), basic(0xeadfca)); cor.rotation.x=Math.PI/2; cor.rotation.z=Math.PI/4; cor.position.y=h+1.6; grp.add(cor);
   } else if(style==='aframe'){
     // chalet: a tall, sharp gable whose eaves sweep down low over the walls
-    const r=new THREE.Mesh(new THREE.ConeGeometry(w*0.82,3.5,4), rmat(4,2.3)); r.position.y=h+0.45; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
+    const r=rmesh(new THREE.ConeGeometry(w*0.82,3.5,4),4,2.3); r.position.y=h+0.45; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
     const ridge=rbox(0.18,0.18,w*1.18,shade(color,-26),0.04); ridge.position.y=h+1.0; grp.add(ridge);
   } else if(style==='shed'){
     // modern single-slope (mono-pitch): a clean wedge, low at the street, high at the back
     const sh=new THREE.Shape(); sh.moveTo(-w*0.54,0); sh.lineTo(w*0.54,0); sh.lineTo(w*0.54,1.5); sh.lineTo(-w*0.54,0.06); sh.lineTo(-w*0.54,0);
-    const wedge=new THREE.Mesh(new THREE.ExtrudeGeometry(sh,{depth:w*1.06,bevelEnabled:false}), rmat(2.0,1.3));
+    const wedge=rmesh(new THREE.ExtrudeGeometry(sh,{depth:w*1.06,bevelEnabled:false}),2,1.3);
     wedge.position.set(0,h+0.02,w*0.53); wedge.castShadow=true; outline(wedge,0.05); grp.add(wedge);
   } else if(style==='barrel'){
     // rounded barrel vault running front-to-back, clamped to the building footprint
     const R=w*0.52, L=w*1.02;
     const sh=new THREE.Shape(); sh.moveTo(-R,0); sh.lineTo(R,0); sh.absarc(0,0,R,0,Math.PI,false);
-    const v=new THREE.Mesh(new THREE.ExtrudeGeometry(sh,{depth:L,bevelEnabled:false,steps:1,curveSegments:20}), rmat(3.2,1.4));
+    const v=rmesh(new THREE.ExtrudeGeometry(sh,{depth:L,bevelEnabled:false,steps:1,curveSegments:20}),3.2,1.4);
     v.position.set(0,h+0.02,-L/2); v.castShadow=true; outline(v,0.05); grp.add(v);
     const ridge=rbox(0.16,0.16,L*0.98,shade(color,-26),0.03); ridge.position.set(0,h+R+0.02,0); grp.add(ridge);
   } else {
-    const r=new THREE.Mesh(new THREE.ConeGeometry(w*0.95,2.6,4), rmat(4,1.8)); r.position.y=h+1.3; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
+    const r=rmesh(new THREE.ConeGeometry(w*0.95,2.6,4),4,1.8); r.position.y=h+1.3; r.rotation.y=Math.PI/4; r.castShadow=true; outline(r,0.06); grp.add(r);
   }
   return grp;
 }
@@ -5567,9 +5622,10 @@ function addGarage(g,w,d,yr,roofColor){
 }
 
 /* ---- grand-house parts: wings, porch, balcony, portico, cupola, dormer ---- */
-function addWing(g, ww, wh, wd, wall, roofColor, x){
-  const wb=rbox(ww,wh,wd,wall,0.16); bakeVGrad(wb); wb.position.set(x,wh/2,0); outline(wb,0.05); g.add(wb);
-  const wr=makeRoof('hip', ww*0.92, wh, roofColor); wr.position.x=x; g.add(wr);
+function addWing(g, ww, wh, wd, wall, roofColor, x, surface){
+  const repeat=surfaceWallRepeat(surface.family,ww,wh),wb=rbox(ww,wh,wd,wall,0.16);
+  _applySurfaceMaterial(wb,surface.texture,wall,repeat.x,repeat.y,`${surface.seed}:wall`,null,{legacyMaterial:false}); bakeVGrad(wb); wb.position.set(x,wh/2,0); outline(wb,0.05); g.add(wb);
+  const wr=makeRoof('hip', ww*0.92, wh, roofColor,`${surface.seed}:roof`); wr.position.x=x; g.add(wr);
   const gl=new THREE.Mesh(new THREE.PlaneGeometry(0.66,0.66), basic(0xffe4a0)); gl.position.set(x,wh*0.55,wd/2+0.05); g.add(gl);
 }
 function addPorch(g, w, d, color){
@@ -5752,19 +5808,21 @@ function makeBuilding(repo){
 
   // body + roof (score-tiered silhouette: cabin→cottage→house→townhouse→villa→manor→mansion + tower/shop)
   const bodyR=(kind==='tower'||kind==='townhouse')?0.12:0.2;
-  const wstyle=wallStyleFor(repo); repo._wstyle=wstyle; const wtex=wallTexture(wstyle, repo.wall);
-  const body=rbox(w,h,d,repo.wall,bodyR); body.material=texMat(wtex, Math.max(1.2,w/3.2), Math.max(1.2,h/3.2)); bakeVGrad(body);
+  const wstyle=wallStyleFor(repo),surfaceSeedKey=`${repo.repo}:facade`,wvariant=surfaceVariant(surfaceSeedKey,SURFACE_COMPACT); repo._wstyle=wstyle;
+  const wtex=wallTexture(wstyle,surfaceSeedKey,repo.wall),wallRepeat=surfaceWallRepeat(wstyle,w,h);
+  const body=rbox(w,h,d,repo.wall,bodyR); _applySurfaceMaterial(body,wtex,repo.wall,wallRepeat.x,wallRepeat.y,`${surfaceSeedKey}:body`,null,{preserveCloneSequence:true,glow:repo._ruin?0:repo._activity}); bakeVGrad(body);
   body.position.y=h/2; outline(body,0.06); g.add(body);
-  repo._body=body;
+  repo._body=body; repo._surface={family:wstyle,variant:wvariant,seed:surfaceSeedKey};
   // projecting stone base course (water-table) grounds the building on its plot
   const plinth=rbox(w+0.26, 0.5, d+0.26, 0x8f8676, bodyR); plinth.position.y=0.25; outline(plinth,0.05); g.add(plinth);
   repo._cw=(w*0.5+0.6)*((kind==='manor'||kind==='mansion')?1.4:(kind==='villa')?1.18:1);
   let topH=h, topW=w;
-  if(kind==='shop'){ const uh=Math.max(1.8,h*0.34); const up=rbox(w*0.62,uh,d*0.62,repo.wall,0.14); up.material=texMat(wtex, Math.max(1,w*0.62/3.2), Math.max(1,uh/3.2)); bakeVGrad(up); up.position.y=h+uh/2; outline(up,0.05); g.add(up); topH=h+uh; topW=w*0.62; }
+  if(kind==='shop'){ const uh=Math.max(1.8,h*0.34),repeat=surfaceWallRepeat(wstyle,w*.62,uh),up=rbox(w*0.62,uh,d*0.62,repo.wall,0.14); _applySurfaceMaterial(up,wtex,repo.wall,repeat.x,repeat.y,`${surfaceSeedKey}:upper`,null,{preserveCloneSequence:true}); bakeVGrad(up); up.position.y=h+uh/2; outline(up,0.05); g.add(up); topH=h+uh; topW=w*0.62; }
   // side wings for grand residences (저택)
-  if(kind==='villa'){ addWing(g, w*0.52, h*0.66, d*0.8, repo.wall, repo.roof, w*0.66); }
+  if(kind==='villa'){ addWing(g, w*0.52, h*0.66, d*0.8, repo.wall, repo.roof, w*0.66,{family:wstyle,texture:wtex,seed:`${surfaceSeedKey}:right-wing`}); }
   else if(kind==='manor'||kind==='mansion'){ const wh=h*(kind==='mansion'?0.8:0.72), wx=w*0.72;
-    addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, wx); addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, -wx); }
+    addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, wx,{family:wstyle,texture:wtex,seed:`${surfaceSeedKey}:right-wing`});
+    addWing(g, w*0.5, wh, d*0.82, repo.wall, repo.roof, -wx,{family:wstyle,texture:wtex,seed:`${surfaceSeedKey}:left-wing`}); }
   // central roof
   repo._lodSpec={kind,roof:typ.roof,tier:typ.tier,w,h,d,topH,topW,wall:repo.wall,roofColor:repo.roof,accent:repo.accent,entranceColor:(CATS[repo._cat]||CATS.Software).color,
     yardRadius:yr,yardColor:repo._downtown?0xcbb888:0x86c069,hedgeColor:repo._downtown?0xb7a274:0x5d9e46,rich,fancy,flags,stars:repo.stars||0,
@@ -5782,7 +5840,7 @@ function makeBuilding(repo){
       x:repo._x+Math.cos(rot)*wx*side,z:repo._z-Math.sin(rot)*wx*side,r:partR,minY:0,maxY:wh+2.2,id:`${repo.repo}-wing-${side}`
     });
   }
-  const roof=makeRoof(typ.roof, topW, topH, repo.roof); g.add(roof); repo._roof=roof;
+  const roof=makeRoof(typ.roof, topW, topH, repo.roof,`${repo.repo}:principal-roof`); g.add(roof); repo._roof=roof;
   const flatTop = (typ.roof==='flat');
   if(typ.roof!=='flat' && typ.roof!=='aframe'){ const chim=rbox(0.55,1.2,0.55,0x6e4a32,0.08); chim.position.set(w*0.32,topH+1.4,d*0.22); outline(chim,0.04); g.add(chim);
     if(!repo._ruin&&(rich>0.18 || repo._busy>0)) addSmoke(g, w*0.32, topH+2.3, d*0.22, repo._busy); }
@@ -6204,7 +6262,7 @@ function _initBuildingLodPrototype(){
       const shadowProxy=new THREE.Mesh(silhouetteGeometry,shadowMaterial); shadowProxy.name='BuildingLOD_ShadowProxy'; shadowProxy.castShadow=true; shadowProxy.receiveShadow=false; shadowProxy.scale.set(.985,1,.985); shadowProxy.customDepthMaterial=shadowDepthMaterial; shadowProxy.layers.set(BUILDING_LOD_SHADOW_LAYER);
       const originalShadowCasters=[]; for(const group of [full,active]) group.traverse(o=>{ if(o.isMesh&&o.castShadow){ originalShadowCasters.push(o); o.castShadow=false; } });
       root.add(functional); const visualIndex=root.children.length; root.add(full); root.add(shadowProxy); root.add(active);
-      const entry={repo,root,groups:{full,mid,far},functional,active,shadowProxy,originalChildren,originalShadowCasters,visualIndex,tier:'full',forcedTier:null,pending:null,pendingCount:0,lastSwitchFrame:-999,originalsMode:false,
+      const entry={repo,root,groups:{full,mid,far},functional,active,shadowProxy,midBody,originalChildren,originalShadowCasters,visualIndex,tier:'full',forcedTier:null,pending:null,pendingCount:0,lastSwitchFrame:-999,originalsMode:false,
         detailScale:(LOW_END||IS_MOBILE)?1:(repo._lodSpec.tier>=4?.82:repo._lodSpec.tier===3?.92:1),localCenter,radius,worldCenter:new THREE.Vector3(),worldScale:new THREE.Vector3(),projected:new THREE.Vector3(),projectedPx:Infinity,
         facadeGeometry,readabilityGeometry,silhouetteGeometry,farVisualGeometry,
         identity:{originalSign:repo._sign,midSign,farSign,originalEmblem:repo._emblem,midEmblem,farEmblem}};
@@ -7472,10 +7530,10 @@ function setNightState(night){
                  else { m.map=_winTex; m.color.setHex(0x2b3442); } }
       else { m.map=_winTex; m.color.setHex(DAY_GLASS); }
       m.needsUpdate=true; });
-    if(b._body){ if(night&&!b._ruin) b._body.material.emissive.setRGB(0.5,0.32,0.12).multiplyScalar(0.45*b._activity);
-                 else b._body.material.emissive.setHex(0x000000); }
     if(b._glowPool) b._glowPool.material.opacity = night&&!b._ruin ? (0.06+0.5*b._activity) : 0;
   });
+  for(const material of _surfaceMaterialCache.values()){ const glow=night?(material.userData.proceduralSurfaceGlow||0):0;
+    if(glow>0) material.emissive.setRGB(.5,.32,.12).multiplyScalar(glow); else material.emissive.setHex(0x000000); }
   libNightBoost.forEach(o=>{ o.material.opacity = night ? o._n : o._d; });
   if(LIB&&LIB._group) LIB._group.traverse(o=>{ if(o.userData&&o.userData.libGlow!==undefined&&o.material&&o.material.emissive) o.material.emissive.setHex(night?o.userData.libGlow:0x000000); });
   _refreshResidentHomeLights(night);
@@ -14198,6 +14256,34 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
       identity:{midSign:e.identity.midSign?.material.map===e.identity.originalSign?.material.map,farSign:e.identity.farSign?.material.map===e.identity.originalSign?.material.map,
         midEmblem:e.identity.midEmblem?.material.map===e.identity.originalEmblem?.material.map,farEmblem:e.identity.farEmblem?.material.map===e.identity.originalEmblem?.material.map},
       full:_buildingLodGroupStats(e.groups.full),mid:_buildingLodGroupStats(e.groups.mid),far:_buildingLodGroupStats(e.groups.far),active:_buildingLodGroupStats(e.active),shadow:_buildingLodGroupStats(e.shadowProxy)}))}; };
+  let _surfaceDebugFixture=null;
+  window.__proceduralSurfaces=()=>({version:PROCEDURAL_SURFACE_VERSION,compact:SURFACE_COMPACT,variants:SURFACE_VARIANTS,
+    cache:{size:_surfaceCache.size,limit:SURFACE_CACHE_LIMIT,requests:SURFACE_CACHE_STATE.requests,hits:SURFACE_CACHE_STATE.hits,created:SURFACE_CACHE_STATE.created,
+      materials:_surfaceMaterialCache.size,materialLimit:SURFACE_MATERIAL_CACHE_LIMIT,materialHits:SURFACE_CACHE_STATE.materialHits,
+      contextRestores:SURFACE_CACHE_STATE.contextRestores,disposed:SURFACE_CACHE_STATE.disposed},
+    entries:[..._surfaceCache.entries()].map(([key,texture])=>({key,size:[texture.image.width,texture.image.height],hash:texture.userData.pixelHash,pixels:texture.userData.pixelStats,
+      colorSpace:texture.colorSpace,repeat:[texture.repeat.x,texture.repeat.y],wrap:[texture.wrapS,texture.wrapT],anisotropy:texture.anisotropy,
+      minFilter:texture.minFilter,magFilter:texture.magFilter,mipmaps:texture.generateMipmaps})),
+    bindings:(()=>{ const surfaceMeshes=[]; for(const repo of REPOS) repo._group?.traverse(object=>{ if(object.userData.proceduralSurfaceKind) surfaceMeshes.push(object); });
+      const bodies=REPOS.map(repo=>repo._body).filter(Boolean),facadeMaterials=new Set(bodies.map(body=>body.material?.uuid).filter(Boolean)),emissiveGroups=new Map();
+      for(const body of bodies){ const values=emissiveGroups.get(body.material.uuid)||[]; values.push(body.material.userData.proceduralSurfaceGlow||0); emissiveGroups.set(body.material.uuid,values); }
+      return {facades:new Set(REPOS.map(repo=>repo._body?.material?.map?.uuid).filter(Boolean)).size,facadeMaterials:facadeMaterials.size,
+        sharedFacadeBindings:Math.max(0,bodies.length-facadeMaterials.size),emissiveBuckets:new Set(bodies.map(body=>body.material.userData.proceduralSurfaceGlow||0)).size,
+        sharedEmissiveGroups:[...emissiveGroups.values()].filter(values=>values.length>1).length,
+        distinctSharedEmissiveGroups:[...emissiveGroups.values()].filter(values=>values.length>1&&new Set(values).size>1).length,
+        roofs:new Set(REPOS.flatMap(repo=>repo._roof?.children||[]).map(mesh=>mesh.material?.map?.uuid).filter(Boolean)).size,
+        wallMeshes:surfaceMeshes.filter(mesh=>mesh.userData.proceduralSurfaceKind==='wall').length,
+        roofMeshes:surfaceMeshes.filter(mesh=>mesh.userData.proceduralSurfaceKind==='roof').length,
+        missingMaps:surfaceMeshes.filter(mesh=>!mesh.material?.map).length}; })(),
+    families:PROCEDURAL_SURFACE_FAMILIES.map(family=>({family,repos:REPOS.filter(repo=>repo._surface?.family===family).length,
+      variants:[...new Set(REPOS.filter(repo=>repo._surface?.family===family).map(repo=>repo._surface.variant))]}))});
+  window.__proceduralSurfaceFixture=(family=null,name='foundry-iq-demo-suite',variant=0)=>{
+    if(_surfaceDebugFixture){ const previous=_surfaceDebugFixture; previous.repo._body.material.map=previous.map; previous.repo._body.material.needsUpdate=true; _surfaceDebugFixture=null; }
+    if(family==null||family==='restore') return window.__proceduralSurfaces();
+    const normalized=normalizeSurfaceFamily(family),repo=repoByKey(name)||REPOS.find(candidate=>candidate._body); if(!repo||!repo._body) return null;
+    _surfaceDebugFixture={repo,map:repo._body.material.map}; repo._body.material.map=wallTexture(normalized,`debug:${normalized}:v${variant}`,repo.wall,variant); repo._body.material.needsUpdate=true;
+    window.__buildingLodPrototypeForce(repo.repo,'full'); return {repo:repo.repo,family:normalized,variant:Math.max(0,Math.min(SURFACE_VARIANTS-1,variant|0)),surface:window.__proceduralSurfaces()};
+  };
   window.__buildingLodPrototype=()=>_buildingLodDebug();
   window.__buildingLodPrototypeForce=(name,tier='auto')=>{ const entry=BUILDING_LOD_PROTO.entries.find(e=>e.repo.repo===name); if(!entry) return null;
     entry.forcedTier=tier==='auto'?null:tier; if(entry.forcedTier) _buildingLodAttach(entry,entry.forcedTier,true); else _updateBuildingLodPrototype(renderedFrame,true); return _buildingLodDebug(); };
@@ -14499,6 +14585,10 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
   window.__perfReset=()=>{ RENDER_METRICS.history.length=0; RENDER_METRICS.latest=null; RENDER_METRICS.lastStartedAt=0; return true; };
   window.__perfDiagnostics=()=>({enabled:_DIAGNOSTICS,debug:_DBG,autoReset:renderer.info.autoReset,shadowWrapped:!!renderer.shadowMap.render.__repolisMetrics,
     frameAllocations:RENDER_METRICS.frameAllocations,passTokenAllocations:RENDER_METRICS.passTokenAllocations,historyWrites:RENDER_METRICS.historyWrites,history:RENDER_METRICS.history.length,gpuSupported:GPU_TIMER.supported});
+  window.__canvasPixels=()=>{ const gl=renderer.getContext(),w=gl.drawingBufferWidth,h=gl.drawingBufferHeight,pixels=new Uint8Array(w*h*4); _renderWorldTreeFrame(); gl.readPixels(0,0,w,h,gl.RGBA,gl.UNSIGNED_BYTE,pixels);
+    let nonblank=0,min=255,max=0,sum=0; for(let i=0;i<pixels.length;i+=4){ const luma=(pixels[i]*54+pixels[i+1]*183+pixels[i+2]*19)>>8; if(luma>2) nonblank++; min=Math.min(min,luma); max=Math.max(max,luma); sum+=luma; }
+    const rect=renderer.domElement.getBoundingClientRect(); return {viewport:[innerWidth,innerHeight],drawingBuffer:[w,h],canvasRect:[rect.x,rect.y,rect.width,rect.height],
+      nonblankPct:+(nonblank/(w*h)*100).toFixed(3),luma:{min,max,mean:+(sum/(w*h)).toFixed(2)},noHorizontalOverflow:document.documentElement.scrollWidth<=innerWidth}; };
   window.__visualGovernor=(command)=>_debugVisualGovernor(command);
   window.__undercroft=()=>_undercroftDebug();
   window.__undercroftFixture=(kind='records')=>{

--- a/llms.txt
+++ b/llms.txt
@@ -28,6 +28,8 @@
 - [assets/repo-route.js](assets/repo-route.js): strict current-catalog validation and canonical links for ordered 2–3 house Repo Routes.
 - [assets/contribution-quests.js](assets/contribution-quests.js): pure current-owner/catalog issue projection and bounded ranking for Open Source Quests.
 - [assets/issue-code-scout.js](assets/issue-code-scout.js): deterministic exact-repo Quest title/label matching against an already-loaded Blueprint, capped at five candidate paths.
+- [assets/procedural-surfaces.js](assets/procedural-surfaces.js): deterministic seeded facade/roof variants, UV phases, and bounded shared caches.
+- [docs/procedural-surface-pass-v2.md](docs/procedural-surface-pass-v2.md): rendering contract and reproducible desktop/LOW_END budget evidence.
 - [assets/contribution-library.json](assets/contribution-library.json): generated bilingual Contribution Library data.
 
 ## Main product systems

--- a/repolis.yaml
+++ b/repolis.yaml
@@ -65,6 +65,7 @@ entrypoints:
   taxi_voice: assets/taxi-voice.js
   session_footprints: assets/session-footprints.js
   fork_lineage: assets/fork-lineage.js
+  procedural_surfaces: assets/procedural-surfaces.js
   data_builder: scripts/build_repos.py
   launch_config: repolis.config.js
   library_builder: scripts/build-contribution-library.mjs
@@ -110,6 +111,12 @@ endpoints:
 features:
   - id: data-built-city
     summary: Repository traffic and metadata shape houses, gardens, ornaments, and night glow.
+  - id: procedural-surfaces
+    summary: Eight facade families and shingle use deterministic seeded UV phases over nine bounded shared CanvasTextures.
+    desktop_texture_cache_cap: 9
+    low_end_texture_cache_cap: 9
+    added_runtime_requests: 0
+    added_draw_calls: 0
   - id: thirty-day-sap-ledger
     summary: The owner World Tree keeps up to 30 actual UTC daily public aggregate entries with same-day replacement, explicit gaps, and no foreign history reuse.
     runtime_requests: 0

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -138,6 +138,7 @@ const REPO_BUILDER = readFileSync(join(ROOT, 'scripts/build_repos.py'), 'utf8');
 const CAMERA_MATH_SRC = readFileSync(join(ROOT, 'assets/camera-obstruction.js'), 'utf8');
 const POSTCARD_SRC = readFileSync(join(ROOT, 'assets/town-postcard.js'), 'utf8');
 const PUBLIC_TOWN_PROOF_SRC = readFileSync(join(ROOT, 'assets/public-town-proof.js'), 'utf8');
+const PROCEDURAL_SURFACE_SRC = readFileSync(join(ROOT, 'assets/procedural-surfaces.js'), 'utf8');
 const TWIN_TOWNS_SRC = readFileSync(join(ROOT, 'assets/twin-towns.js'), 'utf8');
 const TOWN_CREATOR_SRC = readFileSync(join(ROOT, 'assets/town-creator.js'), 'utf8');
 const TOWN_GROWTH_SRC = readFileSync(join(ROOT, 'assets/town-growth.js'), 'utf8');
@@ -3628,6 +3629,70 @@ ok((HTML.match(/watchKicker:\s*['"]/g) || []).length >= 2 && (HTML.match(/watchC
 ok(/window\.__lanternWatchPlan=/.test(HTML) && /window\.__lanternWatchStart=/.test(HTML)
   && /window\.__lanternWatchNext=/.test(HTML) && /window\.__lanternWatchEnd=/.test(HTML), '?dbg watch plan/start/advance/end hooks are present');
 ok(/updateLanternWatch\(clock\.elapsedTime\)/.test(HTML), 'the main world loop updates active night-watch lanterns');
+
+group('Procedural Surface Pass v2 - bounded deterministic facade and roof detail');
+const proceduralSurfaceBlock = (HTML.match(/\/\*PROCEDURAL_SURFACES:START\*\/([\s\S]*?)\/\*PROCEDURAL_SURFACES:END\*\//) || [, ''])[1];
+ok(proceduralSurfaceBlock.length > 0
+  && /procedural-surfaces\.js\?v=procedural-surface-v2-3/.test(HTML)
+  && /PROCEDURAL_SURFACE_FAMILIES/.test(HTML),
+  'surface runtime and pure deterministic helper remain explicit and extractable');
+ok(/\[\s*'brick',[\s\S]*?'siding',[\s\S]*?'panel',[\s\S]*?'stone',[\s\S]*?'stucco',[\s\S]*?'timber',[\s\S]*?'board',[\s\S]*?'metal'/.test(PROCEDURAL_SURFACE_SRC)
+  && /surfaceTextureKey\(kind, family, variant\)/.test(PROCEDURAL_SURFACE_SRC)
+  && /surfaceVariant\(seed, compact = false\)/.test(PROCEDURAL_SURFACE_SRC),
+  'all existing facade families and shared shingle variants keep deterministic keys');
+ok(/desktopCacheEntries: PROCEDURAL_SURFACE_FAMILIES\.length \+ 1/.test(PROCEDURAL_SURFACE_SRC)
+  && /compactCacheEntries: PROCEDURAL_SURFACE_FAMILIES\.length \+ 1/.test(PROCEDURAL_SURFACE_SRC)
+  && /getOrCreateBoundedSurface\(_surfaceCache,key,SURFACE_CACHE_LIMIT/.test(proceduralSurfaceBlock)
+  && /materialCacheEntries: 384/.test(PROCEDURAL_SURFACE_SRC)
+  && /SURFACE_MATERIAL_CACHE_LIMIT=PROCEDURAL_SURFACE_LIMITS\.materialCacheEntries/.test(proceduralSurfaceBlock)
+  && /surface cache limit exceeded/.test(PROCEDURAL_SURFACE_SRC)
+  && /surface material cache limit exceeded/.test(proceduralSurfaceBlock),
+  'desktop and compact texture/material keyspaces are fixed and fail explicitly at their bounds');
+ok(/texture\.colorSpace=THREE\.SRGBColorSpace/.test(proceduralSurfaceBlock)
+  && /texture\.generateMipmaps=true/.test(proceduralSurfaceBlock)
+  && /texture\.minFilter=THREE\.LinearMipmapLinearFilter/.test(proceduralSurfaceBlock)
+  && /texture\.magFilter=THREE\.LinearFilter/.test(proceduralSurfaceBlock)
+  && /texture\.wrapS=texture\.wrapT=THREE\.RepeatWrapping/.test(proceduralSurfaceBlock)
+  && /texture\.anisotropy=Math\.min\(MAXANISO,SURFACE_COMPACT\?4:8\)/.test(proceduralSurfaceBlock),
+  'surface color space, mipmaps, filters, anisotropy, wrapping, and grazing-angle sampling are explicit');
+ok(/function _surfaceUv\(geometry,repeatX,repeatY,seed\)/.test(proceduralSurfaceBlock)
+  && /surfaceUvTransform\(seed\)/.test(proceduralSurfaceBlock)
+  && /surfaceWallRepeat\(wstyle,w,h\)/.test(HTML)
+  && /_applySurfaceMaterial\(body,wtex,repo\.wall/.test(HTML)
+  && /makeRoof\(typ\.roof, topW, topH, repo\.roof,`\$\{repo\.repo\}:principal-roof`\)/.test(HTML)
+  && !/texMat\(wtex/.test(HTML),
+  'per-house UV transforms reuse pooled maps without minting full-resolution texture clones');
+ok(/surfaceGlow=texture\.userData\.kind==='wall'\?Math\.round\(Math\.max\(0,Math\.min\(1,glow\)\)\*2\)\/2\*\.45:0/.test(proceduralSurfaceBlock)
+  && /material\.userData\.proceduralSurfaceGlow=surfaceGlow/.test(proceduralSurfaceBlock)
+  && /glow:repo\._ruin\?0:repo\._activity/.test(HTML)
+  && /for\(const material of _surfaceMaterialCache\.values\(\)\)/.test(HTML)
+  && /material\.userData\.proceduralSurfaceGlow\|\|0/.test(HTML)
+  && !/aSurfaceGlow|onBeforeRender=_surfaceBeforeRender|_setSurfaceGlow/.test(HTML)
+  && /addWing[\s\S]*?legacyMaterial:false/.test(HTML)
+  && !/addWing[\s\S]*?_applySurfaceMaterial\([^;]+wb\.material\)/.test(HTML),
+  'activity-bucketed materials preserve full/mid house warmth while grand-house wings stay dark and textured');
+ok(/function _preserveTextureCloneUuidSequence\(\)\{ THREE\.MathUtils\.generateUUID\(\); THREE\.MathUtils\.generateUUID\(\); \}/.test(proceduralSurfaceBlock)
+  && /function _surfacePrivateUuid\(key,create\)/.test(proceduralSurfaceBlock)
+  && /finally \{ Math\.random=globalRandom; \}/.test(proceduralSurfaceBlock),
+  'removing Texture plus Source clones preserves the unrelated seeded scene RNG sequence');
+ok(/function _restoreProceduralSurfaceTextures\(\)/.test(proceduralSurfaceBlock)
+  && /texture\.needsUpdate=true/.test(proceduralSurfaceBlock)
+  && /function _disposeProceduralSurfaceTextures\(\)/.test(proceduralSurfaceBlock)
+  && /disposeBoundedSurfaceCache\(_surfaceCache\); disposeBoundedSurfaceCache\(_surfaceMaterialCache\)/.test(proceduralSurfaceBlock)
+  && /if\(!event\.persisted\) _disposeProceduralSurfaceTextures\(\)/.test(proceduralSurfaceBlock)
+  && /webglcontextrestored'[\s\S]*?_restoreProceduralSurfaceTextures\(\)/.test(HTML),
+  'surface maps have explicit context-restore upload and non-bfcache disposal');
+ok(/window\.__proceduralSurfaces=/.test(HTML) && /window\.__proceduralSurfaceFixture=/.test(HTML)
+  && /pixelHash:surfacePixelHash/.test(proceduralSurfaceBlock)
+  && /pixelStats:\{min,max,mean:/.test(proceduralSurfaceBlock)
+  && /sharedFacadeBindings:/.test(HTML) && /distinctSharedEmissiveGroups:/.test(HTML) && /missingMaps:/.test(HTML)
+  && /window\.__canvasPixels=/.test(HTML)
+  && /_renderWorldTreeFrame\(\); gl\.readPixels/.test(HTML),
+  '?dbg exposes cache, deterministic pixel, family, binding, and visual-fixture evidence');
+ok(!/(?:fetch|XMLHttpRequest|WebSocket|sendBeacon|TextureLoader|GLTFLoader|setTimeout|setInterval|requestAnimationFrame)\s*\(/.test(proceduralSurfaceBlock + PROCEDURAL_SURFACE_SRC)
+  && !/new THREE\.(?:PointLight|SpotLight|DirectionalLight|AmbientLight|HemisphereLight)/.test(proceduralSurfaceBlock)
+  && !/(?:bumpMap|normalMap|roughnessMap)/.test(proceduralSurfaceBlock),
+  'surface pass adds no request, binary/model load, timer, light, or unproven PBR channel');
 
 group('Adaptive Visual Governor - sustained frame budget without gameplay resets');
 const visualGovernorCoreBlock = (HTML.match(/\/\*VISUAL_GOVERNOR_CORE:START\*\/([\s\S]*?)\/\*VISUAL_GOVERNOR_CORE:END\*\//) || [, ''])[1];

--- a/scripts/test-procedural-surfaces.mjs
+++ b/scripts/test-procedural-surfaces.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import {
+  PROCEDURAL_SURFACE_FAMILIES,
+  PROCEDURAL_SURFACE_LIMITS,
+  PROCEDURAL_SURFACE_VERSION,
+  createSurfaceRng,
+  disposeBoundedSurfaceCache,
+  getOrCreateBoundedSurface,
+  normalizeSurfaceFamily,
+  surfacePixelHash,
+  surfaceTextureKey,
+  surfaceUvTransform,
+  surfaceVariant,
+  surfaceWallRepeat,
+} from '../assets/procedural-surfaces.js';
+
+assert.equal(PROCEDURAL_SURFACE_VERSION, 2);
+assert.deepEqual(PROCEDURAL_SURFACE_FAMILIES, [
+  'brick', 'siding', 'panel', 'stone', 'stucco', 'timber', 'board', 'metal',
+]);
+assert.equal(PROCEDURAL_SURFACE_LIMITS.desktopCacheEntries, 9);
+assert.equal(PROCEDURAL_SURFACE_LIMITS.compactCacheEntries, 9);
+assert.equal(PROCEDURAL_SURFACE_LIMITS.materialCacheEntries, 384);
+assert.ok(PROCEDURAL_SURFACE_LIMITS.materialCacheEntries >= 300);
+assert.equal(normalizeSurfaceFamily('brick'), 'brick');
+assert.equal(normalizeSurfaceFamily('unknown'), 'stucco');
+
+const sequence = seed => {
+  const random = createSurfaceRng(seed);
+  return Array.from({ length: 12 }, () => random());
+};
+assert.deepEqual(sequence('brick:v0'), sequence('brick:v0'));
+assert.notDeepEqual(sequence('brick:v0'), sequence('brick:v1'));
+
+const transform = surfaceUvTransform('repo:facade');
+assert.deepEqual(transform, surfaceUvTransform('repo:facade'));
+assert.notDeepEqual(transform, surfaceUvTransform('other:facade'));
+assert.ok(transform.offsetX >= 0 && transform.offsetX < 1);
+assert.ok(transform.offsetY >= 0 && transform.offsetY < 1);
+
+for (const family of PROCEDURAL_SURFACE_FAMILIES) {
+  const repeat = surfaceWallRepeat(family, 8, 10);
+  assert.ok(Number.isFinite(repeat.x) && repeat.x >= 1.15);
+  assert.ok(Number.isFinite(repeat.y) && repeat.y >= 1.15);
+  assert.match(surfaceTextureKey('wall', family, 0), new RegExp(`^wall:${family}:v0$`));
+}
+assert.equal(surfaceTextureKey('roof', 'ignored', 1), 'roof:shingle:v1');
+assert.deepEqual(new Set(Array.from({ length: 32 }, (_, index) => surfaceVariant(`repo-${index}`, false))), new Set([0]));
+assert.deepEqual(new Set(Array.from({ length: 32 }, (_, index) => surfaceVariant(`repo-${index}`, true))), new Set([0]));
+
+const cache = new Map();
+let creates = 0, disposals = 0;
+const first = getOrCreateBoundedSurface(cache, 'wall:brick:v0', 2, () => ({ id: ++creates }));
+const hit = getOrCreateBoundedSurface(cache, 'wall:brick:v0', 2, () => ({ id: ++creates }));
+assert.equal(hit, first);
+assert.equal(creates, 1);
+getOrCreateBoundedSurface(cache, 'roof:shingle:v0', 2, () => ({ id: ++creates }));
+assert.throws(
+  () => getOrCreateBoundedSurface(cache, 'wall:stone:v0', 2, () => ({ id: ++creates })),
+  /surface cache limit exceeded/,
+);
+disposeBoundedSurfaceCache(cache, () => { disposals += 1; });
+assert.equal(disposals, 2);
+assert.equal(cache.size, 0);
+
+const pixels = new Uint8Array([0, 16, 128, 255, 8, 24, 64, 255]);
+assert.equal(surfacePixelHash(pixels), surfacePixelHash(pixels.slice()));
+assert.notEqual(surfacePixelHash(pixels), surfacePixelHash(new Uint8Array([...pixels, 1])));
+
+console.log('ALL GREEN - procedural surface determinism, variants, UV scale, bounded cache, and disposal fixtures');


### PR DESCRIPTION
## Summary
- replace per-house facade/roof texture clones with nine bounded deterministic procedural maps and seeded geometry UV phases
- refine brick, siding, panel, stone, stucco, timber, board-and-batten, metal, and shingle while preserving palette, wear, windows, signs, gutters, ruins, scaffolding, architectural LOD, and Visual Governor behavior
- add explicit sRGB/mipmap/filter/anisotropy/wrap policy, bounded material pooling, context-restore upload, disposal, debug evidence, hermetic tests, smoke guards, and measured documentation

## Measured budget
- warm p95: desktop day `7.0 -> 7.0 ms`, desktop night `11.5 -> 9.7 ms`
- warm p95: 390x844 LOW_END day `6.5 -> 6.3 ms`, night `8.9 -> 8.3 ms`
- live GPU textures: desktop `185 -> 155`, LOW_END `136 -> 124`
- seeded LOD-init RNG and full-group draw sums match exactly; no mesh, render pass, request, asset, dependency, light, collider, timer, or PBR channel was added

## Verification
- complete current `AGENTS.md` verification block passes
- `scripts/smoke.mjs`: 1,468 checks
- `scripts/test-procedural-surfaces.mjs`: deterministic seed/UV/cache/disposal fixtures
- desktop and 390x844 mobile day/night canvas, console, context-loss/restore, and family/roof pixel evidence completed locally

Closes #114
