### PR TITLE
Fix Creator Hall public Star total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This file keeps the current product era (`1.50.0` onward) easy to scan. Earlier 
 
 ## [Unreleased]
 
+### Creator Hall public Star total
+
+- Creator Hall now reports Stars across every public repository in the account, including forks intentionally
+  omitted from the 3D town, while the town catalog and building rules remain unchanged.
+
 ### Procedural Surface Pass v2
 
 - Brick, siding, panel, stone, stucco, timber, board-and-batten, metal, and shingle now use deterministic seeded

--- a/assets/town-creator.js
+++ b/assets/town-creator.js
@@ -41,7 +41,7 @@ export function selectTownCreatorFields(raw = {}) {
   });
 }
 
-export function summarizeTownCreator(profile, repos = [], nowMs = Date.now()) {
+export function summarizeTownCreator(profile, repos = [], nowMs = Date.now(), options = {}) {
   const selected = selectTownCreatorFields({
     login: profile?.login,
     name: profile?.name,
@@ -67,6 +67,11 @@ export function summarizeTownCreator(profile, repos = [], nowMs = Date.now()) {
       languages.set(language, (languages.get(language) || 0) + 1);
     }
   }
+  const requestedPublicStars = Number(options?.publicStars);
+  const publicStars = options?.publicStars !== null && options?.publicStars !== undefined
+    && options?.publicStars !== '' && Number.isFinite(requestedPublicStars)
+    ? Math.max(stars, nonNegative(requestedPublicStars))
+    : stars;
 
   const topLanguages = [...languages.entries()]
     .map(([name, count]) => Object.freeze({ name, count }))
@@ -94,7 +99,7 @@ export function summarizeTownCreator(profile, repos = [], nowMs = Date.now()) {
   if (list.length >= 10 || selected.publicRepos >= 10) badges.push('builder');
   if (topLanguages.length >= 4) badges.push('polyglot');
   if (latestPush && now - latestPush <= 90 * DAY_MS) badges.push('maintainer');
-  if (stars >= 100) badges.push('starred');
+  if (publicStars >= 100) badges.push('starred');
   if (years >= 5) badges.push('veteran');
 
   return Object.freeze({
@@ -103,6 +108,7 @@ export function summarizeTownCreator(profile, repos = [], nowMs = Date.now()) {
     profileUrl: `https://github.com/${selected.login}`,
     townRepos: list.length,
     townStars: stars,
+    publicStars,
     townForks: forks,
     years,
     joinedYear: createdAt ? new Date(createdAt).getUTCFullYear() : null,

--- a/data/city-state.json
+++ b/data/city-state.json
@@ -358,6 +358,7 @@
       "recent_30d_repositories": 21,
       "repositories_with_push_date": 69
     },
+    "public_repository_stars": 587,
     "repository_count": 69,
     "total_forks": 135,
     "total_stars": 572

--- a/data/city-state.schema.json
+++ b/data/city-state.schema.json
@@ -688,6 +688,11 @@
           "minimum": 0,
           "type": "integer"
         },
+        "public_repository_stars": {
+          "description": "Stars across every public repository owned by the GitHub account, including forks excluded from the town catalog.",
+          "minimum": 0,
+          "type": "integer"
+        },
         "total_forks": {
           "minimum": 0,
           "type": "integer"
@@ -702,6 +707,7 @@
         "active_repository_count",
         "archived_repository_count",
         "total_stars",
+        "public_repository_stars",
         "total_forks",
         "language_distribution",
         "latest_push_signal",

--- a/index.html
+++ b/index.html
@@ -2650,7 +2650,7 @@ const I18N = {
     creatorPartial:'프로필 세부 정보를 불러오지 못해 마을에 이미 있는 공개 레포 정보만 보여드려요.', creatorRetry:'다시 불러오기',
     creatorNoBio:'공개 bio가 아직 없어요. 대신 이 마을의 레포가 소개를 이어갑니다.',
     creatorCompany:'소속 · {value}', creatorLocation:'위치 · {value}', creatorJoined:'GitHub 시작 · {year}',
-    creatorStatRepos:'마을 레포', creatorStatStars:'받은 Star', creatorStatFollowers:'팔로워', creatorStatYears:'GitHub 활동', creatorYearsValue:'{count}년',
+    creatorStatRepos:'마을 레포', creatorStatStars:'전체 공개 Star', creatorStatFollowers:'팔로워', creatorStatYears:'GitHub 활동', creatorYearsValue:'{count}년',
     creatorBadgesTitle:'이 마을의 신호', creatorLanguagesTitle:'주요 언어', creatorSignatureTitle:'대표 프로젝트',
     creatorBadgeBuilder:'🏗️ 공개 레포 빌더', creatorBadgePolyglot:'🌐 다중 언어', creatorBadgeMaintainer:'🛠️ 최근 관리', creatorBadgeStarred:'⭐ Star 받은 작업', creatorBadgeVeteran:'🧭 장기 메이커',
     creatorNoBadges:'아직 배지를 만들 만큼 공개 신호가 쌓이지 않았어요.', creatorNoLanguages:'표시할 주요 언어가 없어요.', creatorNoRepos:'표시할 공개 대표 프로젝트가 없어요.',
@@ -3030,7 +3030,7 @@ const I18N = {
     creatorPartial:'Profile details could not be loaded, so this hall is using the public repository facts already in town.', creatorRetry:'Try again',
     creatorNoBio:'No public bio yet. The repositories in this town continue the introduction.',
     creatorCompany:'Company · {value}', creatorLocation:'Location · {value}', creatorJoined:'Joined GitHub · {year}',
-    creatorStatRepos:'Town repos', creatorStatStars:'Stars earned', creatorStatFollowers:'Followers', creatorStatYears:'On GitHub', creatorYearsValue:'{count}y',
+    creatorStatRepos:'Town repos', creatorStatStars:'Public repo Stars', creatorStatFollowers:'Followers', creatorStatYears:'On GitHub', creatorYearsValue:'{count}y',
     creatorBadgesTitle:'Signals from this town', creatorLanguagesTitle:'Top languages', creatorSignatureTitle:'Signature projects',
     creatorBadgeBuilder:'🏗️ Public repo builder', creatorBadgePolyglot:'🌐 Polyglot', creatorBadgeMaintainer:'🛠️ Recently maintained', creatorBadgeStarred:'⭐ Starred work', creatorBadgeVeteran:'🧭 Long-haul maker',
     creatorNoBadges:'Not enough public signals for a town badge yet.', creatorNoLanguages:'No top language to show yet.', creatorNoRepos:'No public signature project to show yet.',
@@ -10582,13 +10582,17 @@ async function _loadTownCreatorProfile(user,force=false){
   }
 }
 function _creatorFallbackProfile(){ return selectTownCreatorFields({login:currentUser,public_repos:REPOS.length}); }
+function _creatorSummary(profile){
+  const publicStars=Number(CITY_STATE?.stats?.public_repository_stars);
+  return summarizeTownCreator(profile,REPOS,_now,{publicStars:Number.isFinite(publicStars)?publicStars:null});
+}
 function _creatorStatusSet(key='',tone='',retry=false){
   CREATOR_STATE.status=key?{key,tone,retry}:null; creatorStatus.textContent=key?t(key):''; creatorStatus.dataset.tone=tone||'';
   if(retry){ const button=document.createElement('button'); button.type='button'; button.textContent=t('creatorRetry'); button.onclick=()=>loadCreatorHallProfile(true); creatorStatus.appendChild(button); }
 }
 function _creatorEmpty(container,key){ const empty=document.createElement('div'); empty.className='creatorEmpty'; empty.textContent=t(key); container.appendChild(empty); }
 function renderCreatorHall(summary=CREATOR_STATE.summary){
-  if(!summary) summary=summarizeTownCreator(_creatorFallbackProfile(),REPOS,_now);
+  if(!summary) summary=_creatorSummary(_creatorFallbackProfile());
   CREATOR_STATE.summary=summary;
   document.getElementById('creatorName').textContent=summary.displayName;
   document.getElementById('creatorLogin').textContent='@'+summary.login;
@@ -10604,7 +10608,7 @@ function renderCreatorHall(summary=CREATOR_STATE.summary){
     const chip=document.createElement('span'); chip.textContent=tf(key,{value}); meta.appendChild(chip); });
   if(summary.joinedYear){ const chip=document.createElement('span'); chip.textContent=tf('creatorJoined',{year:summary.joinedYear}); meta.appendChild(chip); }
   const stats=document.getElementById('creatorStats'); stats.innerHTML='';
-  [[summary.townRepos,'creatorStatRepos'],[summary.townStars,'creatorStatStars'],[summary.followers,'creatorStatFollowers'],
+  [[summary.townRepos,'creatorStatRepos'],[summary.publicStars,'creatorStatStars'],[summary.followers,'creatorStatFollowers'],
     [summary.joinedYear?tf('creatorYearsValue',{count:summary.years}):'\u2014','creatorStatYears']].forEach(([value,key])=>{
       const box=document.createElement('div'); box.className='creatorStat'; const number=document.createElement('b'),label=document.createElement('span');
       number.textContent=typeof value==='number'?_creatorNumber(value):value; label.textContent=t(key); box.appendChild(number); box.appendChild(label); stats.appendChild(box); });
@@ -10627,15 +10631,15 @@ function renderCreatorHall(summary=CREATOR_STATE.summary){
 }
 async function loadCreatorHallProfile(force=false){
   const requestId=++CREATOR_STATE.requestId; CREATOR_STATE.loading=true; creatorCard.setAttribute('aria-busy','true');
-  _creatorStatusSet('creatorLoading'); renderCreatorHall(summarizeTownCreator(_creatorFallbackProfile(),REPOS,_now));
+  _creatorStatusSet('creatorLoading'); renderCreatorHall(_creatorSummary(_creatorFallbackProfile()));
   const result=await _loadTownCreatorProfile(currentUser,force);
   if(requestId!==CREATOR_STATE.requestId) return false;
   CREATOR_STATE.loading=false; CREATOR_STATE.source=result.source; creatorCard.setAttribute('aria-busy','false');
   if(result.profile){
-    renderCreatorHall(summarizeTownCreator(result.profile,REPOS,_now)); _creatorStatusSet('creatorReady','success');
+    renderCreatorHall(_creatorSummary(result.profile)); _creatorStatusSet('creatorReady','success');
     track('creator_profile_loaded',{source:result.source,partial:false}); return CREATOR_STATE.summary;
   }
-  renderCreatorHall(summarizeTownCreator(_creatorFallbackProfile(),REPOS,_now)); _creatorStatusSet('creatorPartial','error',true);
+  renderCreatorHall(_creatorSummary(_creatorFallbackProfile())); _creatorStatusSet('creatorPartial','error',true);
   track('creator_profile_loaded',{source:result.source,partial:true,reason:result.error?.reason||'unknown'}); return CREATOR_STATE.summary;
 }
 openCreatorHall=(entry='landmark')=>{
@@ -14108,7 +14112,7 @@ if(_DIAGNOSTICS){ const _debugVec=v=>[+v.x.toFixed(5),+v.y.toFixed(5),+v.z.toFix
       meshes:CREATOR_HALL.meshes,draws:CREATOR_HALL.draws,textures:2,lights:0,repoGap:+repoGap.toFixed(2),nearestRepo,
       placement:{gap:+CREATOR_HALL.placement.gap.toFixed(2),near:CREATOR_HALL.placement.near,center:CREATOR_HALL.placement.center.map(value=>+value.toFixed(2))},
       open:CREATOR_STATE.open,loading:CREATOR_STATE.loading,source:CREATOR_STATE.source,
-      profile:summary?{login:summary.login,name:summary.displayName,repos:summary.townRepos,stars:summary.townStars,followers:summary.followers,
+      profile:summary?{login:summary.login,name:summary.displayName,repos:summary.townRepos,stars:summary.publicStars,townStars:summary.townStars,followers:summary.followers,
         languages:summary.topLanguages.map(item=>item.name),badges:summary.badges.slice(),signature:summary.signatureRepos.map(repo=>repo.name)}:null}; };
   window.__creatorOpen=async(force=false)=>{ openCreatorHall('debug'); await loadCreatorHallProfile(force); return window.__creatorHall(); };
   window.__creatorClose=()=>closeCreatorHall();

--- a/scripts/build_repos.py
+++ b/scripts/build_repos.py
@@ -319,6 +319,11 @@ def build():
     # Public owner endpoint works with the built-in Actions token, so a fork can
     # build its first city without a PAT. A PAT is only needed for traffic data.
     repos = gh_api(f"/users/{OWNER}/repos?per_page=100&type=owner&sort=full_name")
+    public_repository_stars = sum(
+        max(0, int(repo.get("stargazers_count") or 0))
+        for repo in repos
+        if repo.get("private") is not True
+    )
     social = social_map(OWNER)
     out = []
     source_timestamps = {}
@@ -395,6 +400,7 @@ def build():
         source_timestamps,
         as_of=CITY_STATE_AS_OF,
         prior_ledger=load_sap_ledger(CITY_STATE_OUT),
+        public_repository_stars=public_repository_stars,
     )
     write_city_state(CITY_STATE_OUT, city_state)
     resident_summary = write_resident_artifacts(

--- a/scripts/city_state.py
+++ b/scripts/city_state.py
@@ -448,7 +448,14 @@ def _merge_sap_ledger(prior_ledger, entry):
     return ledger
 
 
-def build_city_state(repositories, source_timestamps=None, *, as_of=None, prior_ledger=None):
+def build_city_state(
+    repositories,
+    source_timestamps=None,
+    *,
+    as_of=None,
+    prior_ledger=None,
+    public_repository_stars=None,
+):
     public = _public_repositories(repositories)
     reference_time = _reference_time(public, source_timestamps, as_of)
     reference_day = reference_time.date()
@@ -469,6 +476,11 @@ def build_city_state(repositories, source_timestamps=None, *, as_of=None, prior_
     push_count = sum(bool(_parse_datetime(repo.get("pushed") or repo.get("pushed_at"))) for repo in public)
     season = _season(public, reference_day)
     silence = _silence(public, reference_day)
+    town_stars = sum(max(0, int(repo.get("stars") or 0)) for repo in public)
+    if public_repository_stars is None:
+        profile_stars = town_stars
+    else:
+        profile_stars = max(town_stars, min(MAX_SAFE_INTEGER, max(0, int(public_repository_stars))))
 
     state = {
         "schema": SCHEMA_NAME,
@@ -492,7 +504,8 @@ def build_city_state(repositories, source_timestamps=None, *, as_of=None, prior_
             "repository_count": len(public),
             "active_repository_count": len(public) - len(archived),
             "archived_repository_count": len(archived),
-            "total_stars": sum(max(0, int(repo.get("stars") or 0)) for repo in public),
+            "total_stars": town_stars,
+            "public_repository_stars": profile_stars,
             "total_forks": sum(max(0, int(repo.get("forks") or 0)) for repo in public),
             "language_distribution": language_distribution,
             "latest_push_signal": {
@@ -533,12 +546,18 @@ def main():
     parser.add_argument("--repos", default=root / "repos.json", type=Path)
     parser.add_argument("--output", default=root / "data" / "city-state.json", type=Path)
     parser.add_argument("--as-of", help="Explicit ISO-8601 UTC reference date or timestamp.")
+    parser.add_argument(
+        "--public-repository-stars",
+        type=int,
+        help="Star total across all public owner repositories, including town-excluded forks.",
+    )
     args = parser.parse_args()
     repositories = json.loads(args.repos.read_text(encoding="utf-8"))
     state = build_city_state(
         repositories,
         as_of=args.as_of,
         prior_ledger=load_sap_ledger(args.output),
+        public_repository_stars=args.public_repository_stars,
     )
     write_city_state(args.output, state)
     print(

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -998,8 +998,9 @@ const creatorSummary = summarizeTownCreator(creatorFields, [
   {repo:'beta',lang:'Rust',stars:10,forks:2,pushed:'2025-01-01T00:00:00Z',desc:'Beta'},
   {repo:'gamma',lang:'JavaScript',stars:2,forks:0,pushed:'2024-01-01T00:00:00Z'},
   {repo:'delta',lang:'Go',stars:1,forks:0,pushed:'2023-01-01T00:00:00Z'}
-], creatorNow);
+], creatorNow, {publicStars:33});
 ok(creatorSummary.displayName==='The Octocat' && creatorSummary.townRepos===4 && creatorSummary.townStars===18
+  && creatorSummary.publicStars===33
   && creatorSummary.townForks===3 && creatorSummary.years===15 && creatorSummary.joinedYear===2011,
   'creator proof combines public profile age with truthful facts from the rendered town');
 ok(creatorSummary.topLanguages.map(item=>item.name).join(',')==='Go,JavaScript,Python,Rust'
@@ -1038,6 +1039,9 @@ ok(/const CREATOR_CACHE_TTL=24\*3600\*1000/.test(creatorPanelBlock)
   && /selectTownCreatorFields\(await response\.json\(\)\)/.test(creatorPanelBlock)
   && /localStorage\.setItem\(key,JSON\.stringify\(\{fetchedAt:now,profile\}\)\)/.test(creatorPanelBlock),
   'an explicit hall open caches only the selected public profile fields for one day');
+ok(/CITY_STATE\?\.stats\?\.public_repository_stars/.test(creatorPanelBlock)
+  && /\[summary\.publicStars,'creatorStatStars'\]/.test(creatorPanelBlock),
+  'Creator Hall uses the generated all-public repository Star total without widening its runtime profile request');
 ok(/openCreatorHall=\(entry='landmark'\)=>/.test(creatorPanelBlock)
   && /loadCreatorHallProfile\(false\)/.test(creatorPanelBlock)
   && !/await _loadTownCreatorProfile\(currentUser/.test(HTML.slice(0,HTML.indexOf('openCreatorHall='))),

--- a/scripts/test_city_state.py
+++ b/scripts/test_city_state.py
@@ -49,11 +49,16 @@ class CityStateTests(unittest.TestCase):
             repo("memory", "2018-03-04", "2022-04-05", archived=True, stars=3, desc="Archived public work."),
             repo("secret", "2017-01-01", "2026-06-30", private=True, stars=999),
         ]
-        state = build_city_state(repos, {"active": "2026-06-30T12:00:00Z"})
+        state = build_city_state(
+            repos,
+            {"active": "2026-06-30T12:00:00Z"},
+            public_repository_stars=25,
+        )
         self.validate_state(state)
         self.assertEqual(state["era"]["oldest_repository"], "memory")
         self.assertEqual(state["stats"]["repository_count"], 2)
         self.assertEqual(state["stats"]["total_stars"], 10)
+        self.assertEqual(state["stats"]["public_repository_stars"], 25)
         self.assertIsNone(state["stats"]["commit_history"]["total"])
         self.assertFalse(state["stats"]["commit_history"]["available"])
         self.assertEqual([root["repo"] for root in state["roots"]], ["memory"])
@@ -62,6 +67,19 @@ class CityStateTests(unittest.TestCase):
         self.assertEqual(state["silence"]["repositories"]["with_push_date"], 1)
         self.assertEqual(state["silence"]["quiet"]["at_least_365_days"], 0)
         self.assertNotIn("secret", serialize_city_state(state))
+
+    def test_public_repository_stars_falls_back_to_town_total_and_never_undercounts(self):
+        repos = [repo("alpha", "2020-01-01", "2026-06-30", stars=7)]
+        fallback = build_city_state(repos, as_of="2026-06-30T00:00:00Z")
+        lower_override = build_city_state(
+            repos,
+            as_of="2026-06-30T00:00:00Z",
+            public_repository_stars=3,
+        )
+        self.assertEqual(fallback["stats"]["public_repository_stars"], 7)
+        self.assertEqual(lower_override["stats"]["public_repository_stars"], 7)
+        self.validate_state(fallback)
+        self.validate_state(lower_override)
 
     def test_identical_inputs_are_byte_stable_and_order_independent(self):
         repos = [
@@ -416,6 +434,7 @@ class CityStateTests(unittest.TestCase):
             repositories,
             as_of=f"{checked_in['era']['as_of']}T00:00:00Z",
             prior_ledger=checked_in.get("sap_ledger"),
+            public_repository_stars=checked_in["stats"]["public_repository_stars"],
         )
         self.assertEqual(serialize_city_state(regenerated), state_path.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- count Stars across every public owner repository, including town-excluded forks
- keep the 69-repository town catalog and building filter unchanged
- show the account-wide total in Creator Hall with clearer KO/EN labels

## Verification
- full hermetic verification suite passed
- desktop and 390x844 mobile Creator Hall QA in Korean and English
- no console errors or horizontal overflow