### PR TITLE
chore: raise visitor dialogue cap to ten dollars

### DIFF
--- a/cloudflare-taxi/README.md
+++ b/cloudflare-taxi/README.md
@@ -393,8 +393,8 @@ to best-effort accounting.
 | `NPC_TIMEOUT_MS` | `12000` | Entra token + model request deadline; timeout aborts the request and releases its reservation. |
 | `NPC_MAX_TURNS` / `NPC_HARD_MAX_TURNS` | `6` / `10` | Advertised default / absolute ambient conversation caps. |
 | `RESIDENT_DIALOGUE_MAX_COMPLETION_TOKENS` | `96` | Separate explicit resident-dialogue output/reservation cap. |
-| `RESIDENT_DIALOGUE_DAY_CAP_USD` | `0.05` in this deployment | Separate daily visitor resident-dialogue dollar ceiling; the independent turn, attempt, and rate caps remain in force. Missing configuration defaults to zero and fails closed. |
-| `RESIDENT_DIALOGUE_DAY_CAP_REVISION` | `1` in this deployment | Monotonic operator revision for an explicit same-day visitor-dialogue cap replacement. |
+| `RESIDENT_DIALOGUE_DAY_CAP_USD` | `10` in this deployment | Separate daily visitor resident-dialogue dollar ceiling (`$310` across 31 days if considered alone); the independent turn, attempt, and rate caps remain in force. Missing configuration defaults to zero and fails closed. |
+| `RESIDENT_DIALOGUE_DAY_CAP_REVISION` | `2` in this deployment | Monotonic operator revision applying the `$10` visitor-dialogue cap immediately while preserving today's ledger. |
 | `RESIDENT_DIALOGUE_DAILY_TURN_MAX` | `120` | Separate completed/in-flight visitor dialogue cap. |
 | `RESIDENT_DIALOGUE_DAILY_ATTEMPT_MAX` | `240` | Separate accepted-attempt/storage ceiling. |
 | `RESIDENT_DIALOGUE_RATE_MAX` / `RESIDENT_DIALOGUE_RATE_WINDOW_S` | `12` / `60` | Durable aggregate rate cap; stores counts only, with no IP, user agent, cookie, transcript, or visitor identity. |

--- a/cloudflare-taxi/wrangler.toml
+++ b/cloudflare-taxi/wrangler.toml
@@ -97,9 +97,10 @@ NPC_DAY_CAP_USD = "0.15"
 # Explicit visitor-to-resident Bound dialogue uses its own Durable Object ledger.
 # Its output, turn, attempt, and rate bounds stay separate from scholar usage.
 RESIDENT_DIALOGUE_MAX_COMPLETION_TOKENS = "96"
-# The baseline remains unchanged while monotonic same-day revisions are deployed.
-RESIDENT_DIALOGUE_DAY_CAP_USD = "0.05"
-RESIDENT_DIALOGUE_DAY_CAP_REVISION = "1"
+# Owner-selected dollar ceiling; separate turn/attempt/rate bounds remain in force.
+RESIDENT_DIALOGUE_DAY_CAP_USD = "10"
+# Revision 2 applies this increase immediately without clearing today's ledger.
+RESIDENT_DIALOGUE_DAY_CAP_REVISION = "2"
 RESIDENT_DIALOGUE_DAILY_TURN_MAX = "120"
 RESIDENT_DIALOGUE_DAILY_ATTEMPT_MAX = "240"
 RESIDENT_DIALOGUE_RATE_MAX = "12"

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2917,9 +2917,9 @@ ok(/NPC_AMBIENT_ENABLED = "true"/.test(TAXI_WRANGLER)
   && /NPC_DAY_CAP_USD = "0\.15"/.test(TAXI_WRANGLER)
   && /scriptedAmbient:true/.test(npcBlock),
   'canonical ambient AI stays owner-controlled and durably capped at $0.15/day with scripted fallback');
-ok(/RESIDENT_DIALOGUE_DAY_CAP_USD = "0\.05"/.test(TAXI_WRANGLER)
-  && /RESIDENT_DIALOGUE_DAY_CAP_REVISION = "1"/.test(TAXI_WRANGLER),
-  'canonical visitor dialogue keeps its baseline cap while same-day policy revisions are deployed');
+ok(/RESIDENT_DIALOGUE_DAY_CAP_USD = "10"/.test(TAXI_WRANGLER)
+  && /RESIDENT_DIALOGUE_DAY_CAP_REVISION = "2"/.test(TAXI_WRANGLER),
+  'canonical visitor dialogue uses the explicitly revised $10/day dollar ceiling');
 
 group('Phase 4 lore, newcomers, warm ruins, and Shared-only taxi travel');
 await runLoreTests(ok);


### PR DESCRIPTION
## 변경 사항
- 방문자 ↔ 주민 resident-dialogue 전용 일일 달러 cap을 $0.05에서 $10으로 변경
- cap revision을 1에서 2로 올려 오늘 사용·예약 장부를 보존한 채 즉시 적용
- Ambient/NPC $0.15 원장, 120 turns/day, 240 attempts/day, 12 calls/min 제한은 유지

## 안전한 선행 조건
PR #117의 revision-aware Governor를 먼저 100% 배포하고 라이브에서 $0.05/rev1을 확인했습니다.

## 검증
- smoke 1485 checks
- git diff --check
- Wrangler dry-run에서 RESIDENT_DIALOGUE_DAY_CAP_USD=10, revision=2 확인