### PR TITLE
feat: version resident dialogue budget caps

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -311,7 +311,9 @@ so loss of availability cannot become cap overshoot.
 UTC rollover starts a clean active-day aggregate on the first Governor operation of the new day. Prior-day
 in-flight reservations and their aggregate remain only as needed to settle/release cross-midnight calls safely.
 Lowering the cap or imposing a tighter turn limit during a day is sticky until the next UTC day, so an older
-Worker isolate cannot reopen it with stale higher settings. In-day increases deliberately wait until rollover.
+Worker isolate cannot reopen it with stale higher settings. In-day increases normally wait until rollover. An
+operator can deliberately apply one immediately, without clearing spend or reservations, by increasing the
+matching monotonic `*_DAY_CAP_REVISION`; calls from an older revision cannot overwrite that cap.
 If current spend/reservations already exceed a new lower cap, no new reservation is accepted.
 `NPC_DAY_CAP_USD=0` disables model turns immediately at the Governor.
 Accepted reservations also increment a durable attempt counter. `NPC_DAILY_ATTEMPT_MAX` provides a bounded
@@ -334,10 +336,13 @@ possibly billable dollars.
 //                  hardAiEnabled, hardAmbientEnabled, hardPlayerChatEnabled,
 //                  maxTurns, hardMaxTurns, source:"durable-object", flagSource, liveToggle },
 //      budget:{ source:"durable-object", durable:true, enforcement:"atomic_reservation",
-//               available, ... } }
+//               scope:"npc", dayCapUsd, capRevision, available, ... },
+//      residentDialogueBudget:{ source:"durable-object", durable:true,
+//               enforcement:"atomic_reservation", scope:"resident-dialogue",
+//               dayCapUsd, capRevision, available, ... } }
 { "npc_action": "npcBudget" }
 // → { ok, budget:{ enabled, available, source:"durable-object", durable:true,
-//                  enforcement:"atomic_reservation", day, dayCapUsd,
+//                  enforcement:"atomic_reservation", day, dayCapUsd, capRevision,
 //                  spentUsd, reservedUsd, remainingUsd, turnsToday, reservedTurns,
 //                  dailyTurnMax, attemptsToday, dailyAttemptMax, blocked } }
 { "npc_action": "npcAmbientTurn", "speaker":"sol", "listener":"jun", "topic":"model", "lang":"ko",
@@ -380,6 +385,7 @@ to best-effort accounting.
 | `NPC_MODEL_PRICING_JSON` | built-in `gpt-5.4-mini` table | JSON map of deployment alias to `inputPer1MUsd`, `cachedInputPer1MUsd`, `outputPer1MUsd`, `maxInputTokens`, and `maxOutputTokens`. Invalid/unknown/incomplete means no call. |
 | `NPC_MAX_COMPLETION_TOKENS` | `120` | Provider output cap and reservation output bound (1–4096). |
 | `NPC_DAY_CAP_USD` | `0.15` in this deployment (`10` code default) | Durable UTC-day hard cap. The committed value bounds a 31-day month to `$4.65` of resident Azure model calls. `0` disables calls; invalid values fail closed. |
+| `NPC_DAY_CAP_REVISION` | `1` | Monotonic operator revision for an explicit same-day NPC cap change. Keep unchanged for normal rollover changes; increase it only when an in-day cap replacement is intentional. |
 | `NPC_DAILY_TURN_MAX` | `0` (off) | Optional durable daily turn cap; in-flight reservations consume slots. |
 | `NPC_DAILY_ATTEMPT_MAX` | `5000` | Hard abuse/storage ceiling for accepted reservations, including provider failures. Must be positive. |
 | `NPC_BUDGET_TIMEOUT_MS` | `3000` | Internal Governor response deadline (100–10000 ms); timeout fails closed. Retryable failures wait 100–250 ms before one idempotent retry; overload is not retried. |
@@ -387,7 +393,8 @@ to best-effort accounting.
 | `NPC_TIMEOUT_MS` | `12000` | Entra token + model request deadline; timeout aborts the request and releases its reservation. |
 | `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient conversation caps. |
 | `RESIDENT_DIALOGUE_MAX_COMPLETION_TOKENS` | `96` | Separate explicit resident-dialogue output/reservation cap. |
-| `RESIDENT_DIALOGUE_DAY_CAP_USD` | `0.05` | Separate daily visitor resident-dialogue cap (31-day worst case `$1.55`). Missing configuration defaults to zero and fails closed. |
+| `RESIDENT_DIALOGUE_DAY_CAP_USD` | `0.05` in this deployment | Separate daily visitor resident-dialogue dollar ceiling; the independent turn, attempt, and rate caps remain in force. Missing configuration defaults to zero and fails closed. |
+| `RESIDENT_DIALOGUE_DAY_CAP_REVISION` | `1` in this deployment | Monotonic operator revision for an explicit same-day visitor-dialogue cap replacement. |
 | `RESIDENT_DIALOGUE_DAILY_TURN_MAX` | `120` | Separate completed/in-flight visitor dialogue cap. |
 | `RESIDENT_DIALOGUE_DAILY_ATTEMPT_MAX` | `240` | Separate accepted-attempt/storage ceiling. |
 | `RESIDENT_DIALOGUE_RATE_MAX` / `RESIDENT_DIALOGUE_RATE_WINDOW_S` | `12` / `60` | Durable aggregate rate cap; stores counts only, with no IP, user agent, cookie, transcript, or visitor identity. |

--- a/cloudflare-taxi/src/grounded.js
+++ b/cloudflare-taxi/src/grounded.js
@@ -1671,7 +1671,10 @@ async function npcHandler(body, request, env, ctx) {
   const requestMeta = metricContext(body, request);
 
   if (action === "npcConfig") {
-    const budget = await npcBudgetStatus(env, aiEnabled, emitBudgetMetric);
+    const [budget, residentDialogueBudget] = await Promise.all([
+      npcBudgetStatus(env, aiEnabled, emitBudgetMetric),
+      npcBudgetStatus(env, playerOn, emitBudgetMetric, "resident-dialogue"),
+    ]);
     const status = npcControlStatus(flags, budget);
     const budgetReady = status.runtimeAvailable;
     const effective = status.effective;
@@ -1702,7 +1705,7 @@ async function npcHandler(body, request, env, ctx) {
       hardCeiling: flags.hardCeiling,
       maxTurns: Number(env.NPC_MAX_TURNS || 6), hardMaxTurns: Number(env.NPC_HARD_MAX_TURNS || 10),
       source: "durable-object", flagSource: flags.source, liveToggle: flags.liveToggle,
-    }, budget }, 200, env);
+    }, budget, residentDialogueBudget }, 200, env);
   }
   if (action === "npcBudget") {
     return json({ ok: true, budget: await npcBudgetStatus(env, aiEnabled, emitBudgetMetric) }, 200, env);

--- a/cloudflare-taxi/src/npc-budget-governor.js
+++ b/cloudflare-taxi/src/npc-budget-governor.js
@@ -65,6 +65,8 @@ function validLedger(ledger) {
     && /^\d{4}-\d{2}-\d{2}$/.test(String(ledger.day || ""))
     && Object.prototype.hasOwnProperty.call(NPC_BUDGET_OBJECT_NAMES, ledger.scope)
     && isSafeNonNegativeInteger(ledger.capNanos)
+    && isSafeNonNegativeInteger(ledger.capRevision)
+    && ledger.capRevision > 0
     && isSafeNonNegativeInteger(ledger.dailyTurnMax)
     && isSafeNonNegativeInteger(ledger.dailyAttemptMax)
     && ledger.dailyAttemptMax > 0
@@ -80,11 +82,12 @@ function validLedger(ledger) {
     && isSafeNonNegativeInteger(ledger.attempts);
 }
 
-function freshLedger(day, scope, capNanos, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds, nowMs) {
+function freshLedger(day, scope, capNanos, capRevision, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds, nowMs) {
   return {
     day,
     scope,
     capNanos,
+    capRevision,
     dailyTurnMax,
     dailyAttemptMax,
     rateMax,
@@ -102,6 +105,7 @@ function freshLedger(day, scope, capNanos, dailyTurnMax, dailyAttemptMax, rateMa
 function upgradeLedger(ledger) {
   if (!ledger || typeof ledger !== "object") return ledger;
   if (ledger.scope === undefined) ledger.scope = "npc";
+  if (ledger.capRevision === undefined) ledger.capRevision = 1;
   if (ledger.rateMax === undefined) ledger.rateMax = 0;
   if (ledger.rateWindowSeconds === undefined) ledger.rateWindowSeconds = 60;
   if (ledger.rateWindowKey === undefined) ledger.rateWindowKey = 0;
@@ -115,19 +119,29 @@ function tighterTurnMax(current, incoming) {
   return Math.min(current, incoming);
 }
 
-function tightenPolicy(ledger, capNanos, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds) {
-  const nextCap = Math.min(ledger.capNanos, capNanos);
+// Same-revision calls can only tighten a cap. Raising the monotonic revision is
+// the explicit operator signal for a same-day replacement; older isolates are
+// then ignored for this field so they cannot restore the superseded cap.
+function tightenPolicy(ledger, capNanos, capRevision, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds) {
+  const capRevisionRaised = capRevision > ledger.capRevision;
+  const capRevisionCurrent = capRevision === ledger.capRevision;
+  let nextCap = ledger.capNanos;
+  if (capRevisionRaised) nextCap = capNanos;
+  else if (capRevisionCurrent) nextCap = Math.min(ledger.capNanos, capNanos);
+  const nextCapRevision = Math.max(ledger.capRevision, capRevision);
   const nextTurnMax = tighterTurnMax(ledger.dailyTurnMax, dailyTurnMax);
   const nextAttemptMax = Math.min(ledger.dailyAttemptMax, dailyAttemptMax);
   const nextRateMax = tighterTurnMax(ledger.rateMax, rateMax);
   const nextRateWindowSeconds = Math.max(ledger.rateWindowSeconds, rateWindowSeconds);
   const changed = nextCap !== ledger.capNanos
+    || nextCapRevision !== ledger.capRevision
     || nextTurnMax !== ledger.dailyTurnMax
     || nextAttemptMax !== ledger.dailyAttemptMax
     || nextRateMax !== ledger.rateMax
     || nextRateWindowSeconds !== ledger.rateWindowSeconds;
   if (changed) {
     ledger.capNanos = nextCap;
+    ledger.capRevision = nextCapRevision;
     ledger.dailyTurnMax = nextTurnMax;
     ledger.dailyAttemptMax = nextAttemptMax;
     ledger.rateMax = nextRateMax;
@@ -146,6 +160,10 @@ function budgetPolicy(env, scope = "npc") {
   const capNanos = usdToNanos(
     resident ? env?.RESIDENT_DIALOGUE_DAY_CAP_USD : env?.NPC_DAY_CAP_USD,
     resident ? 0 : 10,
+  );
+  const capRevision = parseNonNegativeInteger(
+    resident ? env?.RESIDENT_DIALOGUE_DAY_CAP_REVISION : env?.NPC_DAY_CAP_REVISION,
+    1,
   );
   const dailyTurnMax = parseNonNegativeInteger(
     resident ? env?.RESIDENT_DIALOGUE_DAILY_TURN_MAX : env?.NPC_DAILY_TURN_MAX,
@@ -177,7 +195,7 @@ function budgetPolicy(env, scope = "npc") {
   const reservationLeaseMs = hasConfiguredLease
     ? configuredLeaseMs
     : Math.max(60_000, minimumLeaseMs || 0);
-  if (capNanos === null || dailyTurnMax === null
+  if (capNanos === null || capRevision === null || capRevision < 1 || dailyTurnMax === null
     || dailyAttemptMax === null || dailyAttemptMax < 1
     || rateMax === null || rateWindowSeconds === null
     || rateWindowSeconds < 10 || rateWindowSeconds > 3600
@@ -191,6 +209,7 @@ function budgetPolicy(env, scope = "npc") {
     ok: true,
     scope,
     capNanos,
+    capRevision,
     dailyTurnMax,
     dailyAttemptMax,
     rateMax,
@@ -202,6 +221,8 @@ function budgetPolicy(env, scope = "npc") {
 function validPolicyPayload(body) {
   return validScope(body?.scope)
     && isSafeNonNegativeInteger(body?.capNanos)
+    && isSafeNonNegativeInteger(body?.capRevision)
+    && body.capRevision > 0
     && isSafeNonNegativeInteger(body?.dailyTurnMax)
     && isSafeNonNegativeInteger(body?.dailyAttemptMax)
     && body.dailyAttemptMax > 0
@@ -225,6 +246,7 @@ function publicBudget(ledger) {
     scope: ledger.scope,
     day: ledger.day,
     dayCapUsd: nanosToUsd(capNanos),
+    capRevision: ledger.capRevision,
     spentUsd: nanosToUsd(ledger.spentNanos),
     reservedUsd: nanosToUsd(ledger.reservedNanos),
     remainingUsd: nanosToUsd(remainingNanos),
@@ -248,6 +270,7 @@ function unavailableBudget(reason, policy) {
     scope: policy?.scope || null,
     day: null,
     dayCapUsd: policy?.ok ? nanosToUsd(policy.capNanos) : null,
+    capRevision: policy?.ok ? policy.capRevision : null,
     spentUsd: null,
     reservedUsd: null,
     remainingUsd: null,
@@ -377,7 +400,7 @@ export class NpcBudgetGovernor {
     }
   }
 
-  async loadLedger(scope, capNanos, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds) {
+  async loadLedger(scope, capNanos, capRevision, dailyTurnMax, dailyAttemptMax, rateMax, rateWindowSeconds) {
     const day = utcDay(this.now());
     const nowMs = this.now();
     const stored = upgradeLedger(await this.state.storage.get(NPC_LEDGER_KEY));
@@ -386,6 +409,7 @@ export class NpcBudgetGovernor {
         day,
         scope,
         capNanos,
+        capRevision,
         dailyTurnMax,
         dailyAttemptMax,
         rateMax,
@@ -401,6 +425,7 @@ export class NpcBudgetGovernor {
       let changed = tightenPolicy(
         stored,
         capNanos,
+        capRevision,
         dailyTurnMax,
         dailyAttemptMax,
         rateMax,
@@ -422,6 +447,7 @@ export class NpcBudgetGovernor {
       day,
       scope,
       capNanos,
+      capRevision,
       dailyTurnMax,
       dailyAttemptMax,
       rateMax,
@@ -505,6 +531,7 @@ export class NpcBudgetGovernor {
     }
     if (body && typeof body === "object") {
       if (body.scope === undefined) body.scope = "npc";
+      if (body.capRevision === undefined) body.capRevision = 1;
       if (body.rateMax === undefined) body.rateMax = 0;
       if (body.rateWindowSeconds === undefined) body.rateWindowSeconds = 60;
     }
@@ -515,6 +542,7 @@ export class NpcBudgetGovernor {
     const loaded = await this.loadLedger(
       body.scope,
       body.capNanos,
+      body.capRevision,
       body.dailyTurnMax,
       body.dailyAttemptMax,
       body.rateMax,

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -95,9 +95,11 @@ NPC_PLAYER_CHAT_ENABLED = "true"
 NPC_DAY_CAP_USD = "0.15"
 
 # Explicit visitor-to-resident Bound dialogue uses its own Durable Object ledger.
-# It is stricter than ambient NPC traffic and stays separate from scholar usage.
+# Its output, turn, attempt, and rate bounds stay separate from scholar usage.
 RESIDENT_DIALOGUE_MAX_COMPLETION_TOKENS = "96"
+# The baseline remains unchanged while monotonic same-day revisions are deployed.
 RESIDENT_DIALOGUE_DAY_CAP_USD = "0.05"
+RESIDENT_DIALOGUE_DAY_CAP_REVISION = "1"
 RESIDENT_DIALOGUE_DAILY_TURN_MAX = "120"
 RESIDENT_DIALOGUE_DAILY_ATTEMPT_MAX = "240"
 RESIDENT_DIALOGUE_RATE_MAX = "12"

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2876,6 +2876,9 @@ ok(/name = "NPC_BUDGET_GOVERNOR"/.test(TAXI_WRANGLER)
 ok(/source: "durable-object"/.test(WORKER)
   && /NPC_BUDGET_SOURCE = "durable-object"/.test(NPC_GOVERNOR),
   'npcConfig and npcBudget identify the Durable Object as their budget authority');
+ok(/residentDialogueBudget/.test(WORKER)
+  && /npcBudgetStatus\(env, playerOn, emitBudgetMetric, "resident-dialogue"\)/.test(WORKER),
+  'npcConfig exposes the separate visitor resident-dialogue Durable Object budget without replacing the NPC budget');
 
 group('Durable NPC budget governor — hermetic atomicity and fail-closed behavior');
 await runNpcBudgetGovernorTests(ok);
@@ -2914,6 +2917,9 @@ ok(/NPC_AMBIENT_ENABLED = "true"/.test(TAXI_WRANGLER)
   && /NPC_DAY_CAP_USD = "0\.15"/.test(TAXI_WRANGLER)
   && /scriptedAmbient:true/.test(npcBlock),
   'canonical ambient AI stays owner-controlled and durably capped at $0.15/day with scripted fallback');
+ok(/RESIDENT_DIALOGUE_DAY_CAP_USD = "0\.05"/.test(TAXI_WRANGLER)
+  && /RESIDENT_DIALOGUE_DAY_CAP_REVISION = "1"/.test(TAXI_WRANGLER),
+  'canonical visitor dialogue keeps its baseline cap while same-day policy revisions are deployed');
 
 group('Phase 4 lore, newcomers, warm ruins, and Shared-only taxi travel');
 await runLoreTests(ok);

--- a/scripts/test-npc-budget-governor.mjs
+++ b/scripts/test-npc-budget-governor.mjs
@@ -149,6 +149,16 @@ export async function runNpcBudgetGovernorTests(check) {
 
   {
     const { governor } = makeGovernor();
+    const env = { ...baseEnv(governor), NPC_DAY_CAP_REVISION: '0' };
+    const status = await npcBudgetStatus(env, true);
+    check(status.available === false
+      && status.blocked === true
+      && status.reason === 'npc_budget_config_invalid',
+    'an invalid cap revision fails closed before a model call');
+  }
+
+  {
+    const { governor } = makeGovernor();
     const policy = { capNanos: 1_000_000, dailyTurnMax: 0, dailyAttemptMax: 5000, reservationLeaseMs: 60_000 };
     const reservations = await Promise.all([
       operation(governor, { op: 'reserve', ...policy, reservationId: reservationId(1), amountNanos: 600_000 }),
@@ -286,6 +296,127 @@ export async function runNpcBudgetGovernorTests(check) {
       && !staleHigherCap.accepted && staleHigherCap.reason === 'day_cap_zero'
       && staleHigherCap.budget.dayCapUsd === 0,
     'midday reductions are sticky so cap=0 cannot be reopened by a stale Worker');
+  }
+
+  {
+    const { governor, nowRef } = makeGovernor();
+    const initial = {
+      capNanos: 1_000_000,
+      capRevision: 1,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+    };
+    const id = reservationId(72);
+    await operation(governor, { op: 'reserve', ...initial, reservationId: id, amountNanos: 500_000 });
+    await operation(governor, { op: 'settle', ...initial, reservationId: id, actualNanos: 400_000 });
+    const raised = await operation(governor, {
+      op: 'status', ...initial, capNanos: 2_000_000, capRevision: 2,
+    });
+    const staleRevision = await operation(governor, {
+      op: 'status', ...initial, capNanos: 300_000, capRevision: 1,
+    });
+    const unversionedStale = await operation(governor, {
+      op: 'status',
+      capNanos: 300_000,
+      dailyTurnMax: 0,
+      dailyAttemptMax: 5000,
+      reservationLeaseMs: 60_000,
+    });
+    const sameRevisionIncrease = await operation(governor, {
+      op: 'status', ...initial, capNanos: 3_000_000, capRevision: 2,
+    });
+    nowRef.value = Date.parse('2026-07-31T00:00:01Z');
+    const staleFirstAfterRollover = await operation(governor, {
+      op: 'status', ...initial,
+    });
+    const currentAfterRollover = await operation(governor, {
+      op: 'status', ...initial, capNanos: 2_000_000, capRevision: 2,
+    });
+    const staleAfterRollover = await operation(governor, {
+      op: 'status', ...initial, capNanos: 300_000, capRevision: 1,
+    });
+    check(raised.budget.dayCapUsd === 0.002
+      && raised.budget.capRevision === 2
+      && raised.budget.spentUsd === 0.0004
+      && raised.budget.turnsToday === 1
+      && staleRevision.budget.dayCapUsd === 0.002
+      && staleRevision.budget.capRevision === 2
+      && unversionedStale.budget.dayCapUsd === 0.002
+      && sameRevisionIncrease.budget.dayCapUsd === 0.002
+      && staleFirstAfterRollover.reset === true
+      && staleFirstAfterRollover.budget.dayCapUsd === 0.001
+      && staleFirstAfterRollover.budget.spentUsd === 0
+      && currentAfterRollover.budget.dayCapUsd === 0.002
+      && currentAfterRollover.budget.capRevision === 2
+      && staleAfterRollover.budget.dayCapUsd === 0.002,
+    'a higher cap revision applies an intentional same-day increase while preserving usage and ignoring stale Workers');
+  }
+
+  {
+    const { state, governor, nowRef } = makeGovernor();
+    const pendingId = reservationId(73);
+    await state.storage.put({
+      ledger: {
+        day: '2026-07-30',
+        scope: 'resident-dialogue',
+        capNanos: 50_000_000,
+        dailyTurnMax: 120,
+        dailyAttemptMax: 240,
+        rateMax: 12,
+        rateWindowSeconds: 60,
+        rateWindowKey: Math.floor(nowRef.value / 60_000),
+        rateCount: 3,
+        spentNanos: 10_000_000,
+        reservedNanos: 5_000_000,
+        turns: 2,
+        reservedTurns: 1,
+        attempts: 4,
+      },
+      ['reservation:' + pendingId]: {
+        day: '2026-07-30',
+        status: 'pending',
+        amountNanos: 5_000_000,
+        expiresAtMs: nowRef.value + 60_000,
+      },
+    });
+    const revised = await operation(governor, {
+      op: 'status',
+      scope: 'resident-dialogue',
+      capNanos: 10_000_000_000,
+      capRevision: 2,
+      dailyTurnMax: 120,
+      dailyAttemptMax: 240,
+      rateMax: 12,
+      rateWindowSeconds: 60,
+      reservationLeaseMs: 60_000,
+    });
+    const expandedReservation = await operation(governor, {
+      op: 'reserve',
+      scope: 'resident-dialogue',
+      capNanos: 10_000_000_000,
+      capRevision: 2,
+      dailyTurnMax: 120,
+      dailyAttemptMax: 240,
+      rateMax: 12,
+      rateWindowSeconds: 60,
+      reservationLeaseMs: 60_000,
+      reservationId: reservationId(74),
+      amountNanos: 100_000_000,
+    });
+    check(revised.budget.dayCapUsd === 10
+      && revised.budget.capRevision === 2
+      && revised.budget.spentUsd === 0.01
+      && revised.budget.reservedUsd === 0.005
+      && revised.budget.remainingUsd === 9.985
+      && revised.budget.turnsToday === 2
+      && revised.budget.reservedTurns === 1
+      && revised.budget.attemptsToday === 4
+      && revised.budget.rateCount === 3
+      && expandedReservation.accepted === true
+      && expandedReservation.budget.reservedUsd === 0.105
+      && expandedReservation.budget.remainingUsd === 9.885,
+    'a legacy ledger upgrades to the explicit cap revision without clearing spend, reservations, turns, attempts, or rate state');
   }
 
   {


### PR DESCRIPTION
## 변경 사항
- 기존 방문자 대화 원장을 보존하며 명시적 revision으로 당일 cap 교체 지원
- 구 Worker revision이 새 cap을 되돌리지 못하도록 단조 정책 적용
- npcConfig에 Ambient/NPC와 visitor resident-dialogue 예산을 별도 노출
- legacy 원장·stale Worker·UTC rollover 회귀 테스트 추가

## 1단계 배포
이 PR은 안전한 2단계 배포의 기반입니다. 값은 기존 $0.05/rev1로 유지하며 revision 지원 코드가 라이브임을 확인한 뒤 별도 PR에서 $10/rev2를 적용합니다.

## 검증
- 전체 Repolis 검증 통과
- smoke 1485 checks
- Wrangler dry-run 통과